### PR TITLE
Update path and inhand icons for BST id

### DIFF
--- a/hrzn/modules/icspawning/code/game/objects/items/cards_ids.dm
+++ b/hrzn/modules/icspawning/code/game/objects/items/cards_ids.dm
@@ -1,6 +1,8 @@
 //SKYRAT MODULE IC-SPAWNING https://github.com/Skyrat-SS13/Skyrat-tg/pull/104
-/obj/item/card/id/debug/bst
+/obj/item/card/id/advanced/debug/bst
 	name = "\improper Bluespace Tech"
 	desc = "A Bluespace Tech ID card. Complete access."
-	icon_state = "gold"
+	icon_state = "card_gold"
+	worn_icon_state = "card_gold"
+	inhand_icon_state = "gold_id"
 	assignment = "Bluespace Tech"

--- a/hrzn/modules/icspawning/code/game/objects/items/cards_ids.dm
+++ b/hrzn/modules/icspawning/code/game/objects/items/cards_ids.dm
@@ -1,8 +1,12 @@
 //SKYRAT MODULE IC-SPAWNING https://github.com/Skyrat-SS13/Skyrat-tg/pull/104
+/datum/id_trim/admin/bst
+	assignment = "Bluespace Tech"
+	trim_state = "trim_centcom"
+
 /obj/item/card/id/advanced/debug/bst
 	name = "\improper Bluespace Tech"
 	desc = "A Bluespace Tech ID card. Complete access."
 	icon_state = "card_gold"
 	worn_icon_state = "card_gold"
 	inhand_icon_state = "gold_id"
-	assignment = "Bluespace Tech"
+	trim = /datum/id_trim/admin/bst

--- a/hrzn/modules/icspawning/code/modules/clothing/outfits/standard.dm
+++ b/hrzn/modules/icspawning/code/modules/clothing/outfits/standard.dm
@@ -49,7 +49,7 @@
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	belt = /obj/item/storage/belt/utility/chief/full/debug
 	shoes = /obj/item/clothing/shoes/combat/debug
-	id = /obj/item/card/id/debug/bst
+	id = /obj/item/card/id/advanced/debug/bst
 	back = /obj/item/storage/backpack/holding
 	box = /obj/item/storage/box/debugtools
 	suit_store = /obj/item/gun/energy/pulse
@@ -73,7 +73,7 @@
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	belt = /obj/item/storage/belt/utility/chief/full/debug
 	shoes = /obj/item/clothing/shoes/combat/debug
-	id = /obj/item/card/id/debug/bst
+	id = /obj/item/card/id/advanced/debug/bst
 	back = /obj/item/storage/backpack/holding
 	box = /obj/item/storage/box/debugtools
 	suit_store = /obj/item/tank/internals/oxygen


### PR DESCRIPTION
## Changelog
:cl: Avunia Takiya
qol: Inhand Bluespace Tech IDs are now gold
fix: Fixed Bluespace Tech IDs
/:cl:
