### PR TITLE
Re-enable specific species emotes and some emotecode TLC

### DIFF
--- a/hrzn/modules/emotes/code/dna_screams.dm
+++ b/hrzn/modules/emotes/code/dna_screams.dm
@@ -4,10 +4,10 @@
 
 /datum/species/synth
 	screamsounds = list('hrzn/modules/emotes/sound/voice/scream_silicon.ogg')
-/* All of the disabled ones here can be readded once the species are in. We should probably find a way to do this better though.
+
 /datum/species/robotic
 	screamsounds = list('hrzn/modules/emotes/sound/voice/scream_silicon.ogg')
-*/
+
 /datum/species/android
 	screamsounds = list('hrzn/modules/emotes/sound/voice/scream_silicon.ogg')
 
@@ -34,13 +34,13 @@
 
 /datum/species/ethereal
 	screamsounds = list('hrzn/modules/emotes/sound/voice/scream_skeleton.ogg')
-/*
+
 /datum/species/dwarf
 	femalescreamsounds = list('hrzn/modules/emotes/sound/voice/scream_f1.ogg', 'hrzn/modules/emotes/sound/voice/scream_f2.ogg')
 
 /datum/species/mammal
 	femalescreamsounds = list('hrzn/modules/emotes/sound/voice/scream_f1.ogg', 'hrzn/modules/emotes/sound/voice/scream_f2.ogg')
-*/
+
 /datum/species/jelly
 	screamsounds = list('hrzn/modules/emotes/sound/emotes/jelly_scream.ogg')
 
@@ -52,22 +52,21 @@
 
 /datum/species/shadow
 	femalescreamsounds = list('hrzn/modules/emotes/sound/voice/scream_f1.ogg', 'hrzn/modules/emotes/sound/voice/scream_f2.ogg')
-/*
+
 /datum/species/robotic/synthliz
 	screamsounds = list('hrzn/modules/emotes/sound/voice/scream_silicon.ogg')
-*/
+
 /datum/species/vampire
 	femalescreamsounds = list('hrzn/modules/emotes/sound/voice/scream_f1.ogg', 'hrzn/modules/emotes/sound/voice/scream_f2.ogg')
-/*
+
 /datum/species/vox
 	screamsounds = list('hrzn/modules/emotes/sound/emotes/voxscream.ogg')
 
 /datum/species/xeno
 	screamsounds = list('sound/voice/hiss6.ogg')
-*/
+
 /datum/species/zombie
 	screamsounds = list('hrzn/modules/emotes/sound/emotes/zombie_scream.ogg')
-/*
+
 /datum/species/tajaran
 	screamsounds = list('hrzn/modules/emotes/sound/emotes/cat_scream.ogg')
-*/

--- a/hrzn/modules/emotes/code/dna_screams.dm
+++ b/hrzn/modules/emotes/code/dna_screams.dm
@@ -35,9 +35,6 @@
 /datum/species/ethereal
 	screamsounds = list('hrzn/modules/emotes/sound/voice/scream_skeleton.ogg')
 
-/datum/species/dwarf
-	femalescreamsounds = list('hrzn/modules/emotes/sound/voice/scream_f1.ogg', 'hrzn/modules/emotes/sound/voice/scream_f2.ogg')
-
 /datum/species/mammal
 	femalescreamsounds = list('hrzn/modules/emotes/sound/voice/scream_f1.ogg', 'hrzn/modules/emotes/sound/voice/scream_f2.ogg')
 

--- a/hrzn/modules/emotes/code/emotes.dm
+++ b/hrzn/modules/emotes/code/emotes.dm
@@ -79,10 +79,8 @@
 	return ..()
 
 /datum/emote/living/cough/get_sound(mob/living/user)
-/* TODO: READD WHEN VOXES ARE BACK
 	if(isvox(user))
 		return 'hrzn/modules/emotes/sound/emotes/voxcough.ogg'
-*/
 	if(iscarbon(user))
 		if(user.gender == MALE)
 			return pick('hrzn/modules/emotes/sound/emotes/male/male_cough_1.ogg',
@@ -97,10 +95,8 @@
 	vary = TRUE
 
 /datum/emote/living/sneeze/get_sound(mob/living/user)
-/* TODO: READD WHEN VOXES ARE BACK
 	if(isvox(user))
 		return 'hrzn/modules/emotes/sound/emotes/voxsneeze.ogg'
-*/
 	if(iscarbon(user))
 		if(user.gender == MALE)
 			return 'hrzn/modules/emotes/sound/emotes/male/male_sneeze.ogg'
@@ -465,7 +461,7 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'hrzn/modules/emotes/sound/voice/long_awoo.ogg'
-	//cooldown = 3 SECONDS -- Removed as the current global cooldown is larger
+	cooldown = 3 SECONDS
 
 /datum/emote/living/rattle
 	key = "rattle"


### PR DESCRIPTION
## About The Pull Request
Re-enables some of the disabled emotes for species with checks like Vox' and others, which required #11 
Also does some QoL fixes.

Maybe more to come, hence draft for now.
[#89 - Reenable some emotes, code fixes](https://app.gitkraken.com/glo/card/075831dc29774732807fb30230bbd855)