### PR TITLE
[Manual Mirror] Soapstone messages voted beneath a certain score don't persist

### DIFF
--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -128,6 +128,9 @@ but only permamently removed with the curator's soapstone.
 
 	var/turf/original_turf
 
+	/// Total vote count at or below which we won't persist.
+	var/delete_at = -5
+
 /obj/structure/chisel_message/Initialize(mapload)
 	. = ..()
 	SSpersistence.chisel_messages += src
@@ -137,6 +140,9 @@ but only permamently removed with the curator's soapstone.
 	if(!good_chisel_message_location(T))
 		persists = FALSE
 		return INITIALIZE_HINT_QDEL
+
+	if(like_keys.len - dislike_keys.len <= delete_at)
+		persists = FALSE
 
 /obj/structure/chisel_message/proc/register(mob/user, newmessage)
 	hidden_message = newmessage
@@ -270,3 +276,6 @@ but only permamently removed with the curator's soapstone.
 			if(confirm == "Yes")
 				persists = FALSE
 				qdel(src)
+				return
+
+	persists = like_keys.len - dislike_keys.len > delete_at


### PR DESCRIPTION
# Mirrored from: tgstation/tgstation#56361

---

## About The Pull Request
Soapstone messages no longer persist if their total voting score is -5 or below (might change based on feedback). The game won't save them and old messages beneath the threshold will be set to non-persistent when they load, which means there's one round to save them (you could also just engrave them again).

## Why It's Good For The Game
These have shit up the place for years now regardless of what the consensus on each one is. One of the reasons nobody looks at them is because there's so many, and they're usually of low quality.

At the moment only the soapstone or admins can delete them. I don't think that's been enough to keep them at a manageable amount and decent quality.

I like this feature a lot. I've just thought for years it needed this to make it worthwhile.

## Changelog
🆑 cacogen
tweak: Soapstone messages at or below -5 voting score won't persist. This is to reduce the amount and increase the overall quality. If this changelog wasn't here last round you may be able to save one
/🆑