### PR TITLE
[Manual Mirror] Reworks skittish quirk to be automatic

### DIFF
--- a/code/datums/elements/skittish.dm
+++ b/code/datums/elements/skittish.dm
@@ -1,0 +1,61 @@
+/*
+ * An element that makes mobs run into lockers when they bump into them.
+ */
+
+/datum/element/skittish
+	element_flags = ELEMENT_DETACH
+
+/datum/element/skittish/Attach(datum/target)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+
+	RegisterSignal(target, COMSIG_MOVABLE_BUMP, .proc/Bump)
+
+/datum/element/skittish/Detach(datum/target)
+	UnregisterSignal(target, COMSIG_MOVABLE_BUMP)
+	. = ..()
+
+/datum/element/skittish/proc/Bump(mob/living/scooby, atom/target)
+	if(scooby.stat != CONSCIOUS || scooby.m_intent != MOVE_INTENT_RUN)
+		return
+
+	if(!istype(target, /obj/structure/closet))
+		return
+
+	var/obj/structure/closet/closet = target
+
+	if(!closet.divable)
+		// Things like secure crates can blow up under certain circumstances
+		return
+
+	var/turf/closet_turf = get_turf(closet)
+
+	if(!closet.opened)
+		if(closet.locked)
+			closet.togglelock(scooby, silent = TRUE)
+		if(!closet.open(scooby))
+			// No message if unable to open, since this is on Bump, spammy potential
+			return
+
+	// If it's a crate, "dive for cover" and start resting so people can jump into crates without slamming the lid on their head
+	if(closet.horizontal)
+		// need to rest before moving, otherwise "can't get crate to close" message will be printed erroneously
+		scooby.set_resting(TRUE, silent = TRUE)
+
+	scooby.forceMove(closet_turf)
+
+	if(!closet.close(scooby))
+		to_chat(scooby, "<span class='warning'>You can't get [closet] to close!</span>")
+		if(closet.horizontal)
+			scooby.set_resting(FALSE, silent = TRUE)
+		return
+
+	closet.togglelock(scooby, silent = TRUE)
+
+	if(closet.horizontal)
+		scooby.set_resting(FALSE, silent = TRUE)
+
+	closet_turf.visible_message("<span class='warning'>[scooby] dives into [closet]!</span>")
+	// If you run into a locker, you don't want to run out immediately
+	scooby.Immobilize(0.5 SECONDS)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -188,8 +188,8 @@
 
 /datum/quirk/skittish
 	name = "Skittish"
-	desc = "You can conceal yourself in danger. Ctrl-shift-click a closed locker to jump into it, as long as you have access."
-	value = 2
+	desc = "You're easy to startle, and hide frequently. Run into a closed locker to jump into it, as long as you have access. You can walk to avoid this."
+	value = 8
 	mob_trait = TRAIT_SKITTISH
 	medical_record_text = "Patient demonstrates a high aversion to danger and has described hiding in containers out of fear."
 

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -12,6 +12,9 @@
 	open_sound_volume = 25
 	close_sound_volume = 50
 
+	// Stops people from "diving into" a crate you can't open normally
+	divable = FALSE
+
 /obj/structure/closet/crate/large/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(manifest)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -13,6 +13,9 @@
 	var/spawned_loot = FALSE
 	tamperproof = 90
 
+	// Stop people from "diving into" the crate accidentally, and then detonating it.
+	divable = FALSE
+
 /obj/structure/closet/crate/secure/loot/Initialize()
 	. = ..()
 	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
@@ -98,17 +101,11 @@
 			return
 	return ..()
 
-/obj/structure/closet/secure/loot/dive_into(mob/living/user)
-	if(!locked)
-		return ..()
-	to_chat(user, "<span class='notice'>That seems like a stupid idea.</span>")
-	return FALSE
-
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user)
 	if(locked)
 		boom(user)
 
-/obj/structure/closet/crate/secure/loot/togglelock(mob/user)
+/obj/structure/closet/crate/secure/loot/togglelock(mob/user, silent = FALSE)
 	if(locked)
 		boom(user)
 	else

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -41,6 +41,9 @@
 	RegisterSignal(src, COMSIG_MOVETYPE_FLAG_ENABLED, .proc/on_movement_type_flag_enabled)
 	RegisterSignal(src, COMSIG_MOVETYPE_FLAG_DISABLED, .proc/on_movement_type_flag_disabled)
 
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_SKITTISH), .proc/on_skittish_trait_gain)
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_SKITTISH), .proc/on_skittish_trait_loss)
+
 /// Called when [TRAIT_KNOCKEDOUT] is added to the mob.
 /mob/living/proc/on_knockedout_trait_gain(datum/source)
 	SIGNAL_HANDLER
@@ -192,3 +195,14 @@
 /mob/living/proc/on_movement_type_flag_disabled(datum/source, trait)
 	SIGNAL_HANDLER
 	update_movespeed(FALSE)
+
+
+/// Called when [TRAIT_SKITTISH] is added to the mob.
+/mob/living/proc/on_skittish_trait_gain(datum/source)
+	SIGNAL_HANDLER
+	AddElement(/datum/element/skittish)
+
+/// Called when [TRAIT_SKITTISH] is removed from the mob.
+/mob/living/proc/on_skittish_trait_loss(datum/source)
+	SIGNAL_HANDLER
+	RemoveElement(/datum/element/skittish)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -629,6 +629,7 @@
 #include "code\datums\elements\rad_insulation.dm"
 #include "code\datums\elements\ridable.dm"
 #include "code\datums\elements\selfknockback.dm"
+#include "code\datums\elements\skittish.dm"
 #include "code\datums\elements\snail_crawl.dm"
 #include "code\datums\elements\squashable.dm"
 #include "code\datums\elements\squish.dm"


### PR DESCRIPTION
Original PR: tgstation/tgstation#56048
---
🆑 coiax
tweak: The Skittish quirk will now cause you to automatically dive into
a locker/crate if you bump into it (although closets must be closed).
Walk to avoid this behaviour.
/🆑

This makes the quirk more useful, while also making it more thematic,
since the "diving into" behaviour can't be disabled, only supressed by
walking.

The cost is unchanged, as the quirk in its current form is overcosted at
2 points.

The emergent effect of skittish people diving into closets when caught
into explosions is definitely a feature, and not a bug.

---

~~There is some performance work that can be done, (moving the bumping behaviour
from the closet to the mob), but only if this is popular.~~

The "skittish" code is now an element that is added/removed from /mob/livings when they
gain/lose the TRAIT_SKITTISH trait.

It handles means that instead of listening for all atoms that bump into closets, we instead
only check when a skittish person bumps into a thing.