### PR TITLE
Lower title music volume to 30%

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -197,7 +197,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	S.status = SOUND_UPDATE
 	SEND_SOUND(src, S)
 
-/client/proc/playtitlemusic(vol = 60)
+/client/proc/playtitlemusic(vol = 30)
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 


### PR DESCRIPTION
..from 60%.
## About The Pull Request
BYOND is loud enough that you can always raise your volume more if there's a banger.
This will do until there's a better solution, let's keep our hearing for a couple more years AND have people not forced to disable the music.

## Changelog
:cl: Avunia Takiya
qol: Lobby music is now at 30% - four ears, rejoice!
/:cl: