### PR TITLE
Adds Meat Product to Chef Order Console and Biogen.

### DIFF
--- a/code/game/machinery/computer/chef_orders/order_datum.dm
+++ b/code/game/machinery/computer/chef_orders/order_datum.dm
@@ -141,6 +141,12 @@
 	item_instance = /obj/item/food/fishmeat
 	cost_per_order = 12
 
+/datum/orderable_item/meatproduct
+	name = "Meat Product"
+	category_index = CATEGORY_MILK_EGGS
+	item_instance = /obj/item/food/meat/slab/meatproduct
+	cost_per_order = 25
+
 /datum/orderable_item/spider_eggs
 	name = "Spider Eggs"
 	category_index = CATEGORY_MILK_EGGS

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -66,6 +66,14 @@
 	build_path = /obj/item/food/monkeycube
 	category = list("initial","Food")
 
+/datum/design/meat_product
+	name = "Meat Product"
+	id = "meatproduct"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 200)
+	build_path = /obj/item/food/meat/slab/meatproduct
+	category = list("initial","Food")
+
 /datum/design/ez_nut   //easy nut :)
 	name = "25u E-Z Nutrient"
 	id = "ez_nut"


### PR DESCRIPTION
Adds Meat Product to Chef Order Console and Biogen.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says on the tin.

## Why It's Good For The Game

It's nice being able to order your own ingredients if you have the money for it. It being available in the biogen removes the need to kill monkeys (but is more expensive than monkey cubes.)

## Changelog
:cl:
add: Adds Meat Product to Chef Order Console and Biogen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
