### PR TITLE
Wrench can be used in setting/repairing bone surgery

### DIFF
--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -53,7 +53,8 @@
 		/obj/item/stack/medical/bone_gel = 100,
 		/obj/item/stack/sticky_tape/surgical = 100,
 		/obj/item/stack/sticky_tape/super = 50,
-		/obj/item/stack/sticky_tape = 30)
+		/obj/item/stack/sticky_tape = 30,
+		TOOL_WRENCH = 30)
 	time = 40
 
 /datum/surgery_step/repair_bone_hairline/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -93,7 +94,8 @@
 		/obj/item/bonesetter = 100,
 		/obj/item/stack/sticky_tape/surgical = 60,
 		/obj/item/stack/sticky_tape/super = 40,
-		/obj/item/stack/sticky_tape = 20)
+		/obj/item/stack/sticky_tape = 20,
+		TOOL_WRENCH = 20)
 	time = 40
 
 /datum/surgery_step/reset_compound_fracture/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
20/30 chances respectively. 
As per request of https://github.com/hrzntal/horizon/issues/385

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most surgeries do have inefficient ghetto ways of doing them, with the exception of this which was probably an oversight when introducing wounds

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Wrench can be used in setting/repairing bone surgery as a ghetto tool, it'll be very ineffective though
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
