### PR TITLE
[CHECK ISSUE] Change file/URL references, horizon.dme

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,11 +17,11 @@ cfg
 data
 SQL
 node_modules
-tgstation.dmb
-tgstation.int
-tgstation.rsc
-tgstation.lk
-tgstation.dyn.rsc
+horizon.dmb
+horizon.int
+horizon.rsc
+horizon.lk
+horizon.dyn.rsc
 *.dll
 Dockerfile
 tools/bootstrap/.cache

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,6 @@ After setting it up, optionally navigate your git commandline to the project fol
 
 We have a [list of guides on the wiki](http://www.tgstation13.org/wiki/Guides#Development_and_Contribution_Guides) that will help you get started contributing to /tg/station with Git and Dream Maker. For beginners, it is recommended you work on small projects like bugfixes at first. If you need help learning to program in BYOND, check out this [repository of resources](http://www.byond.com/developer/articles/resources).
 
-There is an open list of approachable issues for [your inspiration here](https://github.com/tgstation/tgstation/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22).
 
 You can of course, as always, ask for help on the Discord channels or the forums. We're just here to have fun and help out, so please don't expect professional support.
 

--- a/.github/DOWNLOADING.md
+++ b/.github/DOWNLOADING.md
@@ -5,17 +5,6 @@ Option 1:
 Follow this: https://www.tgstation13.org/wiki/Setting_up_git
 
 Option 2: Download the source code as a zip by clicking the ZIP button in the
-code tab of https://github.com/tgstation/tgstation
+code tab of https://github.com/hrzntal/horizon
 (note: this will use a lot of bandwidth if you wish to update and is a lot of
 hassle if you want to make any changes at all, so it's not recommended.)
-
-Option 3: Download a pre-compiled nightly at https://tgstation13.download/nightlies/ (same caveats as option 2)
-
-*Warning: option 4 is out of date, and not maintained, use at your own risk*
-
-Option 4: Use our docker image that tracks the master branch (See commits for build status. Again, same caveats as option 2)
-
-```
-docker run -d -p <your port>:1337 -v /path/to/your/config:/tgstation/config -v /path/to/your/data:/tgstation/data tgstation/tgstation <dream daemon options i.e. -public or -params>
-```
-

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,9 +5,7 @@ about: Create a report to help reproduce and fix the issue
 <!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable -->
 ## Round ID:
 
-<!--- **INCLUDE THE ROUND ID**
-If you discovered this issue from playing tgstation hosted servers:
-[Round ID]: # (It can be found in the Status panel or retrieved from https://atlantaned.space/statbus/round.php ! The round id let's us look up valuable information and logs for the round the bug happened.)-->
+<!-- **INCLUDE THE ROUND ID** -->
 
 ## Testmerges:
 

--- a/.github/RUNNING_A_SERVER.md
+++ b/.github/RUNNING_A_SERVER.md
@@ -8,8 +8,8 @@ Double-click `BUILD.bat` in the root directory of the source code. This'll take
 a little while, and if everything's done right you'll get a message like this:
 
 ```
-saving tgstation.dmb (DEBUG mode)
-tgstation.dmb - 0 errors, 0 warnings
+saving horizon.dmb (DEBUG mode)
+horizon.dmb - 0 errors, 0 warnings
 ```
 
 If you see any errors or warnings, something has gone wrong - possibly a corrupt
@@ -43,7 +43,7 @@ and install it themselves. Directions can be found at the [rust-g
 repo](https://github.com/tgstation/rust-g).
 
 Finally, to start the server, run Dream Daemon and enter the path to your
-compiled tgstation.dmb file. Make sure to set the port to the one you
+compiled horizon.dmb file. Make sure to set the port to the one you
 specified in the config.txt, and set the Security box to 'Safe'. Then press GO
 and the server should start up and be ready to join. It is also recommended that
 you set up the SQL backend (see below).
@@ -62,7 +62,7 @@ the new version.
 ## HOSTING
 
 If you'd like a more robust server hosting option for tgstation and its
-derivatives. Check out our server tools suite at
+derivatives. Check out tgstation's server tools suite at
 https://github.com/tgstation/tgstation-server
 
 If you decide to go this route, here are /tg/ specific details on hosting with TGS.
@@ -91,9 +91,9 @@ Web delivery of game resources makes it quicker for players to join and reduces 
 
 ### All In One Amazon Web Services Hosting and Content delivery network.
 **Important Note**
-It is very Importat to note that since AWS is all highly integrated its "easier" than some solutions. However the Price to ***Performance Ratio is terrible***.
+It is very Important to note that since AWS is all highly integrated its "easier" than some solutions. However the Price to ***Performance Ratio is terrible***.
 
-/tg/ Using around 7TB of bandwidth a month. These costs add up. So AWS is probly only a solution for low to mid pop servers
+/tg/ Using around 7TB of bandwidth a month. These costs add up. So AWS is probably only a solution for low to mid pop servers
 
 **Please use [AWS Cost Estimator](https://calculator.s3.amazonaws.com/index.html) to determine if this solution is right for you.**
 
@@ -136,10 +136,10 @@ It is highly recommended to reference AWS support documentation while reading th
 ```Batch
 @echo off
 cd "C:\Program Files\Amazon\AWSCLIV2"
-aws s3 cp "C:\Instance_Path\Game\Live\tgstation.rsc" s3://BucketName/tgstation.rsc --acl public-read
+aws s3 cp "C:\Instance_Path\Game\Live\horizon.rsc" s3://BucketName/horizon.rsc --acl public-read
 ```
 
-7. In your TGS4's instance's static config files edit resources.txt to point to the resource file uploaded by the batch file. it should resemble `http://BucketName.s3.AWSRegion.amazonaws.com/tgstation.rsc` You can get this url from the S3 object management page after its been uploaded for the first time. *Make sure you do not use use HTTPS. Byond can not do encryption*
+7. In your TGS4's instance's static config files edit resources.txt to point to the resource file uploaded by the batch file. it should resemble `http://BucketName.s3.AWSRegion.amazonaws.com/horizon.rsc` You can get this url from the S3 object management page after its been uploaded for the first time. *Make sure you do not use use HTTPS. Byond can not do encryption*
 7. Tell TGS4 to fetch and deploy. If everything goes according to plan, your server will be compiled and the resource uploaded automatically to amazon S3. You can verify that by checking on the file your bucket via aws web management.
 7. Test your client side connection.
 	* Tell TGS4 to run the compiled server

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -26,7 +26,7 @@ jobs:
           tools/bootstrap/python -c ''
       - name: Run Linters
         run: |
-          bash tools/ci/check_filedirs.sh tgstation.dme
+          bash tools/ci/check_filedirs.sh horizon.dme
           bash tools/ci/check_changelogs.sh
           find . -name "*.php" -print0 | xargs -0 -n1 php -l
           find . -name "*.json" -not -path "*/node_modules/*" -print0 | xargs -0 python3 ./tools/json_verifier.py

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build and Publish Docker Image to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: tgstation/tgstation
+          name: hrzntal/horizon
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: Dockerfile

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,12 +26,12 @@
 		},
 		{
 			"type": "dreammaker",
-			"dme": "tgstation.dme",
+			"dme": "horizon.dme",
 			"problemMatcher": [
 				"$dreammaker"
 			],
 			"group": "build",
-			"label": "dm: build - tgstation.dme"
+			"label": "dm: build - horizon.dme"
 		},
 		{
 			"type": "shell",

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ RUN . ./dependencies.sh \
     && cd .. \
     && rm -rf byond byond.zip
 
-# build = byond + tgstation compiled and deployed to /deploy
+# build = byond + horizon compiled and deployed to /deploy
 FROM byond AS build
-WORKDIR /tgstation
+WORKDIR /horizon
 
 RUN apt-get install -y --no-install-recommends \
         curl
@@ -71,7 +71,7 @@ RUN . ./dependencies.sh \
 
 # final = byond + runtime deps + rust_g + build
 FROM byond
-WORKDIR /tgstation
+WORKDIR /horizon
 
 RUN apt-get install -y --no-install-recommends \
         libssl1.0.0:i386 \
@@ -80,6 +80,6 @@ RUN apt-get install -y --no-install-recommends \
 COPY --from=build /deploy ./
 COPY --from=rust_g /rust_g/target/i686-unknown-linux-gnu/release/librust_g.so ./librust_g.so
 
-VOLUME [ "/tgstation/config", "/tgstation/data" ]
-ENTRYPOINT [ "DreamDaemon", "tgstation.dmb", "-port", "1337", "-trusted", "-close", "-verbose" ]
+VOLUME [ "/horizon/config", "/horizon/data" ]
+ENTRYPOINT [ "DreamDaemon", "horizon.dmb", "-port", "1337", "-trusted", "-close", "-verbose" ]
 EXPOSE 1337

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Code based on [/tg/station](https://github.com/tgstation/tgstation) among others
 
 ## :exclamation: How to compile :exclamation:
 
-On **2021-01-04** we have changed the way to compile the codebase.
+On **2021-01-04** tgstation has changed the way to compile the codebase.
 
-Find `BUILD.bat` here in the root folder of tgstation, and double click it to initiate the build. It consists of multiple steps and might take around 1-5 minutes to compile.
+Find `BUILD.bat` here in the root folder of horizon, and double click it to initiate the build. It consists of multiple steps and might take around 1-5 minutes to compile.
 
-After it finishes, you can then [setup the server](.github/RUNNING_A_SERVER.md) normally by opening `tgstation.dmb` in DreamDaemon.
+After it finishes, you can then [setup the server](.github/RUNNING_A_SERVER.md) normally by opening `horizon.dmb` in DreamDaemon.
 
-**Building tgstation in DreamMaker directly is now deprecated and might produce errors**, such as `'tgui.bundle.js': cannot find file`.
+**Building horizon in DreamMaker directly is now deprecated and might produce errors**, such as `'tgui.bundle.js': cannot find file`.
 
 **[How to compile in VSCode and other build options](tools/build/README.md).**
 
@@ -58,9 +58,9 @@ After it finishes, you can then [setup the server](.github/RUNNING_A_SERVER.md) 
 
 ## LICENSE
 
-All code after [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/tgstation/tgstation/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU AGPL v3](https://www.gnu.org/licenses/agpl-3.0.html).
+All code after [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/hrzntal/horizon/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU AGPL v3](https://www.gnu.org/licenses/agpl-3.0.html).
 
-All code before [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/tgstation/tgstation/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.html).
+All code before [commit 333c566b88108de218d882840e61928a9b759d8f on 2014/31/12 at 4:38 PM PST](https://github.com/hrzntal/horizon/commit/333c566b88108de218d882840e61928a9b759d8f) is licensed under [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.html).
 (Including tools unless their readme specifies otherwise.)
 
 See LICENSE and GPLv3.txt for more details.

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -224,7 +224,7 @@
 	config_entry_value = "http://www.tgstation13.org/wiki/Rules"
 
 /datum/config_entry/string/githuburl
-	config_entry_value = "https://www.github.com/tgstation/tgstation"
+	config_entry_value = "https://www.github.com/hrzntal/horizon"
 
 /datum/config_entry/string/discordbotcommandprefix
 	config_entry_value = "?"

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -2,7 +2,7 @@
 ## Debugging GC issues
 
 In order to debug `qdel()` failures, there are several tools available.
-To enable these tools, define `TESTING` in [_compile_options.dm](https://github.com/tgstation/-tg-station/blob/master/code/_compile_options.dm).
+To enable these tools, define `TESTING` in [_compile_options.dm](https://github.com/hrzntal/horizon/blob/master/code/_compile_options.dm).
 
 First is a verb called "Find References", which lists **every** refererence to an object in the world. This allows you to track down any indirect or obfuscated references that you might have missed.
 

--- a/code/modules/unit_tests/README.md
+++ b/code/modules/unit_tests/README.md
@@ -39,7 +39,7 @@ Open `code/_compile_options.dm` and uncomment the following line.
 //#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 ```
 
-Then, run tgstation.dmb in Dream Daemon. Don't bother trying to connect, you won't need to. You'll be able to see the outputs of all the tests. You'll get to see which tests failed and for what reason. If they all pass, you're set!
+Then, run horizon.dmb in Dream Daemon. Don't bother trying to connect, you won't need to. You'll be able to see the outputs of all the tests. You'll get to see which tests failed and for what reason. If they all pass, you're set!
 
 ## How to think about tests
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -9,17 +9,17 @@ $include interviews.txt
 
 # You can use the @ character at the beginning of a config option to lock it from being edited in-game
 # Example usage:
-# @SERVERNAME tgstation
+# @SERVERNAME horizon
 # Which sets the SERVERNAME, and disallows admins from being able to change it using View Variables.
 # @LOG_TWITTER 0
 # Which explicitly disables LOG_TWITTER, as well as locking it.
 # There are various options which are hard-locked for security reasons.
 
-## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'tgstation' with the name of your choice.
-# SERVERNAME tgstation
+## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'horizon' with the name of your choice.
+# SERVERNAME horizon
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
-# SERVERSQLNAME tgstation
+# SERVERSQLNAME horizon
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13
@@ -247,7 +247,7 @@ CHECK_RANDOMIZER
 # RULESURL http://www.tgstation13.org/wiki/Rules
 
 ## Github address
-# GITHUBURL https://www.github.com/tgstation/tgstation
+# GITHUBURL https://www.github.com/hrzntal/horizon
 
 ## Discord bot command prefix, if the discord bot is used
 # DISCORDBOTCOMMANDPREFIX ?

--- a/horizon.dme
+++ b/horizon.dme
@@ -1,4 +1,4 @@
-// DM Environment file for tgstation.dme.
+// DM Environment file for horizon.dme.
 // All manual changes should be made outside the BEGIN_ and END_ blocks.
 // New source code should be placed in .dm files: choose File/New --> Code File.
 // BEGIN_INTERNALS

--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -175,27 +175,27 @@ export class Changelog extends Component {
 
     const header = (
       <Section>
-        <h1>Traditional Games Space Station 13</h1>
+        <h1>Horizon Project</h1>
         <p>
           <b>Thanks to: </b>
-          Baystation 12, /vg/station, NTstation, CDK Station devs,
+          /tg/station, Baystation 12, /vg/station, NTstation, CDK Station devs,
           FacepunchStation, GoonStation devs, the original Space Station 13
           developers, Invisty for the title image and the countless others who
           have contributed to the game, issue tracker or wiki over the years.
         </p>
         <p>
           {'Current project maintainers can be found '}
-          <a href="https://github.com/tgstation?tab=members">
+          <a href="https://github.com/hrzntal?tab=members">
             here
           </a>
           {', recent GitHub contributors can be found '}
-          <a href="https://github.com/tgstation/tgstation/pulse/monthly">
+          <a href="https://github.com/hrzntal/horizon/pulse/monthly">
             here
           </a>.
         </p>
         <p>
           {'You can also join our discord '}
-          <a href="https://tgstation13.org/phpBB/viewforum.php?f=60">
+          <a href="https://discord.hrzn.fun">
             here
           </a>.
         </p>

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -551,7 +551,7 @@ o8o        `8    "888"  `Y8bood8P'  8""88888P'
 A fatal exception has occurred at 002B:C562F1B7 in TGUI.
 The current application will be terminated.
 Send the copy of the following stack trace to an authorized
-Nanotrasen incident handler at https://github.com/tgstation/tgstation.
+Nanotrasen incident handler at https://github.com/hrzntal/horizon.
 Thank you for your cooperation.
 </marquee>
 <div id="FatalError__stack" class="FatalError__stack"></div>

--- a/tools/CreditsTool/UpdateCreditsDMI.sh
+++ b/tools/CreditsTool/UpdateCreditsDMI.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #If you hit github's rate limit, add a 3rd parameter here that is a github personal access token
-./CreditsTool tgstation tgstation
+./CreditsTool hrzntal horizon
 
 rm ../../icons/credits.dmi
 

--- a/tools/LinuxOneShot/docker-compose.yml
+++ b/tools/LinuxOneShot/docker-compose.yml
@@ -39,7 +39,7 @@ services:
   setup:
     environment:
       TGS_BYOND: 514.1554
-      TGS_REPO: https://github.com/tgstation/tgstation
+      TGS_REPO: https://github.com/hrzntal/horizon
     build:
       context: ./SetupProgram
       dockerfile: Dockerfile

--- a/tools/Upload tgstation.rsc to external FTP/upload_rsc.bat
+++ b/tools/Upload tgstation.rsc to external FTP/upload_rsc.bat
@@ -1,20 +1,20 @@
-@REM Script to easily upload tgstation.rsc to your FTP-server so that clients download it from an
+@REM Script to easily upload horizon.rsc to your FTP-server so that clients download it from an
 @REM external webserver instead of from your connection when joining your game server.
 @REM
 @REM Run this script every time you have compiled your code, otherwise joining players will get errors.
 @REM
 @REM Replace USERNAME with your FTP username
 @REM Replace PASSWORD with your FTP password
-@REM Replace FOLDER/FOLDER with the folder on the FTP server where you want to store tgstation.rsc, for example: cd www/rsc
+@REM Replace FOLDER/FOLDER with the folder on the FTP server where you want to store horizon.rsc, for example: cd www/rsc
 @REM Replace FTP.DOMAIN.COM with the IP-address or domain name of your FTP server
-@REM Add the URL to the location of tgstation.rsc on your webserver into data\external_rsc_urls.txt
+@REM Add the URL to the location of horizon.rsc on your webserver into data\external_rsc_urls.txt
 @REM
 @echo off
 echo user USERNAME> ftpcmd.dat
 echo PASSWORD>> ftpcmd.dat
 echo bin>> ftpcmd.dat
 echo cd FOLDER/FOLDER>> ftpcmd.dat
-echo put ..\..\tgstation.rsc>> ftpcmd.dat
+echo put ..\..\horizon.rsc>> ftpcmd.dat
 echo quit>> ftpcmd.dat
 ftp -n -s:ftpcmd.dat FTP.DOMAIN.COM
 del ftpcmd.dat

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -49,7 +49,7 @@ if (process.env.CBT_BUILD_MODE) {
 }
 console.log(`Starting CBT in ${BUILD_MODE} mode.`)
 
-const DME_NAME = 'tgstation'
+const DME_NAME = 'horizon'
 
 // Main
 // --------------------------------------------------------

--- a/tools/ci/run_server.sh
+++ b/tools/ci/run_server.sh
@@ -8,6 +8,6 @@ mkdir ci_test/config
 cp tools/ci/ci_config.txt ci_test/config/config.txt
 
 cd ci_test
-DreamDaemon tgstation.dmb -close -trusted -verbose -params "log-directory=ci"
+DreamDaemon horizon.dmb -close -trusted -verbose -params "log-directory=ci"
 cd ..
 cat ci_test/data/logs/ci/clean_run.lk

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -20,7 +20,7 @@ if [ -d ".git" ]; then
   cp -r .git/logs/* $1/.git/logs/
 fi
 
-cp tgstation.dmb tgstation.rsc $1/
+cp horizon.dmb horizon.rsc $1/
 cp -r _maps/* $1/_maps/
 cp -r icons/runtime/* $1/icons/runtime/
 cp -r sound/runtime/* $1/sound/runtime/

--- a/tools/expand_filedir_paths.py
+++ b/tools/expand_filedir_paths.py
@@ -20,7 +20,7 @@ source_pattern = re.compile(r"^.*?\.(dm|dmm)$")
 def read_filedirs(filename):
     result = []
     dme_file = file(filename, "rt")
-    
+
     # Read each line from the file and check for regex pattern match
     for row in dme_file:
         match = filedir_pattern.match(row)
@@ -63,7 +63,7 @@ def rewrite_sources(resources):
         else:
             replacement = name.group(1)
         return "'" + replacement + "'"
-    
+
     # Search recursively for all .dm and .dmm files
     for (dirpath, dirs, files) in os.walk("."):
         for name in files:
@@ -88,6 +88,6 @@ def rewrite_sources(resources):
                 os.remove(path)
                 os.rename(path + ".tmp", path)
 
-dirs = read_filedirs("tgstation.dme");
+dirs = read_filedirs("horizon.dme");
 resources = index_files(dirs)
 rewrite_sources(resources)

--- a/tools/tgs4_scripts/PreCompile.bat
+++ b/tools/tgs4_scripts/PreCompile.bat
@@ -4,8 +4,8 @@ set TG_BOOTSTRAP_CACHE=%cd%
 IF NOT %1 == "" (
 	rem TGS4: we are passed the game directory on the command line
 	cd %1
-) ELSE IF EXIST "..\Game\B\tgstation.dmb" (
-	rem TGS3: Game/B/tgstation.dmb exists, so build in Game/A
+) ELSE IF EXIST "..\Game\B\horizon.dmb" (
+	rem TGS3: Game/B/horizon.dmb exists, so build in Game/A
 	cd ..\Game\A
 ) ELSE (
 	rem TGS3: Otherwise build in Game/B


### PR DESCRIPTION
## About The Pull Request
File references pointing to `tgstation.dm*` or similar will now point to `horizon.dm*`
URLs referencing to the tgstation GitHub will now point to the horizon repo - only for ones not pointing to specific commits or pull requests.
