### PR TITLE
Lower title music volume from 85% to 60%

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -197,7 +197,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	S.status = SOUND_UPDATE
 	SEND_SOUND(src, S)
 
-/client/proc/playtitlemusic(vol = 85)
+/client/proc/playtitlemusic(vol = 60)
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 


### PR DESCRIPTION
## About The Pull Request
Quick and dirty edit so people don't feel forced to shut off the lobby screen music because of no volume adjustment.  
Proper rewrite of the system will be done at a later point

## Changelog
:cl: Avunia Takiya
tweak: Title screen music is now at 60% volume - healthy ears are happy ears
/:cl: