### PR TITLE
[Cherry pick] Puts a short cooldown on the Die of Fate (#56174)

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -169,6 +169,8 @@
 	microwave_riggable = FALSE
 	var/reusable = TRUE
 	var/used = FALSE
+	/// So you can't roll the die 20 times in a second and stack a bunch of effects that might conflict
+	COOLDOWN_DECLARE(roll_cd)
 
 /obj/item/dice/d20/fate/one_use
 	reusable = FALSE
@@ -199,19 +201,26 @@
 	reusable = FALSE
 
 /obj/item/dice/d20/fate/diceroll(mob/user)
+	if(!COOLDOWN_FINISHED(src, roll_cd))
+		to_chat(user, "<span class='warning'>Hold on, [src] isn't caught up with your last roll!</span>")
+		return
+
 	. = ..()
-	if(!used)
-		if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
-			to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
-			return
+	if(used)
+		return
 
-		if(!reusable)
-			used = TRUE
+	if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
+		to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
+		return
 
-		var/turf/T = get_turf(src)
-		T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
+	if(!reusable)
+		used = TRUE
 
-		addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
+	var/turf/T = get_turf(src)
+	T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
+
+	addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
+	COOLDOWN_START(src, roll_cd, 2.5 SECONDS)
 
 /obj/item/dice/d20/fate/equipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/56174
There's a short 1 second delay between rolling the Die of Fate and it actually taking effect, meaning you can spam it in your hand multiple times in order to queue up multiple effects that the user may not actually survive to see if one of the first rolls kills or dusts them. This puts a 2.5 seconds cooldown on being able to roll the Die of Fate to prevent stacking