### PR TITLE
[TM ONLY] 24 Add Heaters to Air alarms

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -460,6 +460,10 @@
 			if(A.atmosalert(FALSE, src))
 				post_alert(0)
 			. = TRUE
+		if("heat_mode")
+			investigate_log("has had its heat mode by [key_name(usr)]",INVESTIGATE_ATMOS)
+			airalarm_toggleheat()
+			. = TRUE
 	update_icon()
 
 
@@ -713,7 +717,20 @@
 	if(auto_temp_manage)
 		airalarm_heat()
 
-/obj/machinery/airalarm/proc/airalarm_heat(mode)
+/obj/machinery/airalarm/proc/airalarm_toggleheat()
+	if(auto_temp_manage)
+		if(auto_temp_cur_mode == "Heat")
+			visible_message("<span class='notice'>The air alarm makes a quiet click as it stops heating the area</span>")
+			auto_temp_cur_mode = "Idle"
+			auto_temp_manage = FALSE
+			return
+		else
+			auto_temp_manage = FALSE
+			return
+	else
+		auto_temp_manage = TRUE
+
+/obj/machinery/airalarm/proc/airalarm_heat()
 	var/wanted_mode = ""
 	var/turf/location = get_turf(src)
 	var/datum/gas_mixture/environment = location.return_air()

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -75,7 +75,7 @@ const AirAlarmStatus = (props, context) => {
             <LabeledList.Item
               label="Heating Status"
               color={data.heating_mode === 'heat' ? 'average' : !data.heating_enabled ? 'gray' : 'good'}>
-                {data.heating_enabled ? data.heating_mode : 'Disabled'}
+              {data.heating_enabled ? data.heating_mode : 'Disabled'}
             </LabeledList.Item>
           </>
         ) || (

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -295,37 +295,35 @@ const AirAlarmControlThresholds = (props, context) => {
 // --------------------------------------------------------
 
 const AirAlarmHeatingControls = (props, context) => {
-  const { act, data} = useBackend(context);
+  const { act, data } = useBackend(context);
   const {
     enabled,
     setPoint,
     maxValue,
-    minValue
+    minValue,
   } = data.heating;
   return (
-    <>
-      <Section
+    <Section
       title="Comfort Controls"
-      >
-        <Box mt={1} />
-        <LabeledList>
-          <LabeledList.Item label={"Setpoint"}>
-            <NumberInput
+    >
+      <Box mt={1} />
+      <LabeledList>
+        <LabeledList.Item label={"Setpoint"}>
+          <NumberInput
             value={setPoint}
             minValue={minValue}
             maxValue={maxValue}
-            onChange={(e, value) => act('heat_setpoint',{setPoint: value})}
+            onChange={(e, value) => act('heat_setpoint', { setPoint: value })}
             unit="K"
             tooltip="Change the Setpoint of the heater"
-            />
-            <Button
-              icon="fire"
-              content="Toggle Heating"
-              color={enabled ? 'good' : 'average'}
-              onClick={() => act('heat_mode')} />
-          </LabeledList.Item>
-        </LabeledList>
-      </Section>
-    </>
+          />
+          <Button
+            icon="fire"
+            content="Toggle Heating"
+            color={enabled ? 'good' : 'average'}
+            onClick={() => act('heat_mode')} />
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
   );
-}
+};

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -18,10 +18,10 @@ export const AirAlarm = (props, context) => {
         <InterfaceLockNoticeBox />
         <AirAlarmStatus />
         {!locked && (
-          <AirAlarmControl />
+          <AirAlarmHeatingControls />
         )}
         {!locked && (
-          <AirAlarmHeatingControls />
+          <AirAlarmControl />
         )}
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -74,7 +74,7 @@ const AirAlarmStatus = (props, context) => {
             </LabeledList.Item>
             <LabeledList.Item
               label="Heating Status"
-              color={data.heating_mode == 'heat' ? 'average' : !data.heating_enabled ? 'gray' : 'good' }>
+              color={data.heating_mode === 'heat' ? 'average' : !data.heating_enabled ? 'gray' : 'good'}>
                 {data.heating_enabled ? data.heating_mode : 'Disabled'}
             </LabeledList.Item>
           </>

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -148,6 +148,7 @@ const AirAlarmControlHome = (props, context) => {
   const {
     mode,
     atmos_alarm,
+    heating_enabled,
   } = data;
   return (
     <>
@@ -188,6 +189,12 @@ const AirAlarmControlHome = (props, context) => {
         icon="chart-bar"
         content="Alarm Thresholds"
         onClick={() => setScreen('thresholds')} />
+      <Box mt={1} />
+      <Button
+        icon="fire"
+        content="Toggle Heating"
+        color={heating_enabled ? 'good' : 'average'}
+        onClick={() => act('heat_mode')} />
     </>
   );
 };

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -72,6 +72,11 @@ const AirAlarmStatus = (props, context) => {
                 || data.fire_alarm && 'Fire Alarm'
                 || 'Nominal'}
             </LabeledList.Item>
+            <LabeledList.Item
+              label="Heating Status"
+              color={data.heating_mode == 'heat' ? 'average' : !data.heating_enabled ? 'gray' : 'good' }>
+                {data.heating_enabled ? data.heating_mode : 'Disabled'}
+            </LabeledList.Item>
           </>
         ) || (
           <LabeledList.Item

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -1,7 +1,7 @@
 import { toFixed } from 'common/math';
 import { Fragment } from 'inferno';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, LabeledList, Section } from '../components';
+import { Box, Button, LabeledList, Section, Knob, AnimatedNumber, NumberInput } from '../components';
 import { Window } from '../layouts';
 import { Scrubber, Vent } from './common/AtmosControls';
 import { InterfaceLockNoticeBox } from './common/InterfaceLockNoticeBox';
@@ -19,6 +19,9 @@ export const AirAlarm = (props, context) => {
         <AirAlarmStatus />
         {!locked && (
           <AirAlarmControl />
+        )}
+        {!locked && (
+          <AirAlarmHeatingControls />
         )}
       </Window.Content>
     </Window>
@@ -74,8 +77,8 @@ const AirAlarmStatus = (props, context) => {
             </LabeledList.Item>
             <LabeledList.Item
               label="Heating Status"
-              color={data.heating_mode === 'heat' ? 'average' : !data.heating_enabled ? 'gray' : 'good'}>
-              {data.heating_enabled ? data.heating_mode : 'Disabled'}
+              color={data.heating.mode === 'Heat' ? 'average' : !data.heating.mode ? 'gray' : 'good'}>
+              {data.heating.enabled ? data.heating.mode : 'Disabled'}
             </LabeledList.Item>
           </>
         ) || (
@@ -148,7 +151,6 @@ const AirAlarmControlHome = (props, context) => {
   const {
     mode,
     atmos_alarm,
-    heating_enabled,
   } = data;
   return (
     <>
@@ -189,12 +191,6 @@ const AirAlarmControlHome = (props, context) => {
         icon="chart-bar"
         content="Alarm Thresholds"
         onClick={() => setScreen('thresholds')} />
-      <Box mt={1} />
-      <Button
-        icon="fire"
-        content="Toggle Heating"
-        color={heating_enabled ? 'good' : 'average'}
-        onClick={() => act('heat_mode')} />
     </>
   );
 };
@@ -294,3 +290,42 @@ const AirAlarmControlThresholds = (props, context) => {
     </table>
   );
 };
+
+// Heating
+// --------------------------------------------------------
+
+const AirAlarmHeatingControls = (props, context) => {
+  const { act, data} = useBackend(context);
+  const {
+    enabled,
+    setPoint,
+    maxValue,
+    minValue
+  } = data.heating;
+  return (
+    <>
+      <Section
+      title="Comfort Controls"
+      >
+        <Box mt={1} />
+        <LabeledList>
+          <LabeledList.Item label={"Setpoint"}>
+            <NumberInput
+            value={setPoint}
+            minValue={minValue}
+            maxValue={maxValue}
+            onChange={(e, value) => act('heat_setpoint',{setPoint: value})}
+            unit="K"
+            tooltip="Change the Setpoint of the heater"
+            />
+            <Button
+              icon="fire"
+              content="Toggle Heating"
+              color={enabled ? 'good' : 'average'}
+              onClick={() => act('heat_mode')} />
+          </LabeledList.Item>
+        </LabeledList>
+      </Section>
+    </>
+  );
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a really simple heating controller to the air alarm, that heats off a set point defined in the air alarms vars.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: MissFox
add: Added built-in heater to air alarms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

[Add Heaters to Air alarms](https://app.gitkraken.com/glo/card/7d520976f1134758aed2e23620324aaf)