### PR TITLE
Bearcat QoL 2 - Firelocks, Alarms, Departures, Brig

### DIFF
--- a/_maps/map_files/tradership/tradership1.dmm
+++ b/_maps/map_files/tradership/tradership1.dmm
@@ -35,6 +35,9 @@
 	id = "CARGOLIFT";
 	pixel_y = 23
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cE" = (
@@ -59,6 +62,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/cargo/storage)
 "do" = (
@@ -67,13 +71,30 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "dK" = (
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
+"eg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/vending/security,
+/turf/open/floor/iron,
+/area/security/brig)
 "et" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
+"ev" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "ff" = (
 /turf/closed/mineral/random/high_chance,
 /area/space)
@@ -96,6 +117,10 @@
 	icon_state = "wood-broken7"
 	},
 /area/service/bar)
+"gw" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
@@ -110,10 +135,12 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "gX" = (
 /obj/machinery/light/dim/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hU" = (
@@ -130,6 +157,9 @@
 /area/cargo/storage)
 "ip" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -195,12 +225,22 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"nb" = (
+/turf/closed/wall/r_wall,
+/area/security/brig)
+"nf" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "nk" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/science/xenobiology)
 "nn" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -219,6 +259,7 @@
 	id = "xenobio1";
 	name = "Xenobio Pen 1 Blast Door"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "os" = (
@@ -241,8 +282,16 @@
 "pP" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/bar)
+"pW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron,
+/area/security/brig)
 "pX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -253,6 +302,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
+"qw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron,
+/area/security/brig)
+"qB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/iron,
+/area/security/brig)
 "qF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -265,11 +329,16 @@
 	icon_state = "wood-broken2"
 	},
 /area/service/bar)
+"qX" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "rt" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/bar)
 "se" = (
@@ -289,19 +358,35 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
 /obj/machinery/light/dim/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "tE" = (
 /turf/open/floor/plating/airless,
 /area/science/xenobiology)
+"ul" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/brig)
 "uG" = (
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "uK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig)
 "uN" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -321,12 +406,14 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "vF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vT" = (
@@ -356,8 +443,14 @@
 /area/cargo/storage)
 "xo" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig)
 "xx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -371,6 +464,18 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
+/area/cargo/storage)
+"xP" = (
+/obj/structure/lattice/catwalk,
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 12;
+	height = 18;
+	id = "emergency_home";
+	name = "bearcat emergency evac bay";
+	width = 32
+	},
+/turf/open/space/basic,
 /area/cargo/storage)
 "xX" = (
 /obj/effect/spawner/randomarcade,
@@ -400,6 +505,15 @@
 	icon_state = "wood-broken3"
 	},
 /area/service/bar)
+"zB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "zC" = (
 /mob/living/simple_animal/mouse,
 /obj/structure/cable,
@@ -417,6 +531,8 @@
 /area/service/bar)
 "Af" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "An" = (
@@ -437,6 +553,7 @@
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/service/bar)
 "Bm" = (
@@ -480,13 +597,26 @@
 "CD" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "Dp" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/security/brig)
+"Ds" = (
+/obj/structure/cable,
+/obj/effect/spawner/randomsnackvend,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "DF" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -503,12 +633,30 @@
 /area/cargo/storage)
 "EC" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"EQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "GZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/bar)
+"HA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "HJ" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -539,6 +687,9 @@
 "Iy" = (
 /turf/open/floor/iron,
 /area/cargo/storage)
+"IT" = (
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "IU" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -580,7 +731,11 @@
 /area/science/xenobiology)
 "Lv" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
+/area/maintenance/port/aft)
+"LT" = (
+/turf/closed/wall/r_wall,
 /area/maintenance/port/aft)
 "LU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -595,6 +750,16 @@
 "My" = (
 /turf/open/floor/plating,
 /area/service/bar)
+"MI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "MP" = (
 /obj/structure/cable,
 /obj/machinery/light/dim/directional/east,
@@ -607,12 +772,21 @@
 /area/service/bar)
 "NG" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "NT" = (
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_y = 31
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "Od" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -642,6 +816,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "Pl" = (
@@ -663,6 +840,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/service/bar)
+"Qo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "Qy" = (
 /obj/machinery/jukebox,
 /turf/open/floor/wood,
@@ -672,16 +859,21 @@
 /obj/item/extinguisher,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"QL" = (
+/turf/closed/wall/r_wall,
+/area/service/bar)
 "Rd" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/security/brig)
 "Rk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
 	name = "Xenobio Pen 1 Blast Door"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "RD" = (
@@ -691,14 +883,25 @@
 "RK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/bounty,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/bar)
+"RM" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"RX" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/fore/secondary)
 "Sc" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
 /area/service/bar)
