### PR TITLE
Engines are now faster, propulsion engines take less fuel

### DIFF
--- a/code/modules/overmap/propulsion_engine.dm
+++ b/code/modules/overmap/propulsion_engine.dm
@@ -137,8 +137,8 @@
 			to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
 		return TRUE
 
-#define ENGINE_MINIMUM_OPERATABLE_MOLES 0.1
-#define ENGINE_BASELINE_MOLE_INTAKE 0.7
+#define ENGINE_MINIMUM_OPERATABLE_MOLES 0.05
+#define ENGINE_BASELINE_MOLE_INTAKE 0.25
 
 /obj/machinery/atmospherics/components/unary/engine/proc/DrawThrust(impulse_power)
 	var/datum/gas_mixture/gas = airs[1]

--- a/code/modules/overmap/shuttle_extension.dm
+++ b/code/modules/overmap/shuttle_extension.dm
@@ -76,7 +76,7 @@
 	var/current_fuel = 100
 	var/maximum_fuel = 100
 	var/current_efficiency = 1
-	var/granted_speed = 0.35
+	var/granted_speed = 0.5
 	var/minimum_fuel_to_operate = 1
 	var/turned_on = FALSE
 	var/cap_speed_multiplier = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
People mentioned that the propulsion ones eat too much fuel, and I've noticed that the small shuttles are kinda slow
I've yet to add mass definitions to most shuttles too, as currently only Bearcat and Crow have them set

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Propulsion engines now take 0.25 fuel instead of 0.7
balance: Engines now grant 0.5 speed instead of 0.35
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
