### PR TITLE
Wraps chat text of balloon alerts in notice span and adds a source prefix

### DIFF
--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -39,7 +39,9 @@
 
 	// User has balloon alerts disabled
 	if (viewer_client?.prefs.balloon_alerts_pref != BALLOON_ALERTS_ONLY)
-		to_chat(viewer, chat_text ? chat_text : text)
+		if(!chat_text)
+			chat_text = "<span class='notice'>[src] - [text]</span>"
+		to_chat(viewer, chat_text)
 	if (viewer_client?.prefs.balloon_alerts_pref == BALLOON_ALERTS_NONE)
 		return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1034,7 +1034,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			switch(balloon_alerts_pref)
 				if (BALLOON_ALERTS_NONE)
-					button_name = "Disabled"
+					button_name = "Disabled (Chat only)"
 				if (BALLOON_ALERTS_ONLY)
 					button_name = "On-screen Only"
 				if (BALLOON_ALERTS_BOTH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This only applies to the chat text that is not defined and gets copied from balloon popup text. There's a dash inbetween the user and the text
![dreamseeker_2021-06-26_02-51-51](https://user-images.githubusercontent.com/6381979/123496836-69fb9d00-d62a-11eb-99aa-2d363613577d.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Wraps chat text of balloon alerts in notice span and adds a source prefix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
