### PR TITLE
BIG ME VUNIA CODE

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -435,7 +435,10 @@
 		to_chat(user, "<span class='boldwarning'>You cannot send IC messages (muted).</span>")
 		return FALSE
 	else if(!params)
-		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+		//HORIZON EDIT BEGIN
+		//var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN) - ORIGINAL
+		var/custom_emote = stripped_multiline_input(user, "Choose an emote to display.", "Me", null, MAX_MESSAGE_LEN)
+		//HORIZON EDIT END
 		if(custom_emote && !check_invalid(user, custom_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
 			switch(type)

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -32,7 +32,10 @@
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
 ///The me emote verb
-/mob/verb/me_verb(message as text)
+//HORIZON EDIT BEGIN
+// /mob/verb/me_verb(message as text)
+/mob/verb/me_verb(message as message)
+//HORIZON EDIT END
 	set name = "Me"
 	set category = "IC"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Me's are now big. Thank you Avunia for the code (which means its untested 👍 )
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Big unga
Closes #65 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Foxtrot (Funce)
tweak: ME IS BIG, NO LONGER PUNY ONE LINE (Thank you Avunia for the code)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

[Larger emote input box](https://app.gitkraken.com/glo/card/8fd727bf3000428b8ecad27e1f5bf4b5)