### PR TITLE
Barren planets mistakenly no longer have sandstorms

### DIFF
--- a/code/modules/overmap/planets/planet_types/barren_planet.dm
+++ b/code/modules/overmap/planets/planet_types/barren_planet.dm
@@ -6,7 +6,6 @@
 	default_traits_input = list(ZTRAIT_MINING = TRUE, ZTRAIT_BASETURF = /turf/open/floor/plating/planetary/barren)
 	overmap_type = /datum/overmap_object/shuttle/planet/barren
 	atmosphere_type = /datum/atmosphere/barren
-	weather_controller_type = /datum/weather_controller/desert
 
 	rock_color = list(COLOR_BEIGE_GRAYISH, COLOR_BEIGE, COLOR_GRAY, COLOR_BROWN)
 	planet_flags = PLANET_WRECKAGES|PLANET_REMOTE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
oops

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Barren planets mistakenly no longer have sandstorms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
