### PR TITLE
[Cherry pick] [s] fixes damage multiplicative exploit with foam darts (#56250)

### DIFF
--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -20,8 +20,9 @@
 	newcasing.modified = modified
 	var/obj/projectile/bullet/reusable/foam_dart/newdart = newcasing.BB
 	newdart.modified = modified
-	newdart.damage = damage
-	newdart.nodamage = nodamage
+	if(modified)
+		newdart.damage = 5
+		newdart.nodamage = FALSE
 	newdart.damage_type = damage_type
 	if(pen)
 		newdart.pen = pen


### PR DESCRIPTION
## About The Pull Request
https://github.com/tgstation/tgstation/pull/56250
fixes a pretty bad exploit with foam darts

## Why It's Good For The Game

- Modify a dart with a pen, giving it 5 damage
- Target someone's mouth (or a monkeyman)
- Fire
- Firing sequence for handle_suicide multiplies damage by 5 on the projectile instance
- Dropped projectile has 25
- Repeat 1 more time for 125 instacrit dart, or another time after that for 600 instakill dart

all discovery credits go to @necromanceranne, this was brought to my attention