### PR TITLE
Bearcat QoL Part 3: Disposals and Lights

### DIFF
--- a/_maps/map_files/tradership/tradership1.dmm
+++ b/_maps/map_files/tradership/tradership1.dmm
@@ -2,6 +2,12 @@
 "ab" = (
 /turf/closed/wall,
 /area/science/xenobiology)
+"ah" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "aj" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -17,6 +23,9 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bn" = (
@@ -46,9 +55,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cL" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cP" = (
@@ -56,6 +70,9 @@
 	id = "packageSort2"
 	},
 /obj/effect/turf_decal/box,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "de" = (
@@ -74,6 +91,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
+"dX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
 "eg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -87,6 +110,9 @@
 "et" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/bar)
 "ev" = (
@@ -101,6 +127,12 @@
 "ft" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/storage)
+"fC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fI" = (
@@ -143,6 +175,16 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hK" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "TrashBelt"
+	},
+/obj/machinery/light_switch/directional/south,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "hU" = (
 /obj/structure/cable,
 /obj/machinery/requests_console/directional/south,
@@ -170,6 +212,13 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "kg" = (
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"ku" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kC" = (
@@ -200,10 +249,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"lh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "lF" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "lK" = (
@@ -213,6 +272,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/storage)
+"lY" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mm" = (
@@ -245,6 +311,21 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"nA" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/service/bar)
+"nJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "om" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -296,12 +377,25 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/window/northleft,
 /turf/open/floor/plating,
 /area/cargo/storage)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
+"qc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"qi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/reinforced,
@@ -329,30 +423,50 @@
 	icon_state = "wood-broken2"
 	},
 /area/service/bar)
-"qX" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "rt" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/service/bar)
+"rw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
 "se" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"st" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
 "sP" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/iron,
+/area/cargo/storage)
+"ti" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
 /area/cargo/storage)
 "tu" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -368,15 +482,45 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "tE" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/science/xenobiology)
 "ul" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
-"uG" = (
+"up" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/maintenance/port/aft)
+"ux" = (
+/obj/machinery/button/massdriver{
+	id = "TRASH";
+	pixel_x = 24;
+	pixel_y = 3
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Mass Driver";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"uG" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "TrashBelt"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "uK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -414,6 +558,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vT" = (
@@ -433,6 +578,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wS" = (
@@ -449,6 +597,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -36
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "xx" = (
@@ -484,6 +635,9 @@
 "xZ" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -497,14 +651,39 @@
 	icon_state = "wood-broken"
 	},
 /area/service/bar)
+"yv" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
+/area/service/bar)
+"yL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space)
+"zd" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/door/window/northleft,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "zk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
 /area/service/bar)
+"zn" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "zB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -535,6 +714,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"Ak" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
 "An" = (
 /obj/machinery/requests_console/directional/west,
 /turf/open/floor/iron,
@@ -556,6 +741,14 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/service/bar)
+"AW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
 "Bm" = (
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/wood,
@@ -592,6 +785,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "CD" = (
@@ -625,23 +821,46 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Ev" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/window/northright,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "Ez" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "EC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"ED" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "EQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"FX" = (
+/turf/closed/wall,
+/area/maintenance/disposal)
 "GZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -698,11 +917,33 @@
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "Kg" = (
 /turf/open/space/basic,
 /area/space)
+"Kk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
+"Kn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
 "Kp" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -763,6 +1004,7 @@
 "MP" = (
 /obj/structure/cable,
 /obj/machinery/light/dim/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "MR" = (
@@ -808,8 +1050,21 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/light/broken/directional/west,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -36
+	},
 /turf/open/floor/wood,
 /area/service/bar)
+"Oy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/storage)
+"Pc" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "Pk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -819,6 +1074,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "Pl" = (
@@ -838,6 +1094,9 @@
 /area/maintenance/port/aft)
 "PS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/service/bar)
 "Qo" = (
@@ -850,8 +1109,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"Qp" = (
+/obj/machinery/door/poddoor/massdriver_trash{
+	id = "TRASH"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "Qy" = (
 /obj/machinery/jukebox,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/service/bar)
 "QA" = (
@@ -877,9 +1146,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "RD" = (
-/mob/living/simple_animal/mouse/brown/tom,
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "TRASH"
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/maintenance/disposal)
 "RK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/bounty,
@@ -888,11 +1160,19 @@
 /area/service/bar)
 "RM" = (
 /obj/machinery/firealarm/directional/west,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "TrashBelt"
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/maintenance/disposal)
 "RX" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/fore/secondary)
+/area/maintenance/disposal)
 "Sc" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood{
@@ -906,6 +1186,9 @@
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/bar)
 "Tt" = (
@@ -932,8 +1215,13 @@
 /area/cargo/storage)
 "TD" = (
 /obj/machinery/light/dim/directional/north,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "TrashBelt"
+	},
+/obj/machinery/recycler,
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/maintenance/disposal)
 "TE" = (
 /turf/open/floor/wood,
 /area/service/bar)
