### PR TITLE
Basic Mining Kit

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -273,3 +273,16 @@
 	new /obj/item/gun/energy/kinetic_accelerator(src)
 	new /obj/item/kitchen/knife/combat/survival(src)
 	new /obj/item/flashlight/seclite(src)
+
+/obj/item/storage/backpack/duffelbag/mining_conscript/basic
+	name = "basic mining kit"
+	desc = "A bare-minimum kit for mining."
+	icon_state = "duffel-explorer"
+	inhand_icon_state = "duffel-explorer"
+
+/obj/item/storage/backpack/duffelbag/mining_conscript/basic/PopulateContents()
+	new /obj/item/clothing/suit/hooded/explorer(src)
+	new /obj/item/clothing/mask/gas/explorer(src)
+	new /obj/item/storage/bag/ore(src)
+	new /obj/item/pickaxe(src)
+	new /obj/item/flashlight/lantern(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a basic variant of the mining conscription kit. By itself, this PR does nothing, but I'm hoping Bee will be able to add it to the mining trader/merchant. I mostly don't want to cause conflicts with the stuff they're working on.

Kit contains:
- Explorer Suit/Mask
- Pickaxe
- Lantern
- Mining Bag

![dreamseeker_VG7B5V0Hhg](https://user-images.githubusercontent.com/7543955/124368288-c6178000-dc2d-11eb-8375-bce91e0af8af.png)

## Why It's Good For The Game

They buy materials, so, it'd make sense that they would be willing to sell some basic mining supplies. Instead of adding like, three individual orders for products, I made it a kit.

## Changelog
:cl:
add: Basic Mining Kit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