+"Sn" = (
+/turf/closed/wall/r_wall,
+/area/cargo/storage)
 "Sr" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -745,6 +948,7 @@
 	req_access_txt = "25"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/service/bar)
 "TY" = (
@@ -753,6 +957,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"Ui" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"Ul" = (
+/turf/closed/wall,
+/area/security/brig)
 "Uq" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
@@ -760,6 +972,7 @@
 /area/cargo/storage)
 "Us" = (
 /obj/structure/curtain/bounty,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/service/bar)
 "UH" = (
@@ -772,6 +985,25 @@
 "Vo" = (
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
+"VW" = (
+/obj/structure/cable,
+/obj/effect/spawner/randomcolavend,
+/turf/open/floor/iron,
+/area/cargo/storage)
+"Wn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig)
+"Ww" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/iron,
+/area/security/brig)
 "WB" = (
 /obj/machinery/processor/slime,
 /obj/machinery/light/directional/east,
@@ -780,8 +1012,14 @@
 /area/science/xenobiology)
 "Xa" = (
 /obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "Xg" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -801,6 +1039,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"YN" = (
+/obj/machinery/drone_dispenser,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "YP" = (
 /turf/closed/wall,
 /area/maintenance/port/aft)
@@ -809,13 +1051,26 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ZA" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "ZB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/ladder,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ZI" = (
@@ -30766,12 +31021,12 @@ Kg
 Kg
 Kg
 Kg
-YP
+LT
 IU
 IU
 IU
 IU
-YP
+LT
 Kg
 Kg
 Kg
@@ -31017,25 +31272,25 @@ Kg
 Kg
 Kg
 ff
-YP
-YP
-YP
+LT
+LT
+LT
 Lv
-YP
-YP
-YP
-YP
+LT
+LT
+LT
+LT
 Lv
 Lv
-YP
-YP
-YP
-YP
-YP
-YP
-YP
-YP
-YP
+LT
+LT
+LT
+LT
+LT
+LT
+LT
+LT
+LT
 Kg
 Kg
 Kg
@@ -31274,7 +31529,7 @@ Kg
 Kg
 ff
 ff
-YP
+LT
 HQ
 kg
 kg
@@ -31290,9 +31545,9 @@ kg
 kg
 kg
 kg
-kg
+YN
 vg
-YP
+LT
 uN
 uN
 uN
@@ -31528,14 +31783,14 @@ Kg
 Kg
 Kg
 Kg
-Kr
-Kr
-Kr
-Kr
-kg
+QL
+QL
+QL
+QL
+gw
 PH
 MP
-PH
+Ui
 PH
 CD
 PH
@@ -31785,7 +32040,7 @@ Kg
 Kg
 Kg
 Kg
-Kr
+QL
 qI
 av
 Kr
@@ -31804,7 +32059,7 @@ YP
 YP
 YP
 zC
-kg
+gw
 kg
 Lv
 Kg
@@ -32042,7 +32297,7 @@ Kg
 Kg
 Kg
 Kg
-Kr
+QL
 zY
 Bm
 Kr
@@ -32320,7 +32575,7 @@ YP
 YP
 YP
 kg
-YP
+LT
 uN
 uN
 uN
@@ -32556,7 +32811,7 @@ Kg
 Kg
 Kg
 Kg
-Kr
+QL
 Kr
 TU
 Kr
@@ -32570,14 +32825,14 @@ ZQ
 Ty
 An
 BP
-Iy
+nf
 Iy
 Pr
 go
 bn
 YP
 xX
-YP
+LT
 Kg
 Kg
 Kg
@@ -32831,12 +33086,12 @@ wu
 kG
 Iy
 Iy
-go
+VW
 YP
 YP
-YP
-HY
-HY
+LT
+Sn
+Sn
 Kg
 Kg
 Kg
@@ -33093,7 +33348,7 @@ Yj
 Tz
 Iy
 Iy
-HY
+Sn
 mm
 Kg
 Kg
@@ -33343,7 +33598,7 @@ ZQ
 ZQ
 ip
 Iy
-Iy
+Tz
 mV
 go
 xJ
@@ -33351,7 +33606,7 @@ pK
 Iy
 YW
 sP
-mm
+xP
 Kg
 Kg
 Kg
@@ -33600,7 +33855,7 @@ ZQ
 ZQ
 ip
 Iy
-Iy
+Tz
 Iy
 go
 Ch
@@ -33857,14 +34112,14 @@ ZQ
 ZQ
 ZB
 Iy
-Iy
+Tz
 Iy
 go
 HY
 Iy
 Iy
 Kp
-HY
+Sn
 mm
 Kg
 Kg
@@ -34114,14 +34369,14 @@ nn
 nn
 TY
 Iy
-Iy
+Tz
 Iy
 YK
-dK
-dK
-dK
-HY
-HY
+Ul
+Ul
+nb
+Sn
+Sn
 Kg
 Kg
 Kg
@@ -34355,7 +34610,7 @@ Kg
 Kg
 Kg
 Kg
-Kr
+QL
 Kr
 Us
 Kr
@@ -34371,12 +34626,12 @@ pk
 Iy
 pk
 wS
-go
+EQ
 go
 ft
-dK
-ZA
-dK
+Ul
+eg
+nb
 Kg
 Kg
 Kg
@@ -34616,7 +34871,7 @@ GZ
 kX
 kX
 Kr
-uG
+RM
 Xg
 Vo
 ZQ
@@ -34626,14 +34881,14 @@ iS
 Uq
 gJ
 TS
-iS
-go
-go
-dK
-dK
-dK
-ZA
-dK
+ev
+Ds
+EQ
+Ul
+Ul
+Ul
+zB
+nb
 uN
 uN
 uN
@@ -34869,7 +35124,7 @@ Kg
 Kg
 Kg
 Kg
-Kr
+QL
 kX
 Pl
 Kr
@@ -34889,7 +35144,7 @@ Af
 Dp
 xo
 uK
-xo
+Wn
 Rd
 Kg
 Kg
@@ -35126,7 +35381,7 @@ Kg
 Kg
 Kg
 Kg
-Kr
+QL
 kX
 kX
 Kr
@@ -35143,10 +35398,10 @@ uV
 uV
 ab
 dK
-dK
+Ul
 NT
-ZA
-xo
+pW
+HA
 Rd
 Kg
 Kg
@@ -35383,11 +35638,11 @@ Kg
 Kg
 Kg
 ff
-Kr
-Kr
-Kr
-Kr
-uG
+QL
+QL
+QL
+QL
+qX
 uG
 ab
 gU
@@ -35400,10 +35655,10 @@ DI
 HJ
 ab
 ZA
-ZA
-ZA
-ZA
-xo
+Ww
+ul
+qw
+Wn
 Rd
 Kg
 Kg
@@ -35643,7 +35898,7 @@ ff
 ff
 ff
 ff
-Vo
+RX
 RD
 uG
 ab
@@ -35656,12 +35911,12 @@ uV
 uV
 uV
 ab
-ZA
-ZA
-ZA
-ZA
+qB
+MI
+tz
+Qo
 Xa
-dK
+nb
 uN
 uN
 uN
@@ -35900,25 +36155,25 @@ Kg
 ff
 ff
 ff
-Vo
-Vo
-Vo
-ab
-ab
-ab
-ab
+RX
+RX
+RX
+IT
+IT
+IT
+IT
 EC
-ab
-ab
-ab
-ab
-ab
-dK
-dK
-dK
-dK
-dK
-dK
+IT
+IT
+IT
+IT
+IT
+nb
+nb
+nb
+nb
+nb
+nb
 Kg
 Kg
 Kg
@@ -36163,13 +36418,13 @@ ff
 ff
 ff
 ff
-ab
+IT
 tE
-ab
+IT
 nk
 nk
 nk
-ab
+IT
 Kg
 Kg
 Kg

--- a/_maps/map_files/tradership/tradership2.dmm
+++ b/_maps/map_files/tradership/tradership2.dmm
@@ -9,7 +9,7 @@
 /area/commons/cryopods)
 "ax" = (
 /obj/structure/cable,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engineering/storage)
 "bc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -19,6 +19,9 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "bo" = (
@@ -26,6 +29,7 @@
 /obj/machinery/door/airlock/research,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
 "bF" = (
@@ -83,6 +87,9 @@
 "dQ" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/white,
+/area/science)
+"dV" = (
+/turf/closed/wall/r_wall,
 /area/science)
 "eq" = (
 /obj/machinery/conveyor{
@@ -143,6 +150,7 @@
 "fL" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/large,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "gh" = (
@@ -182,11 +190,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "hx" = (
 /obj/effect/landmark/latejoin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/commons/cryopods)
 "hC" = (
@@ -211,7 +221,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "ij" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/maintenance/aft/secondary)
 "iF" = (
 /obj/machinery/door/airlock/external,
@@ -236,6 +246,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "jj" = (
@@ -259,6 +270,7 @@
 /area/construction/storage_wing)
 "kl" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science)
 "kr" = (
@@ -278,6 +290,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "kS" = (
@@ -285,6 +298,9 @@
 	dir = 1
 	},
 /obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -296,6 +312,7 @@
 	pixel_y = 3
 	},
 /obj/item/stack/sheet/iron/fifty,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "lg" = (
@@ -303,6 +320,7 @@
 /obj/machinery/light_switch/directional/north,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/aft/secondary)
 "lh" = (
@@ -336,6 +354,9 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
+"lH" = (
+/turf/closed/wall/r_wall,
+/area/commons/dorms/barracks)
 "lY" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
@@ -344,6 +365,7 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "mx" = (
@@ -358,6 +380,7 @@
 	req_access_txt = "10"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
 "mQ" = (
@@ -491,6 +514,7 @@
 "pR" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "pW" = (
@@ -532,6 +556,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"rc" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "sj" = (
 /obj/machinery/conveyor{
 	id = "cargo_smeltery"
@@ -551,6 +581,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "sQ" = (
@@ -565,6 +598,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/maintenance/aft/secondary)
+"sS" = (
+/turf/closed/wall/r_wall,
+/area/engineering/storage)
 "tk" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -616,6 +652,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "uK" = (
@@ -650,6 +689,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/construction/storage_wing)
 "vQ" = (
@@ -692,6 +732,7 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wj" = (
@@ -700,6 +741,9 @@
 	},
 /obj/structure/stairs/east,
 /obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -714,6 +758,7 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/commons/cryopods)
 "wO" = (
@@ -743,6 +788,7 @@
 /obj/structure/ladder,
 /obj/effect/landmark/latejoin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/commons/cryopods)
 "xD" = (
@@ -752,6 +798,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "yo" = (
@@ -761,6 +808,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
+"yQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "zv" = (
 /obj/structure/rack,
 /obj/machinery/light_switch/directional/north,
@@ -784,6 +836,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/commons/dorms/barracks)
 "zS" = (
@@ -805,12 +858,17 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "AQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
+"AR" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "AU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southright{
@@ -822,6 +880,7 @@
 	id = "rnd";
 	name = "research lab shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "AY" = (
@@ -868,6 +927,7 @@
 /obj/item/experi_scanner{
 	pixel_x = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science)
 "CN" = (
@@ -928,6 +988,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
+"Fv" = (
+/turf/closed/wall/r_wall,
+/area/commons/cryopods)
 "FG" = (
 /turf/closed/wall,
 /area/commons/dorms)
@@ -1008,6 +1071,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/commons/cryopods)
+"IP" = (
+/turf/closed/wall/r_wall,
+/area/cargo/warehouse)
 "IQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -1027,6 +1093,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "Jg" = (
@@ -1089,12 +1156,20 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
+"KC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "KH" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/engine/airless,
 /area/space)
 "KO" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "Lu" = (
@@ -1121,12 +1196,16 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
 "LW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
+"Me" = (
+/turf/closed/wall/r_wall,
+/area/construction/storage_wing)
 "Mg" = (
 /turf/open/openspace/airless/planetary,
 /area/space)
@@ -1143,6 +1222,7 @@
 /area/science/research/abandoned)
 "Mr" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
 "My" = (
@@ -1164,6 +1244,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/construction/storage_wing)
 "MS" = (
@@ -1265,6 +1346,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/closed/wall,
 /area/cargo/warehouse)
 "QE" = (
@@ -1275,6 +1359,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
 "QG" = (
@@ -1300,6 +1385,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
 "RC" = (
@@ -1324,6 +1410,9 @@
 "Sd" = (
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"SK" = (
+/turf/closed/wall/r_wall,
+/area/science/research/abandoned)
 "SM" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -1331,8 +1420,14 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage)
+"ST" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/cargo/warehouse)
 "Te" = (
 /obj/machinery/door/airlock,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "Tt" = (
@@ -1375,6 +1470,9 @@
 	},
 /obj/structure/ladder,
 /obj/structure/lattice,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/cargo/warehouse)
 "Ur" = (
@@ -1397,6 +1495,7 @@
 /area/hallway/primary/central)
 "Vh" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "Vu" = (
@@ -1435,6 +1534,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/airless/planetary,
 /area/space)
+"Xs" = (
+/turf/closed/wall/r_wall,
+/area/commons/dorms)
 "XH" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
 /turf/open/floor/iron/white,
@@ -1445,6 +1547,7 @@
 	id = "CARGOLIFT";
 	pixel_x = 28
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "Ye" = (
@@ -1454,11 +1557,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "Yk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "Yv" = (
@@ -1513,6 +1618,7 @@
 "Zv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/closed/wall,
 /area/cargo/warehouse)
 "Zw" = (
@@ -1527,6 +1633,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"ZN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
+"ZV" = (
+/turf/closed/wall/r_wall,
+/area/commons/vacant_room)
 "ZX" = (
 /obj/effect/landmark/latejoin,
 /obj/item/storage/toolbox/emergency,
@@ -31217,21 +31331,21 @@ Mg
 Mg
 Mg
 Mg
-we
-we
-we
-we
-dF
-dF
-dF
+SK
+SK
+SK
+SK
+dV
+dV
+dV
 kl
 kl
-dF
+dV
 KO
 KO
 KO
-we
-we
+SK
+SK
 Mg
 Mg
 Mg
@@ -31471,10 +31585,10 @@ Mg
 Mg
 Mg
 Mg
-EP
-EP
-EP
-we
+Fv
+Fv
+Fv
+SK
 jj
 Jg
 uB
@@ -31488,7 +31602,7 @@ ab
 tY
 XH
 wh
-we
+SK
 Mg
 Mg
 Mg
@@ -31728,7 +31842,7 @@ Mg
 Mg
 Mg
 Mg
-EP
+Fv
 ao
 lt
 we
@@ -31745,12 +31859,12 @@ vr
 LW
 wh
 wh
-we
-Zj
-Zj
-Zj
-Zj
-Zj
+SK
+Me
+Me
+Me
+Me
+Me
 Mg
 Mg
 Mg
@@ -31985,7 +32099,7 @@ Mg
 Mg
 Mg
 Mg
-EP
+Fv
 ao
 xw
 we
@@ -32007,7 +32121,7 @@ jX
 nQ
 Tv
 BV
-Zj
+Me
 Mg
 Mg
 Mg
@@ -32242,7 +32356,7 @@ Mg
 Mg
 WQ
 WQ
-EP
+Fv
 Yy
 hV
 we
@@ -32264,7 +32378,7 @@ Eh
 xD
 kA
 vS
-Zj
+Me
 Mg
 Mg
 Mg
@@ -32499,7 +32613,7 @@ Mg
 Mg
 WQ
 WQ
-EP
+Fv
 vV
 jM
 we
@@ -32521,7 +32635,7 @@ ld
 xD
 kA
 YI
-Zj
+Me
 Mg
 Mg
 Mg
@@ -32756,7 +32870,7 @@ Mg
 Mg
 WQ
 WQ
-EP
+Fv
 ao
 iN
 wq
@@ -32778,7 +32892,7 @@ lE
 xD
 kA
 mV
-Zj
+Me
 Mg
 Mg
 Mg
@@ -33012,8 +33126,8 @@ Mg
 Mg
 Mg
 WQ
-sk
-EP
+IP
+Fv
 EP
 EP
 EP
@@ -33035,7 +33149,7 @@ yo
 cd
 cd
 Qa
-Zj
+Me
 Mg
 Mg
 Mg
@@ -33266,10 +33380,10 @@ Mg
 Mg
 Mg
 Mg
-sk
-sk
-sk
-sk
+IP
+IP
+IP
+IP
 Ca
 Ux
 DL
@@ -33285,14 +33399,14 @@ sk
 sk
 pR
 sk
-nb
+KC
 Sd
 Zj
 gh
 xD
 cd
 DO
-Zj
+Me
 Mg
 Mg
 Mg
@@ -33549,7 +33663,7 @@ Gd
 Kp
 BI
 xD
-Zj
+Me
 Mg
 Mg
 Mg
@@ -33788,7 +33902,7 @@ Hv
 mQ
 Tt
 mR
-mR
+rc
 du
 FP
 Yk
@@ -33806,7 +33920,7 @@ Zj
 Zj
 MN
 Zj
-Zj
+Me
 Mg
 Mg
 Mg
@@ -34037,7 +34151,7 @@ Mg
 Mg
 Mg
 Mg
-sk
+IP
 sk
 sk
 zS
@@ -34045,7 +34159,7 @@ Hv
 gW
 gW
 gW
-gW
+AR
 du
 gW
 Vh
@@ -34294,15 +34408,15 @@ Mg
 Mg
 Mg
 Mg
-Km
+ST
 DL
-Ag
+yQ
 Ag
 CO
 gW
 gW
 gW
-gW
+AR
 uK
 Lu
 Ya
@@ -34551,7 +34665,7 @@ Mg
 Mg
 Mg
 Mg
-Km
+ST
 dJ
 Jy
 Ag
@@ -34559,7 +34673,7 @@ bF
 hX
 oT
 ch
-Tt
+ZN
 du
 gW
 Zv
@@ -34577,7 +34691,7 @@ QG
 QG
 QE
 QG
-QG
+sS
 Mg
 Mg
 Mg
@@ -34808,7 +34922,7 @@ Mg
 Mg
 Mg
 Mg
-sk
+IP
 OV
 Km
 jU
@@ -34834,7 +34948,7 @@ QH
 Mr
 Lx
 sQ
-QG
+sS
 Mg
 Mg
 Mg
@@ -35065,7 +35179,7 @@ Mg
 Mg
 Mg
 Mg
-sk
+IP
 eq
 sj
 wb
@@ -35084,14 +35198,14 @@ OX
 sk
 pR
 sk
-nb
+KC
 PO
 mO
 IQ
 IQ
 Lx
 vK
-QG
+sS
 Mg
 Mg
 Mg
@@ -35322,11 +35436,11 @@ Mg
 Mg
 Mg
 Mg
-sk
-sk
-sk
-sk
-EP
+IP
+IP
+IP
+IP
+Fv
 EP
 EP
 ob
@@ -35348,7 +35462,7 @@ zv
 AQ
 kr
 vK
-QG
+sS
 Mg
 Mg
 Mg
@@ -35583,7 +35697,7 @@ Mg
 Mg
 WQ
 WQ
-EP
+Fv
 ao
 IM
 wq
@@ -35605,7 +35719,7 @@ fq
 Mh
 IQ
 ZY
-QG
+sS
 Mg
 Mg
 Mg
@@ -35840,7 +35954,7 @@ Mg
 Mg
 WQ
 WQ
-EP
+Fv
 vV
 hx
 FG
@@ -35857,12 +35971,12 @@ Rr
 Qc
 Rr
 Ny
-QG
-QG
-QG
+sS
+sS
+sS
 NS
-QG
-QG
+sS
+sS
 Mg
 Mg
 Mg
@@ -36097,7 +36211,7 @@ Mg
 Mg
 WQ
 WQ
-EP
+Fv
 Yy
 hV
 FG
@@ -36114,11 +36228,11 @@ MY
 Wn
 Rr
 RO
-Ny
+ZV
 If
 ax
 gY
-QG
+sS
 Mg
 Mg
 Mg
@@ -36354,7 +36468,7 @@ Mg
 Mg
 Mg
 Mg
-EP
+Fv
 ao
 jM
 FG
@@ -36371,11 +36485,11 @@ lh
 gM
 Rr
 tl
-Ny
+ZV
 KH
-QG
+sS
 SM
-QG
+sS
 Mg
 Mg
 Mg
@@ -36611,7 +36725,7 @@ Mg
 Mg
 Mg
 Mg
-EP
+Fv
 ao
 ZX
 FG
@@ -36628,7 +36742,7 @@ ev
 Wn
 Rr
 wp
-Ny
+ZV
 RL
 RL
 Xq
@@ -36868,10 +36982,10 @@ Mg
 Mg
 Mg
 Mg
-EP
-EP
-EP
-FG
+Fv
+Fv
+Fv
+Xs
 pW
 wO
 jh
@@ -36885,7 +36999,7 @@ nt
 Rr
 Rr
 hC
-Ny
+ZV
 Rh
 Xq
 Xq
@@ -37128,21 +37242,21 @@ Mg
 Mg
 Mg
 Mg
-FG
+Xs
 gX
 oY
-FG
-FG
-WG
-WG
-WG
-WG
-WG
-Ny
-Ny
-Ny
-Ny
-Ny
+Xs
+Xs
+lH
+lH
+lH
+lH
+lH
+ZV
+ZV
+ZV
+ZV
+ZV
 qP
 qP
 qP
@@ -37385,10 +37499,10 @@ Mg
 Mg
 Mg
 Mg
-FG
-FG
-FG
-FG
+Xs
+Xs
+Xs
+Xs
 Mg
 Mg
 Mg

--- a/_maps/map_files/tradership/tradership3.dmm
+++ b/_maps/map_files/tradership/tradership3.dmm
@@ -27,6 +27,7 @@
 /area/hallway/primary/central/aft)
 "aI" = (
 /obj/machinery/door/airlock,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aJ" = (
@@ -34,6 +35,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = medbay_shutter1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/medbay)
 "aK" = (
@@ -50,6 +52,9 @@
 /obj/item/kirbyplants/dead,
 /turf/open/floor/plating,
 /area/hallway/primary/central/fore)
+"bb" = (
+/turf/closed/wall/r_wall,
+/area/service/kitchen/coldroom)
 "bg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -63,6 +68,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/command/meeting_room)
+"br" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "bz" = (
 /obj/machinery/atmospherics/components/binary/pump/on/scrubbers/visible,
 /turf/open/floor/iron/dark,
@@ -139,6 +147,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "cN" = (
@@ -146,6 +155,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/openspace/airless/planetary,
 /area/space)
+"cT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "cU" = (
 /turf/closed/wall,
 /area/command/bridge)
@@ -162,6 +179,7 @@
 "dm" = (
 /obj/machinery/requests_console/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "dn" = (
@@ -189,6 +207,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "dI" = (
@@ -208,6 +229,7 @@
 /area/engineering/atmos)
 "eb" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/kitchen/coldroom)
 "ek" = (
@@ -261,6 +283,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "eV" = (
@@ -308,7 +331,7 @@
 /area/command/heads_quarters/hop)
 "fJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "fN" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -376,6 +399,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/fans/tiny,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "gY" = (
@@ -418,6 +442,7 @@
 	name = "Hydroponics Window";
 	req_one_access_txt = "30;35"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "hL" = (
@@ -433,6 +458,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "hZ" = (
@@ -444,15 +470,22 @@
 /area/command/bridge)
 "ib" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/command/heads_quarters/captain)
 "ic" = (
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"ij" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central)
 "ik" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall,
 /area/command/heads_quarters/hop)
+"ir" = (
+/turf/closed/wall/r_wall,
+/area/commons/toilet)
 "ix" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -488,6 +521,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "iN" = (
@@ -509,6 +543,7 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/command/bridge)
 "jf" = (
@@ -561,6 +596,9 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"kb" = (
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter/room)
 "kg" = (
 /turf/open/floor/plating,
 /area/hallway/primary/central/fore)
@@ -684,6 +722,13 @@
 /obj/machinery/requests_console/directional/south,
 /turf/open/floor/iron/smooth,
 /area/command/meeting_room)
+"me" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/box,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "mh" = (
 /obj/machinery/computer/security/wooden_tv{
 	pixel_x = 1;
@@ -709,6 +754,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "mI" = (
@@ -750,6 +796,7 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
 "mY" = (
@@ -792,6 +839,9 @@
 	id = "kitchen_counter";
 	name = "Kitchen Counter Shutters"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "nE" = (
@@ -804,6 +854,7 @@
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "nN" = (
@@ -819,8 +870,14 @@
 /obj/effect/spawner/lootdrop/refreshing_beverage,
 /obj/machinery/dish_drive,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
+"od" = (
+/turf/closed/wall/r_wall,
+/area/commons/locker)
 "oh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 6
@@ -838,6 +895,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "oq" = (
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating/airless,
 /area/hallway/primary/central)
 "or" = (
@@ -876,6 +934,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "pg" = (
@@ -884,6 +943,7 @@
 	name = "Engineering";
 	req_access_txt = "10"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "po" = (
@@ -911,7 +971,7 @@
 /area/space)
 "pF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/service/kitchen/diner)
 "pW" = (
 /obj/structure/chair/office,
@@ -935,10 +995,12 @@
 /area/commons/locker)
 "qN" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/firedoor,
 /turf/closed/wall,
 /area/medical/pharmacy)
 "qR" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
 "qS" = (
@@ -948,6 +1010,9 @@
 	name = "Kitchen Counter Shutters"
 	},
 /obj/effect/spawner/lootdrop/three_course_meal,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "qV" = (
@@ -956,6 +1021,7 @@
 	name = "Pharmacy Desk";
 	req_access_txt = "5; 69"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/pharmacy)
 "rf" = (
@@ -1028,6 +1094,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "su" = (
@@ -1044,7 +1111,7 @@
 "sL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "sO" = (
 /obj/machinery/modular_computer/console/preset/engineering{
@@ -1054,6 +1121,7 @@
 /area/command/bridge)
 "sP" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "sS" = (
@@ -1064,6 +1132,7 @@
 /area/commons/lounge)
 "sT" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "sV" = (
@@ -1087,6 +1156,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/main)
 "tt" = (
@@ -1107,6 +1177,9 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"tE" = (
+/turf/closed/wall/r_wall,
+/area/medical/medbay)
 "tI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -1160,6 +1233,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "ux" = (
@@ -1179,6 +1253,7 @@
 /obj/item/clothing/glasses/science,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "uA" = (
@@ -1197,6 +1272,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/locker)
 "uJ" = (
@@ -1251,6 +1327,7 @@
 /area/command/heads_quarters/captain)
 "vQ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/kitchen/diner)
 "vU" = (
@@ -1261,19 +1338,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"wd" = (
+/turf/closed/wall/r_wall,
+/area/engineering/engine_smes)
 "wg" = (
 /obj/machinery/smartfridge,
+/obj/machinery/door/firedoor,
 /turf/closed/wall,
 /area/service/hydroponics)
 "wj" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"wk" = (
+/turf/closed/wall/r_wall,
+/area/command/meeting_room)
 "wr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/cargo/warehouse/upper)
+"ws" = (
+/turf/closed/wall/r_wall,
+/area/medical/pharmacy)
 "wu" = (
 /turf/open/floor/iron,
 /area/service/kitchen/diner)
@@ -1305,7 +1392,7 @@
 /turf/open/openspace/airless/planetary,
 /area/space)
 "wZ" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/service/kitchen/diner)
 "xc" = (
 /obj/structure/table,
@@ -1321,6 +1408,7 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "xm" = (
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "xw" = (
@@ -1380,6 +1468,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "yM" = (
@@ -1429,6 +1518,7 @@
 	name = "Engineering";
 	req_access_txt = "10"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "zn" = (
@@ -1480,6 +1570,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
+"zY" = (
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/captain)
 "Aa" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1532,7 +1625,7 @@
 /area/engineering/atmos)
 "AI" = (
 /obj/machinery/atmospherics/components/unary/engine,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "AJ" = (
 /obj/structure/fans/tiny,
@@ -1546,6 +1639,7 @@
 /area/engineering/main)
 "AY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "AZ" = (
@@ -1585,6 +1679,7 @@
 /area/command/heads_quarters/captain)
 "BK" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "BR" = (
@@ -1609,6 +1704,9 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"Cc" = (
+/turf/closed/wall/r_wall,
+/area/service/hydroponics)
 "Ce" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -1663,6 +1761,11 @@
 /obj/structure/ladder,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"CP" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "CT" = (
 /obj/machinery/power/supermatter_crystal/shard/engine,
 /turf/open/floor/engine,
@@ -1679,6 +1782,11 @@
 "Dc" = (
 /turf/closed/wall,
 /area/service/hydroponics)
+"Dv" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "Dx" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
@@ -1699,6 +1807,7 @@
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "DI" = (
@@ -1743,6 +1852,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"Eh" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/wood,
+/area/command/heads_quarters/hop)
 "Ej" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/north,
@@ -1753,6 +1866,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"Er" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "Es" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -1890,6 +2011,14 @@
 /obj/machinery/biogenerator,
 /turf/closed/wall,
 /area/service/hydroponics)
+"FF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "FH" = (
 /obj/machinery/shower{
 	pixel_y = 8
@@ -1907,6 +2036,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/closet/crate,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
 "FW" = (
@@ -1918,10 +2048,13 @@
 /area/commons/locker)
 "Gm" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "Gt" = (
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/medical/medbay)
 "Gx" = (
 /obj/machinery/chem_heater/withbuffer,
@@ -1934,6 +2067,7 @@
 	name = "Hydroponics Desk";
 	req_one_access_txt = "30;35"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "GO" = (
@@ -1948,6 +2082,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth,
 /area/command/meeting_room)
 "GQ" = (
@@ -2070,6 +2205,7 @@
 /area/command/heads_quarters/captain)
 "IN" = (
 /obj/machinery/door/airlock,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "IU" = (
@@ -2096,6 +2232,7 @@
 /area/command/meeting_room)
 "Ja" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "Jj" = (
@@ -2115,12 +2252,17 @@
 "Jm" = (
 /obj/machinery/door/airlock/atmos,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "Js" = (
 /obj/structure/table/glass,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"Jv" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "JK" = (
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -2134,10 +2276,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "JN" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
 "JZ" = (
@@ -2156,6 +2300,7 @@
 "Kf" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/locker)
 "Ko" = (
@@ -2165,6 +2310,10 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"Kt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/commons/locker)
 "Kw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2172,6 +2321,9 @@
 	name = "Kitchen Counter Shutters"
 	},
 /obj/effect/spawner/lootdrop/food_packaging,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "KD" = (
@@ -2206,6 +2358,7 @@
 /obj/structure/reflector/single{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "Lc" = (
@@ -2216,6 +2369,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "Lf" = (
@@ -2225,6 +2379,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
+"Lg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "Ll" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -2233,6 +2394,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "Lv" = (
@@ -2244,6 +2406,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"LD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/medical/pharmacy)
 "LE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2262,6 +2429,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "LK" = (
@@ -2310,6 +2478,7 @@
 /area/command/heads_quarters/hop)
 "Mk" = (
 /obj/machinery/door/airlock,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
 "Mn" = (
@@ -2519,6 +2688,7 @@
 "Qq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "Qt" = (
@@ -2534,14 +2704,22 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "QN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/medical/medbay)
 "QQ" = (
 /obj/machinery/vending/cigarette,
+/turf/open/floor/plating,
+/area/hallway/primary/central/aft)
+"QY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
 "Rc" = (
@@ -2687,14 +2865,21 @@
 /area/command/heads_quarters/hop)
 "Tu" = (
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
+"Tz" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "TB" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/kitchen/coldroom)
 "TI" = (
@@ -2709,6 +2894,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "Ue" = (
@@ -2716,18 +2902,35 @@
 /obj/machinery/requests_console/directional/west,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"Uh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "Ui" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "Un" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/commons/lounge)
 "Up" = (
 /obj/machinery/jukebox,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"Ur" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "UK" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -2754,6 +2957,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/openspace,
 /area/cargo/warehouse/upper)
 "Vj" = (
@@ -2852,6 +3056,7 @@
 /area/space)
 "WH" = (
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet,
 /area/command/bridge)
 "WS" = (
@@ -2904,12 +3109,20 @@
 "Xv" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
+"Xw" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central/aft)
 "Xx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"XA" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/cargo/warehouse/upper)
 "XB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -2917,10 +3130,12 @@
 	id_tag = null;
 	name = "meeting room blast door"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
 /area/command/meeting_room)
 "XH" = (
 /obj/machinery/door/airlock/atmos,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/main)
 "XK" = (
@@ -2928,6 +3143,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/meeting_room)
 "XL" = (
@@ -2938,8 +3154,16 @@
 /area/command/heads_quarters/captain)
 "XM" = (
 /obj/machinery/door/airlock,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"XN" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central/fore)
+"XP" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "XW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
@@ -3002,12 +3226,14 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "YD" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "YF" = (
@@ -3031,6 +3257,7 @@
 "Zi" = (
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/vomit/old,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "Zj" = (
@@ -3046,11 +3273,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"Zn" = (
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/hop)
 "Zo" = (
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"Zp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/hallway/primary/central/fore)
 "ZF" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3069,6 +3305,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "ZW" = (
@@ -31223,9 +31460,9 @@ DB
 DB
 mY
 mY
-NK
-NK
-NK
+ij
+ij
+ij
 Zg
 Zg
 DB
@@ -31479,10 +31716,10 @@ DB
 DB
 mY
 mY
+ij
 NK
 NK
-NK
-NK
+ij
 WA
 DB
 DB
@@ -31735,7 +31972,7 @@ DB
 DB
 DB
 mY
-NK
+ij
 NK
 oq
 wT
@@ -31992,7 +32229,7 @@ DB
 DB
 DB
 DB
-NK
+ij
 NK
 Ij
 wT
@@ -32250,10 +32487,10 @@ DB
 DB
 DB
 Zg
-NK
+ij
 AC
 NK
-NK
+ij
 WA
 DB
 DB
@@ -32757,35 +32994,35 @@ DB
 DB
 DB
 DB
-lv
-lv
+bb
+bb
 eb
-lv
-lv
+bb
+bb
 vQ
 vQ
 wZ
 pF
 wZ
-Dc
-Dc
-Dc
+Cc
+Cc
+Cc
 sP
 sP
 sP
 sP
-Dc
-Dc
-oi
-oi
+Cc
+Cc
+br
+br
 Qq
 Gm
 Gm
 Gm
-oi
-oi
-oi
-oi
+br
+br
+br
+br
 Zg
 DB
 DB
@@ -33014,7 +33251,7 @@ DB
 DB
 DB
 DB
-lv
+bb
 ru
 uu
 xK
@@ -33042,8 +33279,8 @@ AE
 rQ
 LO
 wK
-oi
-oi
+br
+br
 DB
 Wg
 DB
@@ -33271,7 +33508,7 @@ DB
 DB
 DB
 DB
-lv
+bb
 xf
 BF
 zb
@@ -33300,7 +33537,7 @@ nj
 LO
 BR
 uf
-oi
+br
 DB
 DB
 DB
@@ -33528,7 +33765,7 @@ DB
 DB
 DB
 Zg
-lv
+bb
 Yo
 BF
 FM
@@ -33550,14 +33787,14 @@ Dc
 bE
 Eb
 NM
-ic
+XP
 dT
 gy
 gy
 Vm
 va
 EB
-oi
+br
 Zg
 Zg
 DB
@@ -33769,15 +34006,15 @@ DB
 DB
 DB
 DB
-wN
-wN
+Zn
+Zn
 qR
-wN
-wN
+Zn
+Zn
 Zg
-VW
+XN
 kg
-VW
+XN
 Zg
 Zg
 Zg
@@ -33785,7 +34022,7 @@ Zg
 Zg
 Zg
 Zg
-lv
+bb
 zW
 LE
 OU
@@ -33794,7 +34031,7 @@ fi
 wu
 PB
 oo
-PB
+Jv
 Dc
 Jl
 Xb
@@ -34026,23 +34263,23 @@ DB
 DB
 DB
 Zg
-wN
+Zn
 Bs
 IB
 Ue
-wN
-wN
-VW
+Zn
+Zn
+XN
 gt
-VW
-EF
-Oy
+XN
+Zp
+Xw
 JN
 JN
 JN
 JN
-Oy
-lv
+Xw
+bb
 lv
 gP
 lv
@@ -34071,7 +34308,7 @@ Wm
 LO
 DI
 uS
-oi
+br
 Zg
 JL
 DB
@@ -34283,11 +34520,11 @@ DB
 Zg
 Zg
 Zg
-wN
+Zn
 fI
 Mg
 UM
-fI
+Eh
 wN
 VW
 NX
@@ -34328,7 +34565,7 @@ BV
 Vm
 XW
 CF
-oi
+br
 GO
 cN
 JL
@@ -34538,9 +34775,9 @@ DB
 DB
 XB
 XB
-hL
-hL
-wN
+wk
+wk
+Zn
 SY
 Zm
 nt
@@ -34554,7 +34791,7 @@ mX
 MX
 MX
 lz
-Rt
+QY
 fO
 fO
 Rt
@@ -34564,13 +34801,13 @@ ZW
 fO
 Rt
 Rt
-CD
+Uh
 CD
 JM
 BS
 Ez
 qi
-Ez
+Er
 BS
 Ez
 Ez
@@ -34585,13 +34822,13 @@ Yk
 Yk
 Yk
 Yk
-Yk
+kb
 mF
-EN
-EN
-Yk
+Tz
+Tz
+kb
 fJ
-Yk
+kb
 DB
 DB
 DB
@@ -35093,7 +35330,7 @@ Ai
 ne
 iB
 Yk
-aO
+me
 Cu
 iJ
 RT
@@ -35333,7 +35570,7 @@ zC
 Up
 ze
 Tu
-Tu
+CP
 FB
 FB
 Pi
@@ -35590,7 +35827,7 @@ nN
 Yh
 ze
 PX
-ox
+XA
 FB
 FB
 wr
@@ -35847,7 +36084,7 @@ sS
 nN
 XM
 ox
-ox
+XA
 FB
 FB
 Hi
@@ -35858,7 +36095,7 @@ xO
 JZ
 Mk
 rp
-Ez
+Ur
 wL
 KD
 pu
@@ -35876,7 +36113,7 @@ Ey
 NT
 MZ
 Px
-Yk
+kb
 DB
 DB
 DB
@@ -36104,7 +36341,7 @@ tI
 BK
 ze
 FA
-Tu
+CP
 FB
 FB
 HZ
@@ -36851,9 +37088,9 @@ DB
 DB
 XB
 XB
-hL
-hL
-IJ
+wk
+wk
+zY
 Zl
 RO
 EC
@@ -36867,7 +37104,7 @@ mX
 MX
 MX
 LQ
-fO
+Lg
 fO
 fO
 MX
@@ -36877,13 +37114,13 @@ LQ
 hC
 zE
 Lf
-CD
+FF
 CD
 JM
 BS
 BS
 EL
-BS
+cT
 BS
 Ez
 BS
@@ -36892,7 +37129,7 @@ kA
 sr
 kA
 Yk
-Pa
+Dv
 ah
 mI
 mI
@@ -37110,7 +37347,7 @@ DB
 mY
 mY
 mY
-IJ
+zY
 XL
 vj
 Ce
@@ -37151,17 +37388,17 @@ KY
 Yk
 zl
 Yk
-Yk
-Yk
+kb
+kb
 eU
-EN
-EN
-EN
-EN
+Tz
+Tz
+Tz
+Tz
 eU
-Yk
-Yk
-Yk
+kb
+kb
+kb
 DB
 DB
 DB
@@ -37367,23 +37604,23 @@ DB
 DB
 mY
 mY
-IJ
+zY
 mK
 vj
 iQ
-IJ
-VW
-VW
+zY
+XN
+XN
 NW
-VW
-EF
-Oy
+XN
+Zp
+Xw
 JN
 JN
 JN
 JN
-Oy
-MS
+Xw
+ws
 MS
 oX
 MS
@@ -37408,7 +37645,7 @@ co
 jF
 jf
 iV
-kA
+wd
 DB
 fV
 eQ
@@ -37624,15 +37861,15 @@ DB
 DB
 DB
 DB
-IJ
-IJ
+zY
+zY
 ib
-IJ
-IJ
+zY
+zY
 Zg
-VW
+XN
 kg
-VW
+XN
 Zg
 Zg
 Zg
@@ -37640,7 +37877,7 @@ Zg
 Zg
 Zg
 Zg
-MS
+ws
 ux
 ck
 qw
@@ -37665,7 +37902,7 @@ jf
 kj
 kT
 gY
-kA
+wd
 eQ
 EG
 EG
@@ -37897,7 +38134,7 @@ DB
 DB
 Zg
 Zg
-MS
+LD
 IU
 dJ
 fx
@@ -37922,7 +38159,7 @@ jf
 zn
 Lv
 GQ
-kA
+wd
 wU
 EG
 EG
@@ -38154,7 +38391,7 @@ DB
 DB
 DB
 Zg
-MS
+LD
 Bj
 aK
 pW
@@ -38172,14 +38409,14 @@ SI
 fm
 Gg
 qK
-kA
-kA
-kA
+wd
+wd
+wd
 sT
-kA
-kA
-kA
-kA
+wd
+wd
+wd
+wd
 Zg
 wU
 Bh
@@ -38411,7 +38648,7 @@ DB
 DB
 DB
 DB
-MS
+ws
 tV
 Gx
 kI
@@ -38429,7 +38666,7 @@ SI
 Kf
 HA
 Qt
-SI
+od
 FW
 Tf
 DC
@@ -38668,25 +38905,25 @@ DB
 DB
 DB
 DB
-MS
-MS
-MS
-MS
-MS
+ws
+LD
+ws
+ws
+ws
 Gt
-Gt
-Gt
+tE
+tE
 QN
-Gt
-Sw
-Sw
-Sw
-Sw
-SI
-SI
-SI
-SI
-SI
+tE
+ir
+ir
+ir
+ir
+od
+od
+Kt
+od
+od
 FW
 DC
 Zg
@@ -39189,10 +39426,10 @@ DB
 DB
 DB
 Zg
-NK
+ij
 AC
 NK
-NK
+ij
 WA
 DB
 DB
@@ -39445,7 +39682,7 @@ DB
 DB
 DB
 mY
-NK
+ij
 NK
 Ij
 wT
@@ -39702,7 +39939,7 @@ DB
 DB
 DB
 mY
-NK
+ij
 NK
 oq
 wT
@@ -39960,10 +40197,10 @@ DB
 DB
 mY
 mY
+ij
 NK
 NK
-NK
-NK
+ij
 WA
 DB
 DB
@@ -40218,9 +40455,9 @@ DB
 DB
 mY
 mY
-NK
-NK
-NK
+ij
+ij
+ij
 Zg
 Zg
 DB

--- a/_maps/map_files/tradership/tradership4.dmm
+++ b/_maps/map_files/tradership/tradership4.dmm
@@ -29,6 +29,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/openspace,
 /area/maintenance/solars/port/aft)
 "gD" = (
@@ -85,6 +88,10 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
+"lE" = (
+/obj/structure/grille,
+/turf/open/openspace/airless/planetary,
+/area/space)
 "lK" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -109,12 +116,18 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/maintenance/solars/port/aft)
 "ok" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
+"oE" = (
+/turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
 "oV" = (
 /obj/structure/cable,
@@ -167,6 +180,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "vf" = (
@@ -177,6 +193,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "vS" = (
@@ -198,6 +217,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/server)
+"xg" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "ya" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit,
@@ -221,6 +245,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
 "zC" = (
@@ -232,6 +257,9 @@
 	},
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/openspace,
@@ -258,6 +286,11 @@
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
+"FM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "Hc" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
@@ -275,6 +308,10 @@
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit,
 /area/tcommsat/server)
+"Iu" = (
+/obj/structure/grille,
+/turf/open/floor/engine/airless,
+/area/space)
 "IE" = (
 /turf/open/openspace,
 /area/maintenance/solars/port/aft)
@@ -290,6 +327,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/railing/corner,
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "Lf" = (
@@ -299,6 +337,11 @@
 /area/maintenance/solars/port/aft)
 "MK" = (
 /obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
+"Nf" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "Ou" = (
@@ -316,6 +359,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "QM" = (
@@ -325,6 +369,7 @@
 	id = "CARGOLIFT";
 	pixel_x = 27
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/openspace,
 /area/maintenance/solars/port/aft)
 "Rg" = (
@@ -340,6 +385,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/openspace,
 /area/maintenance/solars/port/aft)
 "SH" = (
@@ -373,6 +421,7 @@
 "TI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "Uh" = (
@@ -380,6 +429,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "Ux" = (
@@ -390,6 +442,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "UH" = (
@@ -401,7 +456,7 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "Vd" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "Vn" = (
 /obj/structure/cable,
@@ -423,6 +478,10 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"WY" = (
+/obj/structure/lattice,
+/turf/open/floor/engine/airless,
+/area/space)
 "Xb" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -432,6 +491,7 @@
 "Xd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "Ye" = (
@@ -31383,7 +31443,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Zw
 Zw
@@ -31640,7 +31700,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Vd
 Vd
@@ -31896,9 +31956,9 @@ Zw
 Zw
 Zw
 Zw
-Zw
-Zw
-Zw
+lE
+lE
+UH
 Vd
 hT
 qP
@@ -31932,23 +31992,23 @@ Ou
 Ou
 Ou
 Ou
-dO
-nZ
-nZ
-dO
+oE
+FM
+FM
+oE
 yC
 yC
 yC
 Ou
 yC
-dO
+oE
 nZ
 nZ
-dO
+oE
 Ou
-Ou
-Ou
-Ou
+Iu
+Iu
+Iu
 Ou
 Ou
 Ou
@@ -32153,7 +32213,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Zw
 Vd
@@ -32187,25 +32247,25 @@ Ou
 Ou
 Ou
 Ou
-dO
-dO
-dO
+oE
+oE
+oE
 Vn
 Ye
-dO
-dO
-dO
+oE
+oE
+oE
 yC
 yC
 yC
-dO
+oE
 ok
 Hc
-dO
+oE
 Ou
+WY
 Ou
-Ou
-Ou
+WY
 Ou
 Ou
 Ou
@@ -32410,7 +32470,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Vd
 Vd
@@ -32443,26 +32503,26 @@ Ou
 Ou
 Ou
 Ou
-dO
-dO
+oE
+oE
 JQ
 Ux
 Ux
 Ux
 ve
 SU
-dO
+oE
 yC
 yC
 yC
-dO
+oE
 lK
 rQ
-dO
-dO
-dO
-dO
-dO
+oE
+oE
+oE
+oE
+oE
 Ou
 Ou
 Ou
@@ -32667,8 +32727,8 @@ Zw
 Zw
 Zw
 Zw
-Zw
-Zw
+lE
+UH
 Vd
 ya
 cs
@@ -32697,10 +32757,10 @@ Ou
 Ou
 ZG
 Ou
-dO
+oE
 nZ
-dO
-dO
+oE
+oE
 rQ
 Qr
 IE
@@ -32708,20 +32768,20 @@ IE
 IE
 IE
 vf
-dO
-dO
-dO
-dO
-dO
+oE
+oE
+oE
+oE
+oE
 hW
 rQ
 dO
 rQ
 rQ
 rQ
-dO
-Ou
-Ou
+oE
+WY
+Iu
 Ou
 Ou
 Ou
@@ -32924,7 +32984,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Vd
 mP
@@ -32968,7 +33028,7 @@ Uh
 Xd
 Ph
 Ph
-Ph
+xg
 Ph
 Ph
 rQ
@@ -32976,9 +33036,9 @@ WG
 rQ
 pW
 rQ
-dO
+oE
 Ou
-Ou
+Iu
 Ou
 Ou
 Ou
@@ -33181,7 +33241,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Vd
 lC
@@ -33222,7 +33282,7 @@ IE
 IE
 IE
 oa
-WG
+Nf
 rQ
 rQ
 rQ
@@ -33233,9 +33293,9 @@ dO
 rQ
 rQ
 rQ
-dO
-Ou
-Ou
+oE
+WY
+Iu
 Ou
 Ou
 Ou
@@ -33438,8 +33498,8 @@ Zw
 Zw
 Zw
 Zw
-Zw
-Zw
+lE
+UH
 Vd
 im
 HN
@@ -33468,10 +33528,10 @@ Ou
 Ou
 ZG
 Ou
-dO
+oE
 nZ
-dO
-dO
+oE
+oE
 rQ
 yH
 IE
@@ -33479,18 +33539,18 @@ IE
 IE
 IE
 AW
-dO
-dO
-dO
-dO
-dO
+oE
+oE
+oE
+oE
+oE
 nZ
 nZ
-dO
-dO
-dO
-dO
-dO
+oE
+oE
+oE
+oE
+oE
 Ou
 Ou
 Ou
@@ -33695,7 +33755,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Vd
 Vd
@@ -33728,15 +33788,15 @@ Ou
 Ou
 Ou
 Ou
-dO
-dO
+oE
+oE
 gD
 Rx
 fB
 fB
 fB
 SH
-dO
+oE
 Ou
 Ou
 Ou
@@ -33745,9 +33805,9 @@ Ou
 Ou
 Ou
 Ou
+WY
 Ou
-Ou
-Ou
+WY
 Ou
 Ou
 Ou
@@ -33952,7 +34012,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Zw
 Vd
@@ -33986,14 +34046,14 @@ Ou
 Ou
 Ou
 Ou
-dO
-dO
-dO
+oE
+oE
+oE
 rQ
 rQ
-dO
-dO
-dO
+oE
+oE
+oE
 Ou
 Ou
 Ou
@@ -34002,9 +34062,9 @@ Ou
 Ou
 Ou
 Ou
-Ou
-Ou
-Ou
+Iu
+Iu
+Iu
 Ou
 Ou
 Ou
@@ -34209,9 +34269,9 @@ Zw
 Zw
 Zw
 Zw
-Zw
-Zw
-Zw
+lE
+lE
+UH
 Vd
 qM
 qP
@@ -34245,10 +34305,10 @@ Ou
 Ou
 Ou
 Ou
-dO
-nZ
-nZ
-dO
+oE
+FM
+FM
+oE
 Ou
 Ou
 Ou
@@ -34467,7 +34527,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Vd
 Vd
@@ -34724,7 +34784,7 @@ Zw
 Zw
 Zw
 Zw
-Zw
+lE
 Zw
 Zw
 Zw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is the second QoL update for bearcat.
Adding the following:

- All doors and windows now have firelocks
- External airlocks have helpers to stop the mice breaching the ship
- A brig has been added to deck 1 (One cell and some deco)
- There is now a way to end rounds. Departures has been added. the south airlock on Deck 1 now will be able to have the departures shuttle dock to it.
- Minor Deco fixes. added some windows.
- All exterior walls are now R_Walls to improve bearcat's hull from damp paper to dry paper.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Bearcat - Firelocks to all doors
add: Bearcat - Brig on deck 1
add: Bearcat - Departures shuttle dock on deck 1 south airlock (You can now round end ingame bearcat)
fix: Bearcat - Tile leaking causing atmos to runtime sometimes or take a long time to load.
refactor: Bearcat - All external walls are now R_Walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