@@ -960,6 +1248,9 @@
 "Ui" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "Ul" = (
@@ -968,6 +1259,7 @@
 "Uq" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "Us" = (
@@ -980,11 +1272,19 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "Vo" = (
-/turf/closed/wall,
-/area/maintenance/fore/secondary)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposal Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "VW" = (
 /obj/structure/cable,
 /obj/effect/spawner/randomcolavend,
@@ -1010,6 +1310,10 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"WX" = (
+/obj/structure/disposalpipe/trunk/multiz,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "Xa" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/tile/red{
@@ -1022,11 +1326,31 @@
 /area/security/brig)
 "Xg" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/maintenance/disposal)
+"Xr" = (
+/obj/structure/cable,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
+"XU" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "Yi" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/broken/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/bar)
 "Yj" = (
@@ -31532,8 +31856,8 @@ ff
 LT
 HQ
 kg
-kg
-kg
+WX
+qc
 kg
 NG
 kg
@@ -31788,7 +32112,7 @@ QL
 QL
 QL
 gw
-PH
+XU
 MP
 Ui
 PH
@@ -32045,7 +32369,7 @@ qI
 av
 Kr
 kg
-PH
+up
 YP
 YP
 YP
@@ -32301,11 +32625,11 @@ QL
 zY
 Bm
 Kr
-kg
-os
+qi
+ku
 vF
-do
-do
+ah
+AW
 YP
 kg
 gX
@@ -32558,11 +32882,11 @@ GZ
 Bn
 hU
 Kr
-os
+nJ
 os
 YP
 ZQ
-do
+st
 YP
 YP
 YP
@@ -32819,9 +33143,9 @@ rt
 Kr
 Kr
 ZQ
-do
-ZQ
-ZQ
+rw
+Kn
+Pc
 Ty
 An
 BP
@@ -33076,7 +33400,7 @@ zk
 AP
 Kr
 JO
-do
+lh
 aU
 Pk
 Pk
@@ -33339,17 +33663,17 @@ ZQ
 ZQ
 ZQ
 ZQ
-ip
+Kk
 cE
-kG
-Tz
+fC
+Oy
 Cw
 Yj
 Tz
 Iy
 Iy
 Sn
-mm
+ti
 Kg
 Kg
 Kg
@@ -33600,7 +33924,7 @@ ip
 Iy
 Tz
 mV
-go
+lY
 xJ
 pK
 Iy
@@ -33847,7 +34171,7 @@ xZ
 Op
 RK
 aj
-pX
+Ev
 de
 ZQ
 ZQ
@@ -33857,7 +34181,7 @@ ip
 Iy
 Tz
 Iy
-go
+lY
 Ch
 ih
 Iy
@@ -34114,13 +34438,13 @@ ZB
 Iy
 Tz
 Iy
-go
+Xr
 HY
-Iy
+ED
 Iy
 Kp
 Sn
-mm
+ti
 Kg
 Kg
 Kg
@@ -34354,8 +34678,8 @@ Kg
 Kg
 Kg
 GZ
-TE
-MR
+yv
+nA
 Yi
 Qy
 gr
@@ -34618,7 +34942,7 @@ Kr
 pP
 Kr
 Ez
-ZQ
+Ak
 do
 pk
 Iy
@@ -34874,7 +35198,7 @@ Kr
 RM
 Xg
 Vo
-ZQ
+dX
 ZI
 lK
 iS
@@ -35129,8 +35453,8 @@ kX
 Pl
 Kr
 uG
-uG
-ab
+zd
+FX
 ab
 vy
 ab
@@ -35386,8 +35710,8 @@ kX
 kX
 Kr
 TD
-uG
-ab
+hK
+FX
 lF
 Mg
 QA
@@ -35642,9 +35966,9 @@ QL
 QL
 QL
 QL
-qX
 uG
-ab
+zn
+FX
 gU
 Aw
 qF
@@ -35900,8 +36224,8 @@ ff
 ff
 RX
 RD
-uG
-ab
+ux
+FX
 lf
 KU
 WB
@@ -36156,9 +36480,9 @@ ff
 ff
 ff
 RX
+Qp
 RX
 RX
-IT
 IT
 IT
 IT
@@ -36412,9 +36736,9 @@ Kg
 Kg
 ff
 ff
-ff
-ff
-ff
+yL
+Kg
+yL
 ff
 ff
 ff
@@ -36669,15 +36993,15 @@ Kg
 Kg
 Kg
 ff
-ff
-ff
-ff
-ff
-ff
-ff
 Kg
 Kg
 Kg
+ff
+ff
+ff
+yL
+Kg
+yL
 Kg
 Kg
 Kg

--- a/_maps/map_files/tradership/tradership1.dmm
+++ b/_maps/map_files/tradership/tradership1.dmm
@@ -2,19 +2,17 @@
 "ab" = (
 /turf/closed/wall,
 /area/science/xenobiology)
-"ah" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/cargo/storage)
 "aj" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "packageSort2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/storage)
+"ar" = (
+/obj/structure/disposalpipe/trunk/multiz,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "av" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/wood,
@@ -49,6 +47,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"cA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "cE" = (
 /obj/item/stack/ore/iron{
 	amount = 5
@@ -73,7 +79,7 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "de" = (
 /obj/effect/turf_decal/stripes/line,
@@ -87,16 +93,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"dz" = (
+/obj/structure/cable,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "dK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
-"dX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/cargo/storage)
 "eg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -124,25 +132,40 @@
 "ff" = (
 /turf/closed/mineral/random/high_chance,
 /area/space)
+"fi" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "ft" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/storage)
-"fC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fI" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"ge" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/window/northright,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "go" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gq" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gr" = (
 /obj/structure/cable,
 /turf/open/floor/wood{
@@ -175,16 +198,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hK" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "TrashBelt"
-	},
-/obj/machinery/light_switch/directional/south,
-/obj/structure/window/reinforced/spawner{
-	dir = 1
+"hq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/aft)
 "hU" = (
 /obj/structure/cable,
 /obj/machinery/requests_console/directional/south,
@@ -206,19 +228,27 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"iz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "iS" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"kg" = (
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"ku" = (
-/obj/structure/cable,
+"kc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/cargo/storage)
+"kg" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kC" = (
@@ -249,15 +279,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"lh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/cargo/storage)
 "lF" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/power/apc/auto_name/west,
@@ -274,17 +295,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"lY" = (
-/obj/structure/cable,
+"mc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/cargo/storage)
 "mm" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/cargo/storage)
+"mC" = (
+/obj/item/circuitboard/machine/recycler,
+/turf/open/space/basic,
+/area/space)
 "mV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -311,21 +337,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"nA" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/service/bar)
-"nJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "om" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -353,6 +364,19 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"po" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"pB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/cargo/storage)
 "pK" = (
 /obj/structure/fans/tiny,
 /obj/structure/fans/tiny,
@@ -378,24 +402,12 @@
 	dir = 1
 	},
 /obj/machinery/door/window/northleft,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "pY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
-"qc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"qi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "qw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/reinforced,
@@ -434,25 +446,17 @@
 	},
 /turf/open/floor/plating,
 /area/service/bar)
-"rw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/cargo/storage)
 "se" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"st" = (
+"su" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
@@ -462,11 +466,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/cargo/storage)
-"ti" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/space/basic,
 /area/cargo/storage)
 "tu" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -494,26 +493,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
-"up" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"ux" = (
-/obj/machinery/button/massdriver{
-	id = "TRASH";
-	pixel_x = 24;
-	pixel_y = 3
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Mass Driver";
-	req_access_txt = "22"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+"uA" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "uG" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -570,7 +553,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "wu" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -583,6 +566,25 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ww" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space)
+"wF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
+"wR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wS" = (
 /obj/item/stack/ore/iron{
 	amount = 5
@@ -608,7 +610,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "xJ" = (
 /obj/machinery/door/airlock/external,
@@ -651,22 +653,13 @@
 	icon_state = "wood-broken"
 	},
 /area/service/bar)
-"yv" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/wood,
-/area/service/bar)
-"yL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/space/basic,
-/area/space)
 "zd" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/south,
-/obj/machinery/door/window/northleft,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "zk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -678,12 +671,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/service/bar)
-"zn" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "zB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -703,6 +690,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/bar)
+"zP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "zY" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -714,12 +708,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"Ak" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/cargo/storage)
 "An" = (
 /obj/machinery/requests_console/directional/west,
 /turf/open/floor/iron,
@@ -741,14 +729,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/service/bar)
-"AW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/cargo/storage)
 "Bm" = (
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/wood,
@@ -796,6 +776,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"CH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "Dp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -821,13 +807,13 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"Ev" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"DO" = (
+/obj/machinery/door/poddoor/massdriver_trash{
+	id = "TRASH"
 	},
-/obj/machinery/door/window/northright,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/cargo/storage)
+/area/maintenance/disposal)
 "Ez" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8
@@ -838,7 +824,7 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "EC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -848,19 +834,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"ED" = (
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "EQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"FX" = (
-/turf/closed/wall,
-/area/maintenance/disposal)
+"GJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "GZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -921,29 +906,11 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "Kg" = (
 /turf/open/space/basic,
 /area/space)
-"Kk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
-"Kn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/cargo/storage)
 "Kp" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -1055,16 +1022,14 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
-"Oy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/cargo/storage)
-"Pc" = (
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/plating,
-/area/cargo/storage)
+"Oz" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
+/area/service/bar)
+"OR" = (
+/turf/closed/wall,
+/area/maintenance/disposal)
 "Pk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1088,10 +1053,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"PB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "PH" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"PL" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/service/bar)
 "PS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -1099,6 +1076,12 @@
 	},
 /turf/open/floor/plating,
 /area/service/bar)
+"PZ" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "Qo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -1109,13 +1092,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"Qp" = (
-/obj/machinery/door/poddoor/massdriver_trash{
-	id = "TRASH"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "Qy" = (
 /obj/machinery/jukebox,
 /obj/structure/disposalpipe/segment{
@@ -1131,6 +1107,10 @@
 "QL" = (
 /turf/closed/wall/r_wall,
 /area/service/bar)
+"QR" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/plating,
+/area/cargo/storage)
 "Rd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -1145,6 +1125,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"Ry" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal)
 "RD" = (
 /obj/machinery/mass_driver{
 	dir = 4;
@@ -1219,12 +1208,22 @@
 	dir = 4;
 	id = "TrashBelt"
 	},
-/obj/machinery/recycler,
+/obj/item/circuitboard/machine/recycler,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "TE" = (
 /turf/open/floor/wood,
 /area/service/bar)
+"TN" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/door/window/northleft,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/disposal)
 "TS" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
@@ -1275,7 +1274,12 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
+/area/cargo/storage)
+"Vg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
 /area/cargo/storage)
 "Vo" = (
 /obj/structure/disposalpipe/segment,
@@ -1283,7 +1287,9 @@
 	name = "Disposal Access";
 	req_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/maintenance/disposal)
 "VW" = (
 /obj/structure/cable,
@@ -1310,10 +1316,18 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"WX" = (
-/obj/structure/disposalpipe/trunk/multiz,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+"WP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "Xa" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/tile/red{
@@ -1330,23 +1344,10 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"Xr" = (
-/obj/structure/cable,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/cargo/storage)
-"XU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/disposal)
 "Yi" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/broken/directional/east,
@@ -1358,6 +1359,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall,
 /area/cargo/storage)
+"Yp" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "TrashBelt"
+	},
+/obj/machinery/light_switch/directional/south,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/disposal)
 "YK" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/cable,
@@ -1406,6 +1418,20 @@
 "ZQ" = (
 /turf/open/floor/plating,
 /area/cargo/storage)
+"ZW" = (
+/obj/machinery/button/massdriver{
+	id = "TRASH";
+	pixel_x = 24;
+	pixel_y = 3
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Mass Driver";
+	req_access_txt = "22"
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/disposal)
 
 (1,1,1) = {"
 Kg
@@ -31856,8 +31882,8 @@ ff
 LT
 HQ
 kg
-WX
-qc
+ar
+CH
 kg
 NG
 kg
@@ -32112,7 +32138,7 @@ QL
 QL
 QL
 gw
-XU
+gq
 MP
 Ui
 PH
@@ -32369,7 +32395,7 @@ qI
 av
 Kr
 kg
-up
+po
 YP
 YP
 YP
@@ -32625,11 +32651,11 @@ QL
 zY
 Bm
 Kr
-qi
-ku
+wR
+zP
 vF
-ah
-AW
+kc
+su
 YP
 kg
 gX
@@ -32882,11 +32908,11 @@ GZ
 Bn
 hU
 Kr
-nJ
+hq
 os
 YP
 ZQ
-st
+mc
 YP
 YP
 YP
@@ -33142,10 +33168,10 @@ Kr
 rt
 Kr
 Kr
-ZQ
-rw
-Kn
-Pc
+Iy
+wF
+pB
+QR
 Ty
 An
 BP
@@ -33400,7 +33426,7 @@ zk
 AP
 Kr
 JO
-lh
+iz
 aU
 Pk
 Pk
@@ -33663,17 +33689,17 @@ ZQ
 ZQ
 ZQ
 ZQ
-Kk
+WP
 cE
-fC
-Oy
+PB
+GJ
 Cw
 Yj
 Tz
 Iy
 Iy
 Sn
-ti
+Vg
 Kg
 Kg
 Kg
@@ -33924,7 +33950,7 @@ ip
 Iy
 Tz
 mV
-lY
+fi
 xJ
 pK
 Iy
@@ -34171,8 +34197,8 @@ xZ
 Op
 RK
 aj
-Ev
-de
+ge
+zd
 ZQ
 ZQ
 ZQ
@@ -34181,7 +34207,7 @@ ip
 Iy
 Tz
 Iy
-lY
+fi
 Ch
 ih
 Iy
@@ -34438,13 +34464,13 @@ ZB
 Iy
 Tz
 Iy
-Xr
+dz
 HY
-ED
+uA
 Iy
 Kp
 Sn
-ti
+Vg
 Kg
 Kg
 Kg
@@ -34678,8 +34704,8 @@ Kg
 Kg
 Kg
 GZ
-yv
-nA
+Oz
+PL
 Yi
 Qy
 gr
@@ -34942,7 +34968,7 @@ Kr
 pP
 Kr
 Ez
-Ak
+PZ
 do
 pk
 Iy
@@ -35198,7 +35224,7 @@ Kr
 RM
 Xg
 Vo
-dX
+cA
 ZI
 lK
 iS
@@ -35453,8 +35479,8 @@ kX
 Pl
 Kr
 uG
-zd
-FX
+TN
+OR
 ab
 vy
 ab
@@ -35710,8 +35736,8 @@ kX
 kX
 Kr
 TD
-hK
-FX
+Yp
+OR
 lF
 Mg
 QA
@@ -35967,8 +35993,8 @@ QL
 QL
 QL
 uG
-zn
-FX
+Ry
+OR
 gU
 Aw
 qF
@@ -36224,8 +36250,8 @@ ff
 ff
 RX
 RD
-ux
-FX
+ZW
+OR
 lf
 KU
 WB
@@ -36480,7 +36506,7 @@ ff
 ff
 ff
 RX
-Qp
+DO
 RX
 RX
 IT
@@ -36736,9 +36762,9 @@ Kg
 Kg
 ff
 ff
-yL
+ww
 Kg
-yL
+ww
 ff
 ff
 ff
@@ -36999,9 +37025,9 @@ Kg
 ff
 ff
 ff
-yL
+ww
 Kg
-yL
+ww
 Kg
 Kg
 Kg
@@ -37767,7 +37793,7 @@ Kg
 Kg
 Kg
 Kg
-Kg
+mC
 Kg
 Kg
 Kg

--- a/_maps/map_files/tradership/tradership2.dmm
+++ b/_maps/map_files/tradership/tradership2.dmm
@@ -44,6 +44,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "cd" = (
@@ -86,8 +89,16 @@
 /area/cargo/warehouse)
 "dQ" = (
 /obj/structure/chair/office,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/science)
+"dT" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/commons/vacant_room)
 "dV" = (
 /turf/closed/wall/r_wall,
 /area/science)
@@ -131,6 +142,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "fq" = (
@@ -153,6 +167,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"fM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gh" = (
 /obj/structure/rack,
 /obj/machinery/power/apc/auto_name/north,
@@ -164,11 +187,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
 "gM" = (
 /obj/item/instrument/guitar,
 /obj/structure/cable,
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/commons/vacant_room)
 "gW" = (
@@ -183,6 +212,10 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/engineering/storage)
+"hj" = (
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/plating,
+/area/commons/vacant_room)
 "hq" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -268,6 +301,13 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/circuit,
 /area/construction/storage_wing)
+"kj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "kl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -291,6 +331,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "kS" = (
@@ -368,6 +411,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"mn" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "mx" = (
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/trade_pad,
@@ -402,6 +449,15 @@
 /obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
+"mW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "nb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -533,6 +589,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/openspace,
 /area/hallway/primary/central)
 "qP" = (
@@ -564,6 +621,25 @@
 /obj/item/metal_density_scanner,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"rn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
+"ru" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "sj" = (
 /obj/machinery/conveyor{
 	id = "cargo_smeltery"
@@ -640,6 +716,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "uB" = (
@@ -680,6 +757,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "vK" = (
@@ -735,6 +813,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wj" = (
@@ -763,6 +842,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/commons/cryopods)
+"wN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -829,6 +917,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "zG" = (
@@ -855,6 +946,13 @@
 	},
 /turf/open/openspace/airless/planetary,
 /area/space)
+"AJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "AN" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock,
@@ -1034,6 +1132,15 @@
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /turf/closed/wall,
 /area/maintenance/aft/secondary)
+"GO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "GV" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/openspace/airless/planetary,
@@ -1137,6 +1244,15 @@
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/iron/white,
 /area/science)
+"JS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "Kb" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
@@ -1163,17 +1279,37 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "KH" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/engine/airless,
 /area/space)
+"KL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "KO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
+"KW" = (
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "Lu" = (
 /obj/effect/landmark/observer_start,
 /turf/open/floor/iron,
@@ -1199,6 +1335,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
 "LW" = (
@@ -1269,6 +1408,11 @@
 "NI" = (
 /turf/open/floor/iron/white,
 /area/science)
+"NL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/disposalpipe/trunk/multiz/down,
+/turf/open/floor/iron/white,
+/area/science/research/abandoned)
 "NS" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable,
@@ -1282,6 +1426,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/science)
+"OQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "OV" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 1;
@@ -1307,6 +1456,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
+"Px" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "PC" = (
 /obj/machinery/light_switch/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1325,6 +1482,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/commons/vacant_room)
 "Qe" = (
@@ -1339,6 +1499,9 @@
 /area/commons/dorms)
 "Qu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "Qx" = (
@@ -1493,6 +1656,9 @@
 /area/cargo/warehouse)
 "UV" = (
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "Vh" = (
@@ -1500,6 +1666,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"Vq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "Vu" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/plasma,
@@ -1583,6 +1758,9 @@
 "YE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/science/research/abandoned)
 "YI" = (
@@ -1595,6 +1773,9 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "YK" = (
@@ -1613,11 +1794,20 @@
 "YR" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/white,
 /area/science)
 "Zj" = (
 /turf/closed/wall,
 /area/construction/storage_wing)
+"Zs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "Zv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
@@ -32106,13 +32296,13 @@ Fv
 ao
 xw
 we
-Ng
+NL
 YE
 Ng
 dF
 tk
 NI
-Qu
+kj
 Jw
 dF
 li
@@ -32878,12 +33068,12 @@ ao
 iN
 wq
 nb
-Zz
+Vq
 Sd
 Sd
 HZ
 nW
-nb
+ru
 qY
 Te
 Sd
@@ -33135,17 +33325,17 @@ EP
 EP
 EP
 II
-nb
+fM
 qK
-Zz
+KL
 ul
 vD
-Zz
-nb
+mW
+AJ
 wi
-Zz
-Zz
-nb
+KL
+KL
+JS
 nb
 vL
 yo
@@ -33392,7 +33582,7 @@ Ux
 DL
 sk
 My
-mg
+KW
 sk
 OX
 sk
@@ -33649,7 +33839,7 @@ gW
 nk
 RR
 fL
-du
+Zs
 nS
 hF
 uE
@@ -33659,7 +33849,7 @@ bc
 FN
 UU
 sk
-nb
+ru
 Sd
 Zj
 Gd
@@ -33906,7 +34096,7 @@ mQ
 Tt
 mR
 rc
-du
+Zs
 FP
 Yk
 qe
@@ -34158,12 +34348,12 @@ IP
 sk
 sk
 zS
-Hv
-gW
-gW
-gW
-AR
-du
+rn
+mn
+mn
+mn
+OQ
+Px
 gW
 Vh
 qe
@@ -34687,7 +34877,7 @@ qe
 Ui
 pG
 sk
-Zz
+Vq
 Sd
 QG
 QG
@@ -34944,7 +35134,7 @@ sx
 Jm
 UU
 sk
-nb
+ru
 Sd
 QG
 QH
@@ -35457,8 +35647,8 @@ Zz
 Zz
 AN
 nb
-nb
-nb
+wN
+GO
 lY
 QG
 zv
@@ -35714,7 +35904,7 @@ nb
 nP
 Te
 Sd
-Zz
+Vq
 nP
 nw
 QG
@@ -36228,7 +36418,7 @@ YK
 wW
 WG
 MY
-Wn
+dT
 Rr
 RO
 ZV
@@ -36999,7 +37189,7 @@ lj
 IT
 WG
 nt
-Rr
+hj
 Rr
 hC
 ZV

--- a/_maps/map_files/tradership/tradership3.dmm
+++ b/_maps/map_files/tradership/tradership3.dmm
@@ -44,16 +44,6 @@
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"aL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "aO" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -110,15 +100,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"bG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "bL" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -258,14 +239,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/kitchen/coldroom)
-"eg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "ek" = (
 /obj/machinery/button/door/directional/east{
 	id = 1;
@@ -306,12 +279,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall,
 /area/service/hydroponics)
-"eO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -359,11 +326,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"fw" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/openspace/airless/planetary,
-/area/space)
 "fx" = (
 /obj/machinery/chem_master,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -415,13 +377,6 @@
 	},
 /turf/open/openspace/airless/planetary,
 /area/space)
-"gj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "gt" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -442,6 +397,14 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"gK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "gP" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room";
@@ -454,23 +417,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
-"gS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
-"gV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
+"gX" = (
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "gY" = (
 /obj/structure/closet/crate/radiation,
 /obj/item/stack/sheet/mineral/uranium/five,
@@ -483,15 +433,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"hf" = (
+"hl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "hw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -634,6 +582,23 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"jl" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/smooth,
+/area/command/meeting_room)
+"jo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "jq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 6
@@ -750,6 +715,18 @@
 /obj/structure/table/optable,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"la" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
+"lm" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "lv" = (
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
@@ -789,6 +766,9 @@
 /area/engineering/engine_smes)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "mc" = (
@@ -891,17 +871,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"nh" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "nj" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"nk" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "nl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -921,6 +900,14 @@
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
+"nC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "nD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -945,20 +932,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"nL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay)
 "nN" = (
 /turf/open/floor/iron,
 /area/commons/lounge)
-"nV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
+"nU" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "nZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
@@ -1010,10 +990,6 @@
 "ox" = (
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
-"oz" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "oL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1023,6 +999,9 @@
 "oQ" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "oS" = (
@@ -1030,6 +1009,14 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"oT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "oX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy";
@@ -1090,17 +1077,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"ql" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "qw" = (
 /obj/machinery/chem_mass_spec,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"qD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "qK" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
@@ -1136,16 +1126,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/pharmacy)
-"qW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "rf" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron,
@@ -1228,6 +1208,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"sz" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "sF" = (
 /obj/effect/spawner/structure/window/reinforced/indestructable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -1238,6 +1222,15 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"sN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sO" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
@@ -1284,10 +1277,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/main)
-"tm" = (
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "tt" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 8
@@ -1306,16 +1295,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
-"tC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "tE" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay)
@@ -1329,15 +1308,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"tR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "tV" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/bag/chemistry,
@@ -1356,6 +1326,10 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"un" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "uo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
@@ -1405,10 +1379,25 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"uy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "uA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"uC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "uE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1460,6 +1449,16 @@
 	},
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"vc" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "vg" = (
 /obj/machinery/deepfryer,
 /obj/structure/sink{
@@ -1477,11 +1476,27 @@
 "vj" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"vq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "vQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/kitchen/diner)
+"vS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "vU" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -1490,31 +1505,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"vZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
-"wa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "wd" = (
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
-"wf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "wg" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
@@ -1538,13 +1531,18 @@
 "wu" = (
 /turf/open/floor/iron,
 /area/service/kitchen/diner)
-"wv" = (
-/obj/effect/decal/cleanable/dirt,
+"wF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
+"wI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
@@ -1575,16 +1573,6 @@
 	},
 /turf/open/openspace/airless/planetary,
 /area/space)
-"wX" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "wZ" = (
 /turf/closed/wall/r_wall,
 /area/service/kitchen/diner)
@@ -1614,6 +1602,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"xx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "xE" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1651,6 +1649,9 @@
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "yh" = (
@@ -1699,15 +1700,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"za" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "zb" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -1786,20 +1778,6 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
-"zK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"zO" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "zW" = (
 /obj/machinery/gibber,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -1898,13 +1876,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"Bp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/lounge)
 "Bs" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -1925,6 +1896,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"BN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "BR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 1
@@ -2025,6 +2002,16 @@
 "Dc" = (
 /turf/closed/wall,
 /area/service/hydroponics)
+"Di" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "Dv" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
@@ -2077,6 +2064,12 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"DW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay)
 "DX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
@@ -2107,6 +2100,11 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"Ek" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "Eq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2196,14 +2194,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"EQ" = (
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
-"ER" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/commons/lounge)
 "EU" = (
 /obj/machinery/atmospherics/components/unary/engine,
 /turf/closed/wall,
@@ -2288,6 +2278,16 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"FI" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "FM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
@@ -2358,6 +2358,22 @@
 "GV" = (
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"GZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
+"Ha" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "Hg" = (
 /obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/insectguts,
@@ -2394,6 +2410,15 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"Hy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "HA" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -2415,6 +2440,11 @@
 /obj/structure/railing,
 /turf/closed/wall,
 /area/cargo/warehouse/upper)
+"Ib" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "Ig" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2486,6 +2516,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"IV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "IY" = (
 /obj/structure/chair{
 	dir = 1
@@ -2596,6 +2636,11 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
+"Kz" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/openspace/airless/planetary,
+/area/space)
 "KD" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
@@ -2918,14 +2963,6 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/cargo/warehouse/upper)
-"Pn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "Pw" = (
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
@@ -2949,6 +2986,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/command/meeting_room)
+"PQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/hallway/primary/central/fore)
 "PX" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/iron,
@@ -2968,6 +3012,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "Qn" = (
@@ -2998,14 +3043,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"QD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "QN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/closed/wall/r_wall,
@@ -3014,21 +3051,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
-"QW" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/smooth,
-/area/command/meeting_room)
-"QX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/hallway/primary/central/fore)
 "QY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3042,6 +3064,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
+"Rd" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light_switch/directional/west,
+/turf/open/openspace,
+/area/cargo/warehouse/upper)
 "Rt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3049,15 +3076,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
-"RC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "RI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -3117,6 +3135,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"Sg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "Sp" = (
 /obj/machinery/computer/station_alert{
 	dir = 1
@@ -3284,6 +3312,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/command/meeting_room)
+"Va" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/commons/lounge)
 "Vb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3321,14 +3355,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"Vn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "Vs" = (
 /obj/structure/table,
 /obj/item/food/lollipop,
@@ -3393,11 +3419,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"Wo" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light_switch/directional/west,
-/turf/open/openspace,
-/area/cargo/warehouse/upper)
 "Wx" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
 /turf/open/floor/iron,
@@ -3411,6 +3432,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet,
 /area/command/bridge)
+"WQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "WS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -3610,22 +3638,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
-"YJ" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"YO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
-"YV" = (
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"YP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"YV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "Zg" = (
 /obj/structure/lattice,
 /turf/open/openspace/airless/planetary,
@@ -33877,11 +33909,11 @@ DB
 DB
 DB
 DB
-fw
+Kz
 EF
 NW
 EF
-fw
+Kz
 DB
 DB
 DB
@@ -33899,9 +33931,9 @@ Rc
 oo
 WS
 hI
-iN
-iN
-iN
+uC
+sz
+YV
 iN
 Wx
 iN
@@ -34417,8 +34449,8 @@ Jl
 Xb
 yg
 Ql
-iN
-iN
+sz
+YV
 YD
 Cs
 bz
@@ -34925,17 +34957,17 @@ GV
 GV
 GV
 CD
-eO
+wI
 IN
 rp
 Mn
 Mn
 OX
 Mn
-rp
+vq
 RP
 Jm
-nV
+Ek
 Eb
 fQ
 xw
@@ -35164,33 +35196,33 @@ nt
 kD
 Oo
 NX
-tR
-QX
-wa
+Hy
+PQ
+WQ
 mX
 MX
 MX
 lz
 QY
-QD
-vZ
+oT
+hl
 Rt
-wv
-vZ
+Di
+hl
 ZW
-vZ
+hl
 Rt
 Rt
 Uh
-Vn
-YJ
-eg
-hf
+la
+FI
+gK
+ql
 qi
 Er
-eg
-gV
-tC
+gK
+Ha
+Sg
 wL
 wL
 XH
@@ -35420,8 +35452,8 @@ To
 iH
 mW
 wN
-tm
-za
+lm
+jo
 NX
 NX
 cU
@@ -35447,7 +35479,7 @@ Kd
 Kd
 Py
 EI
-zK
+IV
 wL
 OM
 Cj
@@ -35678,7 +35710,7 @@ uv
 wN
 wN
 AY
-za
+jo
 iW
 iW
 cU
@@ -35695,7 +35727,7 @@ ze
 Av
 DF
 eV
-Wo
+Rd
 Fw
 dI
 xO
@@ -35935,18 +35967,18 @@ fo
 VK
 SJ
 NX
-za
+jo
 iW
 bO
 kl
 UO
 KT
-EQ
+gX
 cU
 Ej
 zC
 zC
-Bp
+YO
 Up
 ze
 Tu
@@ -35961,7 +35993,7 @@ xO
 xO
 Py
 dy
-zK
+IV
 sZ
 pu
 pu
@@ -36184,7 +36216,7 @@ XB
 MN
 Yd
 bp
-QW
+jl
 hL
 yv
 fo
@@ -36192,7 +36224,7 @@ fo
 fo
 Qy
 SN
-za
+jo
 iW
 Xe
 ZZ
@@ -36201,9 +36233,9 @@ uE
 rB
 LG
 Fy
-ER
-ER
-YV
+nU
+nU
+Va
 Yh
 ze
 PX
@@ -36443,13 +36475,13 @@ DQ
 jJ
 IY
 mQ
-nk
-oz
-gj
-oz
+Ib
+un
+YP
+un
 aI
-zO
-gS
+nh
+wF
 iW
 bO
 LW
@@ -36702,11 +36734,11 @@ IY
 hL
 kV
 rf
-bG
+sN
 yI
 SJ
 LA
-za
+jo
 iW
 iW
 cU
@@ -36732,7 +36764,7 @@ xO
 rt
 Py
 jt
-aL
+xx
 wL
 Ya
 pu
@@ -36963,7 +36995,7 @@ Lc
 jX
 VW
 ce
-za
+jo
 NX
 NX
 cU
@@ -36989,7 +37021,7 @@ po
 Vb
 Py
 rp
-aL
+xx
 wL
 cZ
 CI
@@ -37220,7 +37252,7 @@ zG
 xm
 VW
 rD
-za
+jo
 NX
 kg
 cU
@@ -37246,7 +37278,7 @@ Kd
 Kd
 Py
 Xi
-zK
+IV
 wL
 dm
 pu
@@ -37478,19 +37510,19 @@ RX
 VW
 aS
 Fs
-wa
-wa
+WQ
+WQ
 mX
 MX
 MX
 LQ
 Lg
-Pn
-vZ
+GZ
+hl
 MX
 MX
-vZ
-wX
+hl
+vc
 hC
 zE
 Lf
@@ -37498,12 +37530,12 @@ FF
 CD
 JM
 BS
-wf
+nC
 EL
 cT
 BS
 Ez
-zK
+IV
 kA
 kA
 sr
@@ -37748,9 +37780,9 @@ Pw
 Jk
 Pd
 bg
-vZ
-vZ
-qW
+hl
+hl
+vS
 fk
 Pw
 IN
@@ -37759,8 +37791,8 @@ OX
 rp
 Mn
 Mn
-RC
-qD
+uy
+BN
 kA
 wj
 hb
@@ -38760,11 +38792,11 @@ DB
 DB
 DB
 DB
-fw
+Kz
 EF
 gt
 EF
-fw
+Kz
 DB
 DB
 DB
@@ -38777,7 +38809,7 @@ aK
 pW
 qV
 Fb
-nL
+DW
 mw
 ot
 mt

--- a/_maps/map_files/tradership/tradership3.dmm
+++ b/_maps/map_files/tradership/tradership3.dmm
@@ -28,6 +28,8 @@
 "aI" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aJ" = (
@@ -42,6 +44,16 @@
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"aL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "aO" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -50,6 +62,7 @@
 /area/engineering/supermatter/room)
 "aS" = (
 /obj/item/kirbyplants/dead,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/plating,
 /area/hallway/primary/central/fore)
 "bb" = (
@@ -60,6 +73,9 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "bp" = (
@@ -94,6 +110,15 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"bG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "bL" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -140,6 +165,7 @@
 "cr" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/openspace,
 /area/cargo/warehouse/upper)
 "cD" = (
@@ -232,6 +258,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/service/kitchen/coldroom)
+"eg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "ek" = (
 /obj/machinery/button/door/directional/east{
 	id = 1;
@@ -272,6 +306,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall,
 /area/service/hydroponics)
+"eO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -319,6 +359,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"fw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/openspace/airless/planetary,
+/area/space)
 "fx" = (
 /obj/machinery/chem_master,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -370,6 +415,13 @@
 	},
 /turf/open/openspace/airless/planetary,
 /area/space)
+"gj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "gt" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -402,6 +454,23 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
+"gS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
+"gV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "gY" = (
 /obj/structure/closet/crate/radiation,
 /obj/item/stack/sheet/mineral/uranium/five,
@@ -414,6 +483,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"hf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "hw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -628,6 +706,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "kr" = (
@@ -682,6 +763,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
 "lB" = (
@@ -797,6 +879,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
 "mY" = (
@@ -814,6 +897,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"nk" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "nl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -857,9 +945,20 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"nL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay)
 "nN" = (
 /turf/open/floor/iron,
 /area/commons/lounge)
+"nV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "nZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
@@ -911,6 +1010,10 @@
 "ox" = (
 /turf/open/floor/iron,
 /area/cargo/warehouse/upper)
+"oz" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "oL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -919,6 +1022,7 @@
 /area/engineering/engine_smes)
 "oQ" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "oS" = (
@@ -983,12 +1087,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "qw" = (
 /obj/machinery/chem_mass_spec,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"qD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "qK" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
@@ -1024,6 +1136,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"qW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "rf" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron,
@@ -1052,6 +1174,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "rC" = (
@@ -1159,6 +1284,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/main)
+"tm" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "tt" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 8
@@ -1177,6 +1306,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"tC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "tE" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay)
@@ -1190,9 +1329,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"tR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "tV" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/bag/chemistry,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "tZ" = (
@@ -1273,6 +1422,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/locker)
 "uJ" = (
@@ -1338,9 +1490,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"vZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
+"wa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "wd" = (
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
+"wf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "wg" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
@@ -1364,6 +1538,16 @@
 "wu" = (
 /turf/open/floor/iron,
 /area/service/kitchen/diner)
+"wv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "wK" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
@@ -1391,6 +1575,16 @@
 	},
 /turf/open/openspace/airless/planetary,
 /area/space)
+"wX" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "wZ" = (
 /turf/closed/wall/r_wall,
 /area/service/kitchen/diner)
@@ -1409,6 +1603,10 @@
 /area/service/kitchen/coldroom)
 "xm" = (
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "xw" = (
@@ -1417,7 +1615,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "xE" = (
-/obj/structure/bed/roller,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "xH" = (
@@ -1473,6 +1674,7 @@
 /area/hallway/primary/fore)
 "yM" = (
 /obj/structure/closet/secure_closet/captains,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "yN" = (
@@ -1492,8 +1694,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"za" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "zb" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -1502,6 +1716,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/locker)
 "ze" = (
@@ -1555,6 +1772,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "zH" = (
@@ -1563,8 +1783,23 @@
 	pixel_x = 12
 	},
 /obj/machinery/requests_console/directional/east,
+/obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/medical/medbay)
+"zK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
+"zO" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "zW" = (
 /obj/machinery/gibber,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -1608,6 +1843,7 @@
 "Am" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "Av" = (
@@ -1662,6 +1898,13 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"Bp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/lounge)
 "Bs" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -1841,6 +2084,7 @@
 /area/engineering/atmos)
 "Ea" = (
 /obj/machinery/vending/dinnerware,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "Eb" = (
@@ -1848,12 +2092,14 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "Eg" = (
-/obj/structure/table,
 /obj/machinery/light/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "Eh" = (
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "Ej" = (
@@ -1872,6 +2118,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "Es" = (
@@ -1949,11 +2196,22 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"EQ" = (
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
+"ER" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "EU" = (
 /obj/machinery/atmospherics/components/unary/engine,
 /turf/closed/wall,
 /area/hallway/primary/central)
 "Fb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "Fe" = (
@@ -1975,6 +2233,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/central/fore)
 "Fw" = (
@@ -1989,6 +2250,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "FA" = (
@@ -2144,6 +2406,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "HZ" = (
@@ -2261,6 +2524,10 @@
 /area/commons/lounge)
 "Jv" = (
 /obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "JK" = (
@@ -2324,6 +2591,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "KD" = (
@@ -2370,6 +2640,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "Lf" = (
@@ -2384,6 +2657,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "Ll" = (
@@ -2395,6 +2669,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "Lv" = (
@@ -2430,6 +2707,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "LK" = (
@@ -2453,6 +2731,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "LW" = (
@@ -2517,6 +2796,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "MZ" = (
@@ -2591,6 +2871,7 @@
 /area/hallway/primary/central/aft)
 "OM" = (
 /obj/structure/closet/toolcloset,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "OO" = (
@@ -2603,6 +2884,8 @@
 /area/space)
 "OU" = (
 /obj/structure/cable,
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "OX" = (
@@ -2635,6 +2918,14 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/cargo/warehouse/upper)
+"Pn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "Pw" = (
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
@@ -2707,6 +2998,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"QD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "QN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/closed/wall/r_wall,
@@ -2715,11 +3014,27 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
+"QW" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/smooth,
+/area/command/meeting_room)
+"QX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/hallway/primary/central/fore)
 "QY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
 "Rc" = (
@@ -2731,11 +3046,24 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/primary/central/aft)
+"RC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "RI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "RO" = (
@@ -2895,6 +3223,9 @@
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/lounge)
 "Ue" = (
@@ -2908,6 +3239,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "Ui" = (
@@ -2929,6 +3261,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "UK" = (
@@ -2963,6 +3298,9 @@
 "Vj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/lounge)
 "Vk" = (
@@ -2983,6 +3321,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"Vn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "Vs" = (
 /obj/structure/table,
 /obj/item/food/lollipop,
@@ -3047,11 +3393,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"Wo" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light_switch/directional/west,
+/turf/open/openspace,
+/area/cargo/warehouse/upper)
 "Wx" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "WA" = (
+/obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/airless,
 /area/space)
 "WH" = (
@@ -3173,6 +3525,7 @@
 "Ya" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "Yd" = (
@@ -3196,11 +3549,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/locker)
 "Ym" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/command/bridge)
 "Yo" = (
@@ -3250,6 +3610,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
+"YJ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
+"YV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/commons/lounge)
 "Zg" = (
 /obj/structure/lattice,
 /turf/open/openspace/airless/planetary,
@@ -3306,6 +3682,9 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "ZW" = (
@@ -3313,6 +3692,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "ZZ" = (
@@ -33497,11 +33877,11 @@ DB
 DB
 DB
 DB
-DB
+fw
 EF
 NW
 EF
-DB
+fw
 DB
 DB
 DB
@@ -34545,7 +34925,7 @@ GV
 GV
 GV
 CD
-GV
+eO
 IN
 rp
 Mn
@@ -34555,7 +34935,7 @@ Mn
 rp
 RP
 Jm
-Xx
+nV
 Eb
 fQ
 xw
@@ -34784,33 +35164,33 @@ nt
 kD
 Oo
 NX
-SN
-Fs
-SN
+tR
+QX
+wa
 mX
 MX
 MX
 lz
 QY
-fO
-fO
+QD
+vZ
 Rt
-MX
-fO
+wv
+vZ
 ZW
-fO
+vZ
 Rt
 Rt
 Uh
-CD
-JM
-BS
-Ez
+Vn
+YJ
+eg
+hf
 qi
 Er
-BS
-Ez
-Ez
+eg
+gV
+tC
 wL
 wL
 XH
@@ -35040,8 +35420,8 @@ To
 iH
 mW
 wN
-NX
-SN
+tm
+za
 NX
 NX
 cU
@@ -35067,7 +35447,7 @@ Kd
 Kd
 Py
 EI
-BS
+zK
 wL
 OM
 Cj
@@ -35298,7 +35678,7 @@ uv
 wN
 wN
 AY
-SN
+za
 iW
 iW
 cU
@@ -35315,7 +35695,7 @@ ze
 Av
 DF
 eV
-FB
+Wo
 Fw
 dI
 xO
@@ -35555,18 +35935,18 @@ fo
 VK
 SJ
 NX
-SN
+za
 iW
 bO
 kl
 UO
 KT
-UO
+EQ
 cU
 Ej
 zC
 zC
-zC
+Bp
 Up
 ze
 Tu
@@ -35581,7 +35961,7 @@ xO
 xO
 Py
 dy
-BS
+zK
 sZ
 pu
 pu
@@ -35804,7 +36184,7 @@ XB
 MN
 Yd
 bp
-IY
+QW
 hL
 yv
 fo
@@ -35812,7 +36192,7 @@ fo
 fo
 Qy
 SN
-SN
+za
 iW
 Xe
 ZZ
@@ -35821,9 +36201,9 @@ uE
 rB
 LG
 Fy
-nN
-nN
-nN
+ER
+ER
+YV
 Yh
 ze
 PX
@@ -36063,13 +36443,13 @@ DQ
 jJ
 IY
 mQ
-JK
-JK
-fo
-JK
+nk
+oz
+gj
+oz
 aI
-NX
-SN
+zO
+gS
 iW
 bO
 LW
@@ -36322,11 +36702,11 @@ IY
 hL
 kV
 rf
-fo
+bG
 yI
 SJ
 LA
-SN
+za
 iW
 iW
 cU
@@ -36352,7 +36732,7 @@ xO
 rt
 Py
 jt
-Ez
+aL
 wL
 Ya
 pu
@@ -36583,7 +36963,7 @@ Lc
 jX
 VW
 ce
-SN
+za
 NX
 NX
 cU
@@ -36609,7 +36989,7 @@ po
 Vb
 Py
 rp
-Ez
+aL
 wL
 cZ
 CI
@@ -36840,7 +37220,7 @@ zG
 xm
 VW
 rD
-SN
+za
 NX
 kg
 cU
@@ -36866,7 +37246,7 @@ Kd
 Kd
 Py
 Xi
-BS
+zK
 wL
 dm
 pu
@@ -37098,19 +37478,19 @@ RX
 VW
 aS
 Fs
-SN
-SN
+wa
+wa
 mX
 MX
 MX
 LQ
 Lg
-fO
-fO
+Pn
+vZ
 MX
 MX
-fO
-LQ
+vZ
+wX
 hC
 zE
 Lf
@@ -37118,12 +37498,12 @@ FF
 CD
 JM
 BS
-BS
+wf
 EL
 cT
 BS
 Ez
-BS
+zK
 kA
 kA
 sr
@@ -37368,9 +37748,9 @@ Pw
 Jk
 Pd
 bg
-fO
-fO
-CD
+vZ
+vZ
+qW
 fk
 Pw
 IN
@@ -37379,8 +37759,8 @@ OX
 rp
 Mn
 Mn
-OX
-rp
+RC
+qD
 kA
 wj
 hb
@@ -38380,11 +38760,11 @@ DB
 DB
 DB
 DB
-DB
+fw
 EF
 gt
 EF
-DB
+fw
 DB
 DB
 DB
@@ -38397,7 +38777,7 @@ aK
 pW
 qV
 Fb
-Fb
+nL
 mw
 ot
 mt

--- a/_maps/map_files/tradership/tradership4.dmm
+++ b/_maps/map_files/tradership/tradership4.dmm
@@ -74,6 +74,7 @@
 /area/tcommsat/server)
 "jE" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/tcommsat/server)
 "kC" = (
@@ -355,6 +356,11 @@
 /obj/structure/ladder,
 /turf/open/floor/iron,
 /area/tcommsat/server)
+"Qd" = (
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "Qr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
@@ -408,6 +414,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "Tj" = (
@@ -472,6 +479,11 @@
 "Wh" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/tcommsat/server)
+"WB" = (
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/tcommsat/server)
 "WG" = (
@@ -32994,7 +33006,7 @@ qP
 qP
 Tj
 oV
-Tj
+WB
 Tj
 Wh
 Vd
@@ -33029,7 +33041,7 @@ Xd
 Ph
 Ph
 xg
-Ph
+Qd
 Ph
 rQ
 WG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Part 3 of the Bearcat QoL updates;

**Disposals**

- Added a new room to ship: Disposals. North east on deck 1.
![image](https://user-images.githubusercontent.com/4310446/122980334-ccd60580-d398-11eb-88c3-c830be055c5c.png)
Note: SEE LAST UPDATE, THIS HAS BEEN CHANGED

- Piped decks 1-3 with disposals system. All rooms that create trash have a disposals bin. other places just have normal bins.
- Xenobio now has a disposals straight to space. for getting rid of those pesky monkeys

**Lights**

- Added lightswitches to all rooms and main walkways. ready for upcoming PR to port roundstart lighting fun.
- Added some marker beacons to external airlocks and disposal outlets.
![image](https://user-images.githubusercontent.com/4310446/122981346-ef1c5300-d399-11eb-8dc3-e9c7db5fa754.png)


**Misc Fixes**

- Fixed another missing wire.
- Added the missing airalarm in chems.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Bearcat QoL Part 3: Disposals and Lights -- See PR for more details
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
