### PR TITLE
Makes food crafting faster.

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -1,6 +1,7 @@
 /datum/crafting_recipe/food
 	var/real_parts
 	category = CAT_FOOD
+	time = 5 // Food is crafted in much larger quantities than other craftables. IE: Chicken Nuggets + Sausage Links + Crackers, ect. Parent object time is 30.
 
 /datum/crafting_recipe/food/New()
 	real_parts = parts.Copy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts food crafting speed from 30 deciseconds, to 5.

## Why It's Good For The Game

For "good" foods, IE, Burgers, Tacos, ect, the time to craft is fine. For "lesser" foods, or foods with multiple steps, it's an absolute pain. This is kind of a bandaid fix for food to be somewhat bearable until things are changed.

## Changelog
:cl:
qol: Food is significantly faster to craft.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
