### PR TITLE
Fixes parallax oddities and overmap shuttle parallax

### DIFF
--- a/code/modules/overmap/overmap_shuttle_process.dm
+++ b/code/modules/overmap/overmap_shuttle_process.dm
@@ -128,8 +128,6 @@
 		if(velocity_length < SHUTTLE_MINIMUM_VELOCITY)
 			velocity_x = 0
 			velocity_y = 0
-			if(is_seperate_z_level)
-				update_seperate_z_level_parallax(TRUE)
 		else
 			//"Friction"
 			velocity_x *= 0.95
@@ -141,11 +139,8 @@
 			partial_x += add_partial_x
 			partial_y += add_partial_y
 
-			if(ProcessPartials() && shuttle_controller)
-				shuttle_controller.ShuttleMovedOnOvermap()
-
-			if(is_seperate_z_level)
-				update_seperate_z_level_parallax()
+			ProcessPartials()
+		update_perceived_parallax()
 
 	//Update rotation
 	if(uses_rotation)

--- a/code/modules/overmap/shuttle_control_component.dm
+++ b/code/modules/overmap/shuttle_control_component.dm
@@ -16,10 +16,6 @@
 		mob_controller.client.pixel_x = x
 		mob_controller.client.pixel_y = y
 
-/datum/overmap_shuttle_controller/proc/ShuttleMovedOnOvermap()
-	if(mob_controller)
-		mob_controller.update_parallax_contents()
-
 /datum/overmap_shuttle_controller/New(datum/overmap_object/shuttle/passed_ov_obj)
 	overmap_obj = passed_ov_obj
 	quit_control_button = new

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -374,6 +374,9 @@
 
 	var/overmap_shuttle_type = /datum/overmap_object/shuttle
 
+	/// The direction override that overmap objects representing this shuttle apply to it. Needs to be tracked seperately to the old method because shuttles should work fine without overmap objects. Null means not overriden, direction means it is (with 0 being stop)
+	var/overmap_parallax_dir
+
 /obj/docking_port/mobile/proc/DrawDockingThrust()
 	var/drawn_power = 0
 	for(var/i in engine_extensions)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Overmap shuttles will now properly respect velocity to animate parallax
fix: Fixes parallax oddities.
fix: Client's parallax is now updated immediately when an overmap object changes its movement state
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
