### PR TITLE
Traders paycheck and credits tweak

### DIFF
--- a/code/__DEFINES/trading.dm
+++ b/code/__DEFINES/trading.dm
@@ -8,16 +8,15 @@
 #define TRADER_BUYS_GOODS (1<<4)
 
 //Cash amounts the traders get
-#define DEFAULT_TRADER_CREDIT_AMOUNT 5000
-#define RICH_TRADER_CREDIT_AMOUNT 10000
-#define POOR_TRADER_CREDIT_AMOUNT 3000
-#define VERY_POOR_TRADER_CREDIT_AMOUNT 1000
+#define DEFAULT_TRADER_CREDIT_AMOUNT 7000
+#define RICH_TRADER_CREDIT_AMOUNT 15000
+#define POOR_TRADER_CREDIT_AMOUNT 3500
+#define VERY_POOR_TRADER_CREDIT_AMOUNT 1500
 
-//TODO:
 //Every time SStrading ticks, if the traders have cash below a threshold they'll gain a small injection of cash
-#define TRADER_LOW_CASH_THRESHOLD 2000
-#define TRADER_PAYCHECK_LOW 200
-#define TRADER_PAYCHECK_HIGH 500
+#define TRADER_LOW_CASH_THRESHOLD 50 //In percentage
+#define TRADER_PAYCHECK_LOW 500
+#define TRADER_PAYCHECK_HIGH 1500
 
 // Extra value margin for the user to make barter trades a bit easier
 #define TRADE_BARTER_EXTRA_MARGIN 1.1

--- a/code/modules/trading/_trader.dm
+++ b/code/modules/trading/_trader.dm
@@ -308,6 +308,8 @@
 	InitializeStock()
 
 /datum/trader/proc/Tick()
+	if(current_credits < (initial(current_credits)*(TRADER_LOW_CASH_THRESHOLD/100)))
+		current_credits += rand(TRADER_PAYCHECK_LOW, TRADER_PAYCHECK_HIGH)
 	if(rotates_stock && prob(rotate_stock_chance))
 		RotateStock()
 

--- a/code/modules/trading/traders/goods.dm
+++ b/code/modules/trading/traders/goods.dm
@@ -234,6 +234,7 @@
 
 /datum/trader/mining
 	name = "Rock'n'Drill Mining Inc"
+	current_credits = RICH_TRADER_CREDIT_AMOUNT
 	buy_margin = 1.3
 	sell_margin = 2
 	possible_origins = list("Automated Smelter AH-532", "CMV Locust", "The Galactic Foundry Company", "Crucible LLC")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Traders if have less than 50% their starting cash they'll receive paychecks over time.
Traders now also have 7000 cash from 5000 and the Rock n Drill trader now has 15000

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Traders if have less than 50% their starting cash they'll receive paychecks over time.
add: Traders now also have 7000 cash from 5000 and the Rock n Drill trader now has 15000
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
