### PR TITLE
Makes existing allergy quirk nicer, adds extreme subtype

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -22,14 +22,17 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(!quirks.len)
 		SetupQuirks()
 
-	quirk_blacklist = list(list("Blind","Nearsighted"), \
-							list("Jolly","Depression","Apathetic","Hypersensitive"), \
-							list("Ageusia","Vegetarian","Deviant Tastes"), \
-							list("Ananas Affinity","Ananas Aversion"), \
-							list("Alcohol Tolerance","Light Drinker"), \
-							list("Clown Fan","Mime Fan"), \
-							list("Bad Touch", "Friendly"), \
-							list("Extrovert", "Introvert"))
+	quirk_blacklist = list(
+		list("Blind", "Nearsighted"),
+		list("Jolly", "Depression", "Apathetic", "Hypersensitive"),
+		list("Ageusia", "Vegetarian", "Deviant Tastes"),
+		list("Ananas Affinity", "Ananas Aversion"),
+		list("Alcohol Tolerance", "Light Drinker"),
+		list("Clown Fan", "Mime Fan"),
+		list("Bad Touch", "Friendly"),
+		list("Extrovert", "Introvert"),
+		list("Extreme Medicine Allergy", "Medicine Allergy"),
+	)
 	return ..()
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -626,15 +626,27 @@
 	hardcore_value = 9
 
 /datum/quirk/allergic
-	name = "Extreme Medicine Allergy"
+	name = "Medicine Allergy"
 	desc = "Ever since you were a kid, you've been allergic to certain chemicals..."
-	value = -6
+	value = -4
 	gain_text = "<span class='danger'>You feel your immune system shift.</span>"
 	lose_text = "<span class='notice'>You feel your immune system phase back into perfect shape.</span>"
-	medical_record_text = "Patient's immune system responds violently to certain chemicals."
+	medical_record_text = "Patient's immune system responds undesirably to certain chemicals."
 	hardcore_value = 3
 	var/list/allergies = list()
-	var/list/blacklist = list(/datum/reagent/medicine/c2,/datum/reagent/medicine/epinephrine,/datum/reagent/medicine/adminordrazine,/datum/reagent/medicine/omnizine/godblood,/datum/reagent/medicine/cordiolis_hepatico,/datum/reagent/medicine/synaphydramine,/datum/reagent/medicine/diphenhydramine)
+	var/list/blacklist = list(
+		/datum/reagent/medicine/c2,
+		/datum/reagent/medicine/epinephrine,
+		/datum/reagent/medicine/adminordrazine,
+		/datum/reagent/medicine/omnizine/godblood,
+		/datum/reagent/medicine/cordiolis_hepatico,
+		/datum/reagent/medicine/synaphydramine,
+		/datum/reagent/medicine/diphenhydramine,
+		/datum/reagent/medicine/insulin,
+		/datum/reagent/medicine/spaceacillin,
+		/datum/reagent/medicine/salglu_solution,
+		/datum/reagent/medicine/coagulant,
+	)
 
 /datum/quirk/allergic/on_spawn()
 	var/list/chem_list = subtypesof(/datum/reagent/medicine) - blacklist
@@ -684,6 +696,25 @@
 		if(DT_PROB(10, delta_time))
 			carbon_quirk_holder.vomit()
 			carbon_quirk_holder.adjustOrganLoss(pick(ORGAN_SLOT_BRAIN,ORGAN_SLOT_APPENDIX,ORGAN_SLOT_LUNGS,ORGAN_SLOT_HEART,ORGAN_SLOT_LIVER,ORGAN_SLOT_STOMACH),10)
+
+/datum/quirk/allergic/extreme
+	name = "Extreme Medicine Allergy"
+	desc = "Ever since you were born, you've been extremely allergic to certain chemicals..."
+	value = -6
+	gain_text = "<span class='danger'>You feel your immune system shift.</span>"
+	medical_record_text = "Patient's immune system responds violently to certain chemicals."
+	var/list/allergies = list()
+	var/list/blacklist = list(
+		/datum/reagent/medicine/c2,
+		/datum/reagent/medicine/epinephrine,
+		/datum/reagent/medicine/adminordrazine,
+		/datum/reagent/medicine/omnizine/godblood,
+		/datum/reagent/medicine/cordiolis_hepatico,
+		/datum/reagent/medicine/synaphydramine,
+		/datum/reagent/medicine/diphenhydramine,
+		/datum/reagent/medicine/insulin,
+		/datum/reagent/medicine/salglu_solution,
+	)
 
 /datum/quirk/bad_touch
 	name = "Bad Touch"

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -629,7 +629,7 @@
 	name = "Medicine Allergy"
 	desc = "Ever since you were a kid, you've been allergic to certain chemicals..."
 	value = -4
-	gain_text = "<span class='danger'>You feel your immune system shift.</span>"
+	gain_text = "<span class='danger'>You feel your immune system shift lightly.</span>"
 	lose_text = "<span class='notice'>You feel your immune system phase back into perfect shape.</span>"
 	medical_record_text = "Patient's immune system responds undesirably to certain chemicals."
 	hardcore_value = 3
@@ -703,8 +703,7 @@
 	value = -6
 	gain_text = "<span class='danger'>You feel your immune system shift.</span>"
 	medical_record_text = "Patient's immune system responds violently to certain chemicals."
-	var/list/allergies = list()
-	var/list/blacklist = list(
+	blacklist = list(
 		/datum/reagent/medicine/c2,
 		/datum/reagent/medicine/epinephrine,
 		/datum/reagent/medicine/adminordrazine,


### PR DESCRIPTION
## About The Pull Request
Adds
- insulin
- spaceacillin
- saline glucose
- coagulant

to the allergy quirk blacklist.

Renames that quirk to "Medicine Allergy", and adjusts its points

Adds an `/extreme` subtype  that inherits from the above and only leaves `insulin` and `saline glucose` as added blacklist items. Because its pretty much impossible to be allergic to those.

## Why It's Good For The Game
Adds a nice middle ground as an allergy perk, and also an extreme variant back incase someone really wants to die. Yet makes it a bit less awful as well.

## Changelog
:cl: Avunia Takiya
qol: Medicine Allergy Quirk now has insulin, spaceacillin, sal-glucose solution and coagulant in their blacklist - no more allergies from those
balance: Medicine Allergy Quirk only gives 4 points now
add: Re-added Extreme Medicine Allergy
balance: Extreme Medicine Allergy now has sal-glucose and insulin blacklisted
/:cl:

