### PR TITLE
Grammar fix on map info

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -49,7 +49,7 @@
 			level_traits[ZTRAIT_STATION] = TRUE
 
 /datum/map_config/proc/get_map_info()
-	return "You're on board the <b>[map_name]</b>, a top of the class NanoTrasen resesearch station."
+	return "You're on board <b>[map_name]</b>, a top of the class NanoTrasen research station."
 
 /proc/load_map_config(filename = "data/next_map.json", default_to_box, delete_after, error_if_missing = TRUE)
 	var/datum/map_config/config


### PR DESCRIPTION
## About The Pull Request
Fixes a presumably little typo.

This was bothering me enough to do a web edit :notlikethis:
## Changelog
:cl: Avunia Takiya
spellcheck: All resesearch stations have been downgraded to research stations. Sorry Reese's Lovers!
/:cl:
