### PR TITLE
Fixes shuttle extensions often not applying to non-maploaded shuttles

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -25,11 +25,10 @@
 /obj/structure/shuttle/engine/Initialize()
 	. = ..()
 	if(extension_type)
-		//Late initialize does not seem to work for this (doesnt get caled at all), so a timer
-		addtimer(CALLBACK(src, .proc/CreateExtension))
+		extension = new extension_type()
+		ApplyExtension()
 
-/obj/structure/shuttle/engine/proc/CreateExtension()
-	extension = new extension_type()
+/obj/structure/shuttle/engine/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	if(state == ENGINE_WELDED)
 		ApplyExtension()
 

--- a/code/modules/overmap/mining_laser.dm
+++ b/code/modules/overmap/mining_laser.dm
@@ -12,10 +12,10 @@
 
 /obj/machinery/mining_laser/Initialize()
 	. = ..()
-	addtimer(CALLBACK(src, .proc/TimedInitialize))
-
-/obj/machinery/mining_laser/proc/TimedInitialize()
 	extension = new extension_type(src)
+	extension.ApplyToPosition(get_turf(src))
+
+/obj/machinery/mining_laser/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	extension.ApplyToPosition(get_turf(src))
 
 /obj/machinery/mining_laser/proc/PostFire()

--- a/code/modules/overmap/propulsion_engine.dm
+++ b/code/modules/overmap/propulsion_engine.dm
@@ -33,15 +33,12 @@
 	extension = new extension_type(src)
 	if(starts_welded)
 		weld_down(mapload)
-		//This needs to be connected a moment after a lot of other initialization stuff happens
-		//Late initialize will fail to apply this correctly as atmos wont yet fully initialize (despite the lies they want you to believe in)
-		addtimer(CALLBACK(src, .proc/ApplyExtension))
+		extension.ApplyToPosition(get_turf(src))
 	. = ..()
 
-/obj/machinery/atmospherics/components/unary/engine/proc/ApplyExtension()
-	if(extension.IsApplied()) //This can and will be a case due to nessecary timer help
-		return
-	extension.ApplyToPosition(get_turf(src))
+/obj/machinery/atmospherics/components/unary/engine/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	if(is_welded)
+		extension.ApplyToPosition(get_turf(src))
 
 /obj/machinery/atmospherics/components/unary/engine/Destroy()
 	extension.RemoveExtension()
@@ -59,7 +56,7 @@
 	is_welded = TRUE
 	can_be_unanchored = FALSE
 	move_resist = INFINITY
-	ApplyExtension()
+	extension.ApplyToPosition(get_turf(src))
 	if(mapload) //Atmos isn't initialized at mapload
 		return
 	SetInitDirections()

--- a/code/modules/overmap/shield_generator.dm
+++ b/code/modules/overmap/shield_generator.dm
@@ -15,12 +15,12 @@
 
 /obj/machinery/shield_generator/Initialize()
 	. = ..()
-	addtimer(CALLBACK(src, .proc/TimedInitialize))
-
-/obj/machinery/shield_generator/proc/TimedInitialize()
 	extension = new extension_type()
 	extension.ApplyToPosition(get_turf(src))
 	power_change()
+
+/obj/machinery/shield_generator/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	extension.ApplyToPosition(get_turf(src))
 
 /obj/machinery/shield_generator/Destroy()
 	extension.RemoveExtension()

--- a/code/modules/overmap/shuttle_extension.dm
+++ b/code/modules/overmap/shuttle_extension.dm
@@ -6,6 +6,8 @@
 	var/datum/space_level/z_level
 
 /datum/shuttle_extension/proc/ApplyToPosition(turf/position)
+	if(IsApplied())
+		return
 	if(SSshuttle.is_in_shuttle_bounds(position))
 		var/obj/docking_port/mobile/M = SSshuttle.get_containing_shuttle(position)
 		if(M)

--- a/code/modules/overmap/transporter.dm
+++ b/code/modules/overmap/transporter.dm
@@ -15,12 +15,12 @@
 
 /obj/machinery/transporter/Initialize()
 	. = ..()
-	addtimer(CALLBACK(src, .proc/TimedInitialize))
-
-/obj/machinery/transporter/proc/TimedInitialize()
 	extension = new extension_type(src)
 	extension.ApplyToPosition(get_turf(src))
 	power_change()
+
+/obj/machinery/transporter/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	extension.ApplyToPosition(get_turf(src))
 
 /obj/machinery/transporter/Destroy()
 	extension.RemoveExtension()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -405,8 +405,6 @@
 	if(!name)
 		name = "shuttle"
 
-	SSshuttle.mobile += src
-
 	var/counter = SSshuttle.assoc_mobile[id]
 	if(!replace || !counter)
 		if(counter)
@@ -414,10 +412,12 @@
 			SSshuttle.assoc_mobile[id] = counter
 			id = "[id]_[counter]"
 			name = "[name] [counter]"
-			//Re link machinery to new shuttle id
-			linkup()
 		else
 			SSshuttle.assoc_mobile[id] = 1
+
+	SSshuttle.mobile += src
+	//Link machinery to new shuttle
+	linkup()
 
 /obj/docking_port/mobile/unregister()
 	. = ..()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -405,6 +405,8 @@
 	if(!name)
 		name = "shuttle"
 
+	SSshuttle.mobile += src
+
 	var/counter = SSshuttle.assoc_mobile[id]
 	if(!replace || !counter)
 		if(counter)
@@ -416,8 +418,6 @@
 			linkup()
 		else
 			SSshuttle.assoc_mobile[id] = 1
-
-	SSshuttle.mobile += src
 
 /obj/docking_port/mobile/unregister()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This issue would happen anytime a shuttle would take more than 1 server tick to load in, due to the timer

All extensions now use the shuttle's `connect_to_shuttle` proc to make sure there's no initialization issues. As the shuttles load, it gets added to the shuttle list before linkup() (calling `connect_to_shuttle`) and not after, as linkup'd things may require that

EDIT: ~~wait now it turns out that maploaded shuttles stop attaching their extensions :joy:~~
EDIT2: Turns out linkup() would only be called on duplicate shuttles, and only was used to append ID's of buttons and stuff. I've changed it so it's always called and all the things wanting to link to a shuttle can safely use it now. All good and ready now

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes shuttle extensions often not applying to non-maploaded shuttles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
