### PR TITLE
Fix chat highlighting

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -176,7 +176,7 @@ class ChatRenderer {
       this.highlightColor = null;
       return;
     }
-    const allowedRegex = /^[a-z0-9_\-\s]+$/ig;
+    const allowedRegex = /^[a-z0-9_\-\s]+$/i;
     const lines = String(text)
       .split(',')
       .map(str => str.trim())


### PR DESCRIPTION
## About The Pull Request
Removes the global flag from the chat highlight regex, which caused only every odd entry to work.

## Changelog
:cl: Avunia Takiya
fix: Chat highlighting now works for every word, not only every odd one.
/:cl:
