### PR TITLE
Remove directory traversal on getting changelog items

### DIFF
--- a/code/datums/changelog/changelog.dm
+++ b/code/datums/changelog/changelog.dm
@@ -25,7 +25,7 @@
 	var/list/data = list( "dates" = list() )
 	var/regex/ymlRegex = regex(@"\.yml", "g")
 
-	for(var/archive_file in flist("[global.config.directory]/../html/changelogs/archive/"))
+	for(var/archive_file in flist("html/changelogs/archive/"))
 		var/archive_date = ymlRegex.Replace(archive_file, "")
 		data["dates"] = list(archive_date) + data["dates"]
 

--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -78,6 +78,8 @@ export class Changelog extends Component {
         const result = await changelogData.text();
         const errorRegex = /^Cannot find/;
 
+        throw result;
+
         if (errorRegex.test(result)) {
           const timeout = 50 + attemptNumber * 50;
 

--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -90,6 +90,8 @@ export class Changelog extends Component {
         } else {
           self.setData(yaml.load(result, { schema: yaml.CORE_SCHEMA }));
         }
+      }).catch(async (err_reason) => {
+        self.setData(err_reason);
       });
   }
 

--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -90,8 +90,6 @@ export class Changelog extends Component {
         } else {
           self.setData(yaml.load(result, { schema: yaml.CORE_SCHEMA }));
         }
-      }).catch(async (err_reason) => {
-        self.setData(err_reason);
       });
   }
 

--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -78,8 +78,6 @@ export class Changelog extends Component {
         const result = await changelogData.text();
         const errorRegex = /^Cannot find/;
 
-        throw result;
-
         if (errorRegex.test(result)) {
           const timeout = 50 + attemptNumber * 50;
 


### PR DESCRIPTION
## About The Pull Request
Changes the ui_act on changelogs from having their workdir on `config`, then traverse up on the tree to switch to `html`
This is incredibly abysmal as config is in most production instances symlinked to a different directory which persists the config instead of overwriting it with repository defaults.

#### Example
![image](https://user-images.githubusercontent.com/6952402/120941707-6a3c0300-c724-11eb-9661-7e1794b3c274.png)
Now where will it go?
`tgs4_instances/Game/Live/html` ? Wrong. ❌ 
`tgs4_instances/Configuration/GameStaticFiles/html`?  ✔️ 


This also makes the changelog work again. What a surprise.

## Changelog
:cl: Avunia Takiya
fix: Hello World! Changelogs work again.
/:cl:

