### PR TITLE
Space Ruin Levels now spawn properly, most maps spawn 3 of them now

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -283,9 +283,10 @@ Used by the AI doomsday and the self-destruct nuke.
 
 #ifndef LOWMEMORYMODE
 	// TODO: remove this when the DB is prepared for the z-levels getting reordered
-	while (world.maxz < 5 && space_levels_so_far < config.space_ruin_levels)
-		++space_levels_so_far
-		add_new_zlevel("Ruins Area [space_levels_so_far]", ZTRAITS_SPACE, overmap_obj = new /datum/overmap_object/ruins(SSovermap.main_system, rand(1,SSovermap.main_system.maxx), rand(1,SSovermap.main_system.maxy)))
+	if(config.space_ruin_levels)
+		for(var/i in 1 to config.space_ruin_levels)
+			++space_levels_so_far
+			add_new_zlevel("Ruins Area [i]", ZTRAITS_SPACE, overmap_obj = new /datum/overmap_object/ruins(SSovermap.main_system, rand(5,25), rand(5,25)))
 	//Load planets
 	if(config.minetype == "lavaland")
 		var/datum/planet_template/lavaland_template = planet_templates[/datum/planet_template/lavaland]

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -19,8 +19,7 @@
 	var/map_file = "MetaStation.dmm"
 
 	var/traits = null
-	var/space_ruin_levels = 7
-	var/space_empty_levels = 1
+	var/space_ruin_levels = 3
 
 	var/minetype = "lavaland"
 

--- a/code/modules/map_content/deltastation_define.dm
+++ b/code/modules/map_content/deltastation_define.dm
@@ -4,8 +4,7 @@
 	map_file = "DeltaStation2.dmm"
 
 	traits = null
-	space_ruin_levels = 7
-	space_empty_levels = 1
+	space_ruin_levels = 3
 
 	minetype = "lavaland"
 

--- a/code/modules/map_content/icebox_define.dm
+++ b/code/modules/map_content/icebox_define.dm
@@ -26,8 +26,7 @@
 						"Ice Ruins" = TRUE,
 						"Baseturf" = "/turf/open/openspace/icemoon/keep_below")
 					)
-	space_ruin_levels = 0
-	space_empty_levels = 0
+	space_ruin_levels = 2
 
 	minetype = "none"
 

--- a/code/modules/map_content/kilostation_define.dm
+++ b/code/modules/map_content/kilostation_define.dm
@@ -4,8 +4,7 @@
 	map_file = "KiloStation.dmm"
 
 	traits = null
-	space_ruin_levels = 4
-	space_empty_levels = 1
+	space_ruin_levels = 3
 
 	minetype = "lavaland"
 

--- a/code/modules/map_content/metastation_define.dm
+++ b/code/modules/map_content/metastation_define.dm
@@ -4,8 +4,7 @@
 	map_file = "MetaStation.dmm"
 
 	traits = null
-	space_ruin_levels = 7
-	space_empty_levels = 1
+	space_ruin_levels = 3
 
 	minetype = "lavaland"
 

--- a/code/modules/map_content/tradership/tradership_define.dm
+++ b/code/modules/map_content/tradership/tradership_define.dm
@@ -15,8 +15,7 @@
 						"Baseturf" = "/turf/open/openspace"),
 					list("Down" = -1,
 						"Baseturf" = "/turf/open/openspace"))
-	space_ruin_levels = 7
-	space_empty_levels = 1
+	space_ruin_levels = 3
 
 	minetype = "lavaland"
 

--- a/code/modules/map_content/tramstation_define.dm
+++ b/code/modules/map_content/tramstation_define.dm
@@ -9,8 +9,7 @@
 						list("Down" = -1,
 						"Baseturf" = "/turf/open/openspace",
 						"Linkage" = "Cross"))
-	space_ruin_levels = 7
-	space_empty_levels = 1
+	space_ruin_levels = 3
 
 	minetype = "lavaland"
 

--- a/code/modules/overmap/overmap_objects.dm
+++ b/code/modules/overmap/overmap_objects.dm
@@ -163,5 +163,6 @@
 	return
 
 /datum/overmap_object/ruins
-	name = "Cluster of ruins"
+	name = "Cluster of Ruins"
 	visual_type = /obj/effect/abstract/overmap/ruins
+	clears_hazards_on_spawn = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This change was suggested to have more exploration content for now

Icebox spawns 2, due to the small amount of shuttles (I think now 0?) it has. But we probably should give it some

Also removed an unused variable about spawning empty levels, we dont use those

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Space Ruin Levels now spawn properly, most maps spawn 3 of them now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
