### PR TITLE
One random planet now spawns

### DIFF
--- a/code/__DEFINES/overmap.dm
+++ b/code/__DEFINES/overmap.dm
@@ -94,3 +94,13 @@
 
 ///Due to the lack of even knowing where to put it in, I'm putting my helper defines stuff here - Azarak
 #define CHECK_AND_PICK_OR_NULL(some_list) some_list ? pick(some_list) : null
+
+//List of all the planets we can spawn roundstart, with an associated weight. Planets with less features are rarer
+#define SPAWN_PLANET_WEIGHT_LIST list(/datum/planet_template/volcanic_planet = 100, \
+					/datum/planet_template/snow_planet = 100, \
+					/datum/planet_template/shrouded_planet = 50, \
+					/datum/planet_template/lush_planet = 100, \
+					/datum/planet_template/jungle_planet = 100, \
+					/datum/planet_template/desert_planet = 100, \
+					/datum/planet_template/chlorine_planet = 50, \
+					/datum/planet_template/barren_planet = 50)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -331,6 +331,16 @@ Used by the AI doomsday and the self-destruct nuke.
 		lavaland_template.LoadTemplate(SSovermap.main_system, rand(3,10), rand(3,10))
 	else if (!isnull(config.minetype) && config.minetype != "none")
 		INIT_ANNOUNCE("WARNING: An unknown minetype '[config.minetype]' was set! This is being ignored! Update the maploader code!")
+
+	var/list/planet_list = SPAWN_PLANET_WEIGHT_LIST
+	if(config.amount_of_planets_spawned)
+		for(var/i in 1 to config.amount_of_planets_spawned)
+			if(!length(planet_list))
+				break
+			var/picked_planet_type = pickweight(planet_list)
+			planet_list -= picked_planet_type
+			var/datum/planet_template/picked_template = planet_templates[picked_planet_type]
+			picked_template.LoadTemplate(SSovermap.main_system, rand(5,25), rand(5,25))
 #endif
 
 	if(LAZYLEN(FailedZs)) //but seriously, unless the server's filesystem is messed up this will never happen

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -53,6 +53,8 @@
 	/// Possible water colors of the loaded map
 	var/list/water_color
 
+	var/amount_of_planets_spawned = 1
+
 /datum/map_config/New()
 	//Make sure that all levels in station do have this z trait
 	. = ..()

--- a/code/modules/map_content/tradership/tradership_define.dm
+++ b/code/modules/map_content/tradership/tradership_define.dm
@@ -18,7 +18,7 @@
 	space_ruin_levels = 7
 	space_empty_levels = 1
 
-	minetype = "lavaland"
+	minetype = "none"
 
 	allow_custom_shuttles = TRUE
 
@@ -27,6 +27,8 @@
 	overflow_job = "Deckhand"
 
 	overmap_object_type = /datum/overmap_object/shuttle/ship/bearcat
+
+	amount_of_planets_spawned = 2
 
 /datum/map_config/tradership/get_map_info()
 	return "You're aboard the <b>[map_name],</b> a survey and mercantile vessel affiliated with the Free Trade Union. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Dependant on https://github.com/hrzntal/horizon/pull/244
## About The Pull Request
One random planet now spawns in the overmap
FTV Bearcat spawns 2 planets but no lavaland

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: One random planet now spawns on the overmap
add: FTV Bearcat now spawns 2 planets on the overmap, but no lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
