### PR TITLE
Bodytype backend for all appearance stuff, fixes and cleanups

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -109,29 +109,5 @@
 #define JP_MEDIUM 2
 #define JP_HIGH 3
 
-//randomised elements
-#define RANDOM_HARDCORE "random_hardcore"
-#define RANDOM_NAME "random_name"
-#define RANDOM_NAME_ANTAG "random_name_antag"
-#define RANDOM_BODY "random_body"
-#define RANDOM_BODY_ANTAG "random_body_antag"
-#define RANDOM_SPECIES "random_species"
-#define RANDOM_GENDER "random_gender"
-#define RANDOM_GENDER_ANTAG "random_gender_antag"
-#define RANDOM_AGE "random_age"
-#define RANDOM_AGE_ANTAG "random_age_antag"
-#define RANDOM_UNDERWEAR "random_underwear"
-#define RANDOM_UNDERWEAR_COLOR "random_underwear_color"
-#define RANDOM_UNDERSHIRT "random_undershirt"
-#define RANDOM_SOCKS "random_socks"
-#define RANDOM_BACKPACK "random_backpack"
-#define RANDOM_JUMPSUIT_STYLE "random_jumpsuit_style"
-#define RANDOM_HAIRSTYLE "random_hairstyle"
-#define RANDOM_HAIR_COLOR "random_hair_color"
-#define RANDOM_FACIAL_HAIR_COLOR "random_facial_hair_color"
-#define RANDOM_FACIAL_HAIRSTYLE "random_facial_hairstyle"
-#define RANDOM_SKIN_TONE "random_skin_tone"
-#define RANDOM_EYE_COLOR "random_eye_color"
-
 //recommened client FPS
 #define RECOMMENDED_FPS 40

--- a/code/__HELPERS/customization/mobs.dm
+++ b/code/__HELPERS/customization/mobs.dm
@@ -1,8 +1,9 @@
 /proc/accessory_list_of_key_for_species(key, datum/species/S, mismatched, ckey)
 	var/list/accessory_list = list()
-	for(var/name in GLOB.sprite_accessories[key])
-		var/datum/sprite_accessory/SP = GLOB.sprite_accessories[key][name]
-		if(!mismatched && SP.recommended_species && !(S.id in SP.recommended_species))
+	var/list/cached_global_list = GLOB.sprite_accessories
+	for(var/name in cached_global_list[key])
+		var/datum/sprite_accessory/SP = cached_global_list[key][name]
+		if(!mismatched && (!(SP.bodytypes & S.bodytype) || (SP.recommended_species && !(S.id in SP.recommended_species))))
 			continue
 		if(SP.ckey_whitelist && !SP.ckey_whitelist[ckey])
 			continue
@@ -35,3 +36,120 @@
 					body_markings[zone] = list()
 				body_markings[zone][set_name] = BM.get_default_color(features, pref_species)
 	return body_markings
+
+/proc/marking_list_of_zone_for_species(zone, datum/species/species, mismatched = FALSE)
+	if(mismatched)
+		return GLOB.body_markings_per_limb[zone].Copy()
+	var/list/compiled_list = list()
+	var/list/global_list_cache = GLOB.body_markings_per_limb[zone]
+	var/list/global_lookup_cache = GLOB.body_markings
+	for(var/name in global_list_cache)
+		var/datum/body_marking/body_marking = global_lookup_cache[name]
+		if(!(body_marking.bodytypes & species.bodytype) || (body_marking.recommended_species && !(species.id in body_marking.recommended_species)))
+			continue
+		compiled_list[name] = body_marking
+	return compiled_list
+
+/proc/marking_sets_for_species(datum/species/species, mismatched = FALSE)
+	if(mismatched)
+		return GLOB.body_marking_sets.Copy()
+	var/list/compiled_list = list()
+	var/list/global_list_cache = GLOB.body_marking_sets
+	for(var/name in global_list_cache)
+		var/datum/body_marking_set/marking_set = global_list_cache[name]
+		if(!(marking_set.bodytypes & species.bodytype) || (marking_set.recommended_species && !(species.id in marking_set.recommended_species)))
+			continue
+		compiled_list[name] = marking_set
+	return compiled_list
+
+/proc/hairstyle_list_for_species(datum/species/species, gender, mismatched = FALSE)
+	if(mismatched)
+		return GLOB.hairstyles_list.Copy()
+	var/list/global_list_cache
+	switch(gender)
+		if(MALE)
+			global_list_cache = GLOB.hairstyles_male_list
+		if(FEMALE)
+			global_list_cache = GLOB.hairstyles_female_list
+		else
+			global_list_cache = GLOB.hairstyles_list
+	var/list/global_list_lookup = GLOB.hairstyles_list
+	var/list/compiled_list = list()
+	for(var/name in global_list_cache)
+		var/datum/sprite_accessory/accessory = global_list_lookup[name]
+		if(!(accessory.bodytypes & species.bodytype))
+			continue
+		compiled_list += accessory.name
+	return compiled_list
+
+/proc/facial_hairstyle_list_for_species(datum/species/species, gender, mismatched = FALSE)
+	if(mismatched)
+		return GLOB.hairstyles_list.Copy()
+	var/list/global_list_cache
+	switch(gender)
+		if(MALE)
+			global_list_cache = GLOB.facial_hairstyles_male_list
+		if(FEMALE)
+			global_list_cache = GLOB.facial_hairstyles_female_list
+		else
+			global_list_cache = GLOB.facial_hairstyles_list
+	var/list/global_list_lookup = GLOB.facial_hairstyles_list
+	var/list/compiled_list = list()
+	for(var/name in global_list_cache)
+		var/datum/sprite_accessory/accessory = global_list_lookup[name]
+		if(!(accessory.bodytypes & species.bodytype))
+			continue
+		compiled_list += accessory.name
+	return compiled_list
+
+/proc/underwear_list_for_species(datum/species/species, gender, mismatched = FALSE)
+	if(mismatched)
+		return GLOB.underwear_list.Copy()
+	var/list/global_list_cache
+	switch(gender)
+		if(MALE)
+			global_list_cache = GLOB.underwear_m
+		if(FEMALE)
+			global_list_cache = GLOB.underwear_f
+		else
+			global_list_cache = GLOB.underwear_list
+	var/list/global_list_lookup = GLOB.underwear_list
+	var/list/compiled_list = list()
+	for(var/name in global_list_cache)
+		var/datum/sprite_accessory/accessory = global_list_lookup[name]
+		if(!(accessory.bodytypes & species.bodytype))
+			continue
+		compiled_list += accessory.name
+	return compiled_list
+
+/proc/undershirt_list_for_species(datum/species/species, gender, mismatched = FALSE)
+	if(mismatched)
+		return GLOB.undershirt_list.Copy()
+	var/list/global_list_cache
+	switch(gender)
+		if(MALE)
+			global_list_cache = GLOB.undershirt_m
+		if(FEMALE)
+			global_list_cache = GLOB.undershirt_f
+		else
+			global_list_cache = GLOB.undershirt_list
+	var/list/global_list_lookup = GLOB.undershirt_list
+	var/list/compiled_list = list()
+	for(var/name in global_list_cache)
+		var/datum/sprite_accessory/accessory = global_list_lookup[name]
+		if(!(accessory.bodytypes & species.bodytype))
+			continue
+		compiled_list += accessory.name
+	return compiled_list
+
+/proc/socks_list_for_species(datum/species/species, mismatched = FALSE)
+	if(mismatched)
+		return GLOB.socks_list.Copy()
+	var/list/global_list_cache = GLOB.socks_list
+	var/list/compiled_list = list()
+	for(var/name in global_list_cache)
+		var/datum/sprite_accessory/accessory = global_list_cache[name]
+		if(!(accessory.bodytypes & species.bodytype))
+			continue
+		compiled_list += accessory.name
+	return compiled_list

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -20,32 +20,18 @@
 		else
 			return "000"
 
-/proc/random_underwear(gender)
-	if(!GLOB.underwear_list.len)
-		init_sprite_accessory_subtypes(/datum/sprite_accessory/underwear, GLOB.underwear_list, GLOB.underwear_m, GLOB.underwear_f)
-	switch(gender)
-		if(MALE)
-			return pick(GLOB.underwear_m)
-		if(FEMALE)
-			return pick(GLOB.underwear_f)
-		else
-			return pick(GLOB.underwear_list)
+/proc/random_underwear(gender, datum/species/species, mismatched = FALSE)
+	if(!species)
+		mismatched = TRUE
+	return pick(underwear_list_for_species(species, gender, mismatched))
 
-/proc/random_undershirt(gender)
-	if(!GLOB.undershirt_list.len)
-		init_sprite_accessory_subtypes(/datum/sprite_accessory/undershirt, GLOB.undershirt_list, GLOB.undershirt_m, GLOB.undershirt_f)
-	switch(gender)
-		if(MALE)
-			return pick(GLOB.undershirt_m)
-		if(FEMALE)
-			return pick(GLOB.undershirt_f)
-		else
-			return pick(GLOB.undershirt_list)
+/proc/random_undershirt(gender, datum/species/species, mismatched = FALSE)
+	if(!species)
+		mismatched = TRUE
+	return pick(undershirt_list_for_species(species, gender, mismatched))
 
-/proc/random_socks()
-	if(!GLOB.socks_list.len)
-		init_sprite_accessory_subtypes(/datum/sprite_accessory/socks, GLOB.socks_list)
-	return pick(GLOB.socks_list)
+/proc/random_socks(datum/species/species, mismatched = FALSE)
+	return pick(socks_list_for_species(species, mismatched))
 
 /proc/random_backpack()
 	return pick(GLOB.backpacklist)
@@ -53,23 +39,15 @@
 /proc/random_features() //Not random now, use the species specific ones for that. This is kept for compatibility
 	return MANDATORY_FEATURE_LIST
 
-/proc/random_hairstyle(gender)
-	switch(gender)
-		if(MALE)
-			return pick(GLOB.hairstyles_male_list)
-		if(FEMALE)
-			return pick(GLOB.hairstyles_female_list)
-		else
-			return pick(GLOB.hairstyles_list)
+/proc/random_hairstyle(gender, datum/species/species, mismatched = FALSE)
+	if(!species)
+		mismatched = TRUE
+	return pick(hairstyle_list_for_species(species, gender, mismatched))
 
-/proc/random_facial_hairstyle(gender)
-	switch(gender)
-		if(MALE)
-			return pick(GLOB.facial_hairstyles_male_list)
-		if(FEMALE)
-			return pick(GLOB.facial_hairstyles_female_list)
-		else
-			return pick(GLOB.facial_hairstyles_list)
+/proc/random_facial_hairstyle(gender, datum/species/species, mismatched = FALSE)
+	if(!species)
+		mismatched = TRUE
+	return pick(facial_hairstyle_list_for_species(species, gender, mismatched))
 
 /proc/random_unique_name(gender, attempts_to_find_unique_name=10)
 	for(var/i in 1 to attempts_to_find_unique_name)

--- a/code/_globalvars/customization/lists.dm
+++ b/code/_globalvars/customization/lists.dm
@@ -59,3 +59,6 @@ GLOBAL_LIST_INIT(robotic_styles_list, list("None" = "None",
 										"Xion Manufacturing Group 2.0" = 'icons/mob/augmentation/xm2ipc.dmi',
 										"Zeng-Hu Pharmaceuticals" = 'icons/mob/augmentation/zhpipc.dmi'
 										))
+
+GLOBAL_LIST_EMPTY(hairstyle_cache)
+GLOBAL_LIST_EMPTY(face_hairstyle_cache)

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -15,11 +15,11 @@
 	H.body_type = H.gender
 	H.real_name = random_unique_name(H.gender)
 	H.name = H.real_name
-	H.underwear = random_underwear(H.gender)
+	H.underwear = random_underwear(H.gender, H.dna.species)
 	H.underwear_color = random_short_color()
 	H.skin_tone = random_skin_tone()
-	H.hairstyle = random_hairstyle(H.gender)
-	H.facial_hairstyle = random_facial_hairstyle(H.gender)
+	H.hairstyle = random_hairstyle(H.gender, H.dna.species)
+	H.facial_hairstyle = random_facial_hairstyle(H.gender, H.dna.species)
 	H.hair_color = random_short_color()
 	H.facial_hair_color = H.hair_color
 	H.eye_color = random_eye_color()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -197,11 +197,11 @@
 	if(hairstyle)
 		H.hairstyle = hairstyle
 	else
-		H.hairstyle = random_hairstyle(H.gender)
+		H.hairstyle = random_hairstyle(H.gender, H.dna.species)
 	if(facial_hairstyle)
 		H.facial_hairstyle = facial_hairstyle
 	else
-		H.facial_hairstyle = random_facial_hairstyle(H.gender)
+		H.facial_hairstyle = random_facial_hairstyle(H.gender, H.dna.species)
 	if(haircolor)
 		H.hair_color = haircolor
 	else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -85,7 +85,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/datum/species/pref_species = new /datum/species/human() //Mutant race
 	//Has to include all information that extra organs from mutant bodyparts would need.
 	var/list/features = MANDATORY_FEATURE_LIST
-	var/list/randomise = list(RANDOM_UNDERWEAR = TRUE, RANDOM_UNDERWEAR_COLOR = TRUE, RANDOM_UNDERSHIRT = TRUE, RANDOM_SOCKS = TRUE, RANDOM_BACKPACK = TRUE, RANDOM_JUMPSUIT_STYLE = TRUE, RANDOM_HAIRSTYLE = TRUE, RANDOM_HAIR_COLOR = TRUE, RANDOM_FACIAL_HAIRSTYLE = TRUE, RANDOM_FACIAL_HAIR_COLOR = TRUE, RANDOM_SKIN_TONE = TRUE, RANDOM_EYE_COLOR = TRUE)
 	var/phobia = "spiders"
 
 	var/list/custom_names = list()
@@ -346,10 +345,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(is_banned_from(user.ckey, "Appearance"))
 						dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
 					dat += "<a href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_NAME]'>Always Random Name: [(randomise[RANDOM_NAME]) ? "Yes" : "No"]</a>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_NAME_ANTAG]'>When Antagonist: [(randomise[RANDOM_NAME_ANTAG]) ? "Yes" : "No"]</a>"
-					/*if(user.client.get_exp_living(TRUE) >= PLAYTIME_HARDCORE_RANDOM)
-						dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_HARDCORE]'>Hardcore Random: [(randomise[RANDOM_HARDCORE]) ? "Yes" : "No"]</a>"*/
 					dat += "<br><b>Name:</b> "
 					dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
 
@@ -365,15 +360,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if(gender == PLURAL || gender == NEUTER)
 							dat += "<BR><b>Body Type:</b> <a href='?_src_=prefs;preference=body_type'>[body_type == MALE ? "Male" : "Female"]</a>"
 
-						/*if(randomise[RANDOM_BODY] || randomise[RANDOM_BODY_ANTAG]) //doesn't work unless random body
-							dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_GENDER]'>Always Random Gender: [(randomise[RANDOM_GENDER]) ? "Yes" : "No"]</A>"
-							dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_GENDER_ANTAG]'>When Antagonist: [(randomise[RANDOM_GENDER_ANTAG]) ? "Yes" : "No"]</A>"*/
-
+						
 					dat += "<br><b>Age:</b> <a href='?_src_=prefs;preference=age;task=input'>[age]</a>"
-					/*if(randomise[RANDOM_BODY] || randomise[RANDOM_BODY_ANTAG]) //doesn't work unless random body
-						dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_AGE]'>Always Random Age: [(randomise[RANDOM_AGE]) ? "Yes" : "No"]</A>"
-						dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_AGE_ANTAG]'>When Antagonist: [(randomise[RANDOM_AGE_ANTAG]) ? "Yes" : "No"]</A>"*/
-
 					dat += "<br><br><b>Special Names:</b><BR>"
 					var/old_group
 					for(var/custom_name_id in GLOB.preferences_custom_names)
@@ -401,9 +389,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(1) //Appearance
 					dat += "<h2>Body</h2>"
 					dat += "<a href='?_src_=prefs;preference=all;task=random'>Random Body</A> "
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_BODY]'>Always Random Body: [(randomise[RANDOM_BODY]) ? "Yes" : "No"]</A>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_BODY_ANTAG]'>When Antagonist: [(randomise[RANDOM_BODY_ANTAG]) ? "Yes" : "No"]</A><br>"
-
+					
 					dat += "<table width='100%'><tr><td width='17%' valign='top'>"
 					dat += "<b>Species:</b><BR><a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a><BR>"
 					dat += "<b>Species Naming:</b><BR><a href='?_src_=prefs;preference=custom_species;task=input'>[(features["custom_species"]) ? features["custom_species"] : "Default"]</a><BR>"
@@ -445,18 +431,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						dat += "[copytext(html_encode(ooc_prefs), 1, 40)]..."
 					dat += "<br>"
 
-					//dat += "<a href='?_src_=prefs;preference=species;task=random'>Random Species</A> "
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_SPECIES]'>Always Random Species: [(randomise[RANDOM_SPECIES]) ? "Yes" : "No"]</A><br>"
-
+					
 					var/use_skintones = pref_species.use_skintones
 					if(use_skintones)
 
 						dat += APPEARANCE_CATEGORY_COLUMN
 
 						dat += "<h3>Skin Tone</h3>"
-
 						dat += "<a href='?_src_=prefs;preference=s_tone;task=input'>[skin_tone]</a>"
-						//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_SKIN_TONE]'>[(randomise[RANDOM_SKIN_TONE]) ? "Lock" : "Unlock"]</A>"
 						dat += "<br>"
 
 
@@ -489,8 +471,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 						dat += "<h3>Eye Color</h3>"
 						dat += "<a href='?_src_=prefs;preference=eyes;task=input'><span class='color_holder_box' style='background-color:#[eye_color]'></span></a>"
-						//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_EYE_COLOR]'>[(randomise[RANDOM_EYE_COLOR]) ? "Lock" : "Unlock"]</A>"
-
+						
 						dat += "<br></td>"
 					else if(use_skintones)
 						dat += "</td>"
@@ -501,21 +482,17 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 						dat += "<h3>Hairstyle</h3>"
 
-						dat += "<a href='?_src_=prefs;preference=hairstyle;task=input'>[hairstyle]</a>"
 						dat += "<a href='?_src_=prefs;preference=previous_hairstyle;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_hairstyle;task=input'>&gt;</a>"
-						//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_HAIRSTYLE]'>[(randomise[RANDOM_HAIRSTYLE]) ? "Lock" : "Unlock"]</A>"
-
+						dat += "<a href='?_src_=prefs;preference=hairstyle;task=input'>[hairstyle]</a>"
+						
 						dat += "<br> <a href='?_src_=prefs;preference=hair;task=input'><span class='color_holder_box' style='background-color:#[hair_color]'></span></a>"
-						//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_HAIR_COLOR]'>[(randomise[RANDOM_HAIR_COLOR]) ? "Lock" : "Unlock"]</A>"
-
+						
 						dat += "<BR><h3>Facial Hairstyle</h3>"
 
-						dat += "<a href='?_src_=prefs;preference=facial_hairstyle;task=input'>[facial_hairstyle]</a>"
 						dat += "<a href='?_src_=prefs;preference=previous_facehairstyle;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_facehairstyle;task=input'>&gt;</a>"
-						//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_FACIAL_HAIRSTYLE]'>[(randomise[RANDOM_FACIAL_HAIRSTYLE]) ? "Lock" : "Unlock"]</A>"
-
+						dat += "<a href='?_src_=prefs;preference=facial_hairstyle;task=input'>[facial_hairstyle]</a>"
+						
 						dat += "<br> <a href='?_src_=prefs;preference=facial;task=input'><span class='color_holder_box' style='background-color:#[facial_hair_color]'></span></a>"
-						//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_FACIAL_HAIR_COLOR]'>[(randomise[RANDOM_FACIAL_HAIR_COLOR]) ? "Lock" : "Unlock"]</A>"
 						dat += "<br></td>"
 
 					//Mutant stuff
@@ -547,25 +524,19 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "<table width='100%'><tr><td width='24%' valign='top'>"
 
 					dat += "<BR><b>Underwear:</b><BR><a href ='?_src_=prefs;preference=underwear;task=input'>[underwear]</a>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_UNDERWEAR]'>[(randomise[RANDOM_UNDERWEAR]) ? "Lock" : "Unlock"]</A>"
-
+					
 					dat += "<a href='?_src_=prefs;preference=underwear_color;task=input'><span class='color_holder_box' style='background-color:#[underwear_color]'></span></a>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_UNDERWEAR_COLOR]'>[(randomise[RANDOM_UNDERWEAR_COLOR]) ? "Lock" : "Unlock"]</A>"
-
+					
 					dat += "<BR><b>Undershirt:</b><BR><a href ='?_src_=prefs;preference=undershirt;task=input'>[undershirt]</a>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_UNDERSHIRT]'>[(randomise[RANDOM_UNDERSHIRT]) ? "Lock" : "Unlock"]</A>"
 					dat += "<a href='?_src_=prefs;preference=undershirt_color;task=input'><span class='color_holder_box' style='background-color:#[undershirt_color]'></span></a>"
 
 					dat += "<br><b>Socks:</b><BR><a href ='?_src_=prefs;preference=socks;task=input'>[socks]</a>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_SOCKS]'>[(randomise[RANDOM_SOCKS]) ? "Lock" : "Unlock"]</A>"
 					dat += "<a href='?_src_=prefs;preference=socks_color;task=input'><span class='color_holder_box' style='background-color:#[socks_color]'></span></a>"
 
 					dat += "<br><b>Jumpsuit Style:</b><BR><a href ='?_src_=prefs;preference=suit;task=input'>[jumpsuit_style]</a>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_JUMPSUIT_STYLE]'>[(randomise[RANDOM_JUMPSUIT_STYLE]) ? "Lock" : "Unlock"]</A>"
-
+					
 					dat += "<br><b>Backpack:</b><BR><a href ='?_src_=prefs;preference=bag;task=input'>[backpack]</a>"
-					//dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_BACKPACK]'>[(randomise[RANDOM_BACKPACK]) ? "Lock" : "Unlock"]</A>"
-
+					
 					if((HAS_FLESH in pref_species.species_traits) || (HAS_BONE in pref_species.species_traits))
 						dat += "<BR><b>Temporal Scarring:</b><BR><a href='?_src_=prefs;preference=persistent_scars'>[(persistent_scars) ? "Enabled" : "Disabled"]</A>"
 						dat += "<a href='?_src_=prefs;preference=clear_scars'>Clear scar slots</A>"
@@ -1702,12 +1673,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						list("Yes", "No")
 					)
 					if(action && action == "Yes")
-						var/list/candidates = GLOB.body_marking_sets.Copy()
-						if(!mismatched_customization)
-							for(var/name in candidates)
-								var/datum/body_marking_set/BMS = GLOB.body_marking_sets[name]
-								if(BMS.recommended_species && !(pref_species.id in BMS.recommended_species))
-									candidates -= name
+						var/list/candidates = marking_sets_for_species(pref_species, mismatched_customization)
 						if(length(candidates) == 0)
 							return
 						var/desired_set = input(user, "Choose your new body markings:", "Character Preference") as null|anything in candidates
@@ -1759,7 +1725,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/zone = href_list["key"]
 					if(!GLOB.body_markings_per_limb[zone])
 						return
-					var/list/possible_candidates = GLOB.body_markings_per_limb[zone].Copy()
+					var/list/possible_candidates = marking_list_of_zone_for_species(zone, pref_species, mismatched_customization)
 					if(body_markings[zone])
 						//To prevent exploiting hrefs to bypass the marking limit
 						if(body_markings[zone].len >= MAXIMUM_MARKINGS_PER_LIMB)
@@ -1767,11 +1733,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						//Remove already used markings from the candidates
 						for(var/list/this_list in body_markings[zone])
 							possible_candidates -= this_list[MUTANT_INDEX_NAME]
-					if(!mismatched_customization)
-						for(var/name in possible_candidates)
-							var/datum/body_marking/BD = GLOB.body_markings[name]
-							if((BD.recommended_species && !(pref_species.id in BD.recommended_species)))
-								possible_candidates -= name
 
 					if(possible_candidates.len == 0)
 						return
@@ -1794,16 +1755,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/zone = href_list["key"]
 					var/changing_name = href_list["name"]
 
-					var/list/possible_candidates = GLOB.body_markings_per_limb[zone].Copy()
+					var/list/possible_candidates = marking_list_of_zone_for_species(zone, pref_species, mismatched_customization)
 					if(body_markings[zone])
 						//Remove already used markings from the candidates
 						for(var/keyed_name in body_markings[zone])
 							possible_candidates -= keyed_name
-					if(!mismatched_customization)
-						for(var/name in possible_candidates)
-							var/datum/body_marking/BD = GLOB.body_markings[name]
-							if(BD.recommended_species && !(pref_species.id in BD.recommended_species))
-								possible_candidates -= name
 					if(possible_candidates.len == 0)
 						return
 					var/desired_marking = input(user, "Choose a marking to change the current one to:", "Character Preference") as null|anything in possible_candidates
@@ -1907,19 +1863,19 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("hair")
 					hair_color = random_short_color()
 				if("hairstyle")
-					hairstyle = random_hairstyle(gender)
+					hairstyle = random_hairstyle(gender, pref_species)
 				if("facial")
 					facial_hair_color = random_short_color()
 				if("facial_hairstyle")
-					facial_hairstyle = random_facial_hairstyle(gender)
+					facial_hairstyle = random_facial_hairstyle(gender, pref_species)
 				if("underwear")
-					underwear = random_underwear(gender)
+					underwear = random_underwear(gender, pref_species)
 				if("underwear_color")
 					underwear_color = random_short_color()
 				if("undershirt")
-					undershirt = random_undershirt(gender)
+					undershirt = random_undershirt(gender, pref_species)
 				if("socks")
-					socks = random_socks()
+					socks = random_socks(pref_species)
 				if(BODY_ZONE_PRECISE_EYES)
 					eye_color = random_eye_color()
 				if("s_tone")
@@ -2152,17 +2108,17 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("hairstyle")
 					needs_update = TRUE
-					var/new_hairstyle = input(user, "Choose your character's hairstyle:", "Character Preference")  as null|anything in GLOB.hairstyles_list
+					var/new_hairstyle = input(user, "Choose your character's hairstyle:", "Character Preference")  as null|anything in hairstyle_list_for_species(pref_species, null, mismatched_customization)
 					if(new_hairstyle)
 						hairstyle = new_hairstyle
 
 				if("next_hairstyle")
+					next_hairstyle()
 					needs_update = TRUE
-					hairstyle = next_list_item(hairstyle, GLOB.hairstyles_list)
 
 				if("previous_hairstyle")
+					prev_hairstyle()
 					needs_update = TRUE
-					hairstyle = previous_list_item(hairstyle, GLOB.hairstyles_list)
 
 				if("facial")
 					needs_update = TRUE
@@ -2172,20 +2128,20 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("facial_hairstyle")
 					needs_update = TRUE
-					var/new_facial_hairstyle = input(user, "Choose your character's facial-hairstyle:", "Character Preference")  as null|anything in GLOB.facial_hairstyles_list
+					var/new_facial_hairstyle = input(user, "Choose your character's facial-hairstyle:", "Character Preference")  as null|anything in facial_hairstyle_list_for_species(pref_species, null, mismatched_customization)
 					if(new_facial_hairstyle)
 						facial_hairstyle = new_facial_hairstyle
 
 				if("next_facehairstyle")
+					next_face_hairstyle()
 					needs_update = TRUE
-					facial_hairstyle = next_list_item(facial_hairstyle, GLOB.facial_hairstyles_list)
 
 				if("previous_facehairstyle")
+					prev_face_hairstyle()
 					needs_update = TRUE
-					facial_hairstyle = previous_list_item(facial_hairstyle, GLOB.facial_hairstyles_list)
 
 				if("underwear")
-					var/new_underwear = input(user, "Choose your character's underwear:", "Character Preference")  as null|anything in GLOB.underwear_list
+					var/new_underwear = input(user, "Choose your character's underwear:", "Character Preference")  as null|anything in underwear_list_for_species(pref_species, null, mismatched_customization)
 					if(new_underwear)
 						underwear = new_underwear
 
@@ -2209,14 +2165,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("undershirt")
 					needs_update = TRUE
-					var/new_undershirt = input(user, "Choose your character's undershirt:", "Character Preference") as null|anything in GLOB.undershirt_list
+					var/new_undershirt = input(user, "Choose your character's undershirt:", "Character Preference") as null|anything in undershirt_list_for_species(pref_species, null, mismatched_customization)
 					if(new_undershirt)
 						undershirt = new_undershirt
 
 				if("socks")
 					needs_update = TRUE
 					var/new_socks
-					new_socks = input(user, "Choose your character's socks:", "Character Preference") as null|anything in GLOB.socks_list
+					new_socks = input(user, "Choose your character's socks:", "Character Preference") as null|anything in socks_list_for_species(pref_species, mismatched_customization)
 					if(new_socks)
 						socks = new_socks
 
@@ -2641,13 +2597,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					else
 						be_special += be_special_type
 
-				if("toggle_random")
-					var/random_type = href_list["random_type"]
-					if(randomise[random_type])
-						randomise -= random_type
-					else
-						randomise[random_type] = TRUE
-
 				if("persistent_scars")
 					persistent_scars = !persistent_scars
 
@@ -2829,18 +2778,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, icon_updates = 1, roundstart_checks = TRUE, character_setup = FALSE, antagonist = FALSE, is_latejoiner = TRUE)
 
 	hardcore_survival_score = 0 //Set to 0 to prevent you getting points from last another time.
-
-	/*if((randomise[RANDOM_SPECIES] || randomise[RANDOM_HARDCORE]) && !character_setup)
-		random_species()
-	if((randomise[RANDOM_BODY] || (randomise[RANDOM_BODY_ANTAG] && antagonist) || randomise[RANDOM_HARDCORE]) && !character_setup)
-		slot_randomized = TRUE
-		random_character(gender, antagonist)
-	if((randomise[RANDOM_NAME] || (randomise[RANDOM_NAME_ANTAG] && antagonist) || randomise[RANDOM_HARDCORE]) && !character_setup)
-		slot_randomized = TRUE
-		real_name = pref_species.random_name(gender)
-	if(randomise[RANDOM_HARDCORE] && parent.mob.mind && !character_setup)
-		if(can_be_random_hardcore())
-			hardcore_random_setup(character, antagonist, is_latejoiner)*/
 
 	if(roundstart_checks)
 		if(CONFIG_GET(flag/humans_need_surnames) && (pref_species.id == "human"))
@@ -3197,3 +3134,55 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	popup.set_window_options("can_close=0")
 	popup.set_content(dat.Join())
 	popup.open(FALSE)
+
+/datum/preferences/proc/get_hairstyle_cache(datum/species/species, mismatched)
+	var/cache_key = mismatched ? ALL_BODYTYPES : species.bodytype
+	if(!GLOB.hairstyle_cache["[cache_key]"])
+		GLOB.hairstyle_cache["[cache_key]"] = hairstyle_list_for_species(species, null, mismatched)
+	return GLOB.hairstyle_cache["[cache_key]"]
+
+/datum/preferences/proc/get_face_hairstyle_cache(datum/species/species, mismatched)
+	var/cache_key = mismatched ? ALL_BODYTYPES : species.bodytype
+	if(!GLOB.face_hairstyle_cache["[cache_key]"])
+		GLOB.face_hairstyle_cache["[cache_key]"] = facial_hairstyle_list_for_species(species, null, mismatched)
+	return GLOB.face_hairstyle_cache["[cache_key]"]
+
+/datum/preferences/proc/next_hairstyle()
+	var/list/our_list = get_hairstyle_cache(pref_species, mismatched_customization)
+	var/index = our_list.Find(hairstyle)
+	if(!index)
+		return
+	if(our_list.len == index)
+		hairstyle = our_list[1]
+	else
+		hairstyle = our_list[index+1]
+
+/datum/preferences/proc/prev_hairstyle()
+	var/list/our_list = get_hairstyle_cache(pref_species, mismatched_customization)
+	var/index = our_list.Find(hairstyle)
+	if(!index)
+		return
+	if(index == 1)
+		hairstyle = our_list[our_list.len]
+	else
+		hairstyle = our_list[index-1]
+
+/datum/preferences/proc/next_face_hairstyle()
+	var/list/our_list = get_face_hairstyle_cache(pref_species, mismatched_customization)
+	var/index = our_list.Find(facial_hairstyle)
+	if(!index)
+		return
+	if(our_list.len == index)
+		facial_hairstyle = our_list[1]
+	else
+		facial_hairstyle = our_list[index+1]
+
+/datum/preferences/proc/prev_face_hairstyle()
+	var/list/our_list = get_face_hairstyle_cache(pref_species, mismatched_customization)
+	var/index = our_list.Find(facial_hairstyle)
+	if(!index)
+		return
+	if(index == 1)
+		facial_hairstyle = our_list[our_list.len]
+	else
+		facial_hairstyle = our_list[index-1]

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -407,7 +407,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["uplink_loc"], uplink_spawn_loc)
 	READ_FILE(S["playtime_reward_cloak"], playtime_reward_cloak)
 	READ_FILE(S["phobia"], phobia)
-	READ_FILE(S["randomise"],  randomise)
 
 	//Custom names
 	for(var/custom_name_id in GLOB.preferences_custom_names)
@@ -451,8 +450,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		custom_names[custom_name_id] = reject_bad_name(custom_names[custom_name_id],namedata["allow_numbers"])
 		if(!custom_names[custom_name_id])
 			custom_names[custom_name_id] = get_default_name(custom_name_id)
-
-	randomise = SANITIZE_LIST(randomise)
 
 	hairstyle = sanitize_inlist(hairstyle, GLOB.hairstyles_list)
 	facial_hairstyle = sanitize_inlist(facial_hairstyle, GLOB.facial_hairstyles_list)
@@ -622,7 +619,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["jumpsuit_style"] , jumpsuit_style)
 	WRITE_FILE(S["uplink_loc"] , uplink_spawn_loc)
 	WRITE_FILE(S["playtime_reward_cloak"] , playtime_reward_cloak)
-	WRITE_FILE(S["randomise"] , randomise)
 	WRITE_FILE(S["species"] , pref_species.id)
 	WRITE_FILE(S["phobia"], phobia)
 	WRITE_FILE(S["persistent_scars"], persistent_scars)

--- a/code/modules/mob/dead/new_player/body_markings/body_marking_sets.dm
+++ b/code/modules/mob/dead/new_player/body_markings/body_marking_sets.dm
@@ -5,11 +5,14 @@
 	var/body_marking_list
 	///Which species is this marking recommended to. Important for randomisations.
 	var/recommended_species = list("mammal", "tajaran", "vulpkanin", "aquatic", "akula")
+	/// Bodytypes which can access this marking set. (This can be bypassed by mismatched parts anyway)
+	var/bodytypes = GENERIC_BODYTYPES
 
 /datum/body_marking_set/none
 	name = "None"
 	recommended_species = null
 	body_marking_list = list()
+	bodytypes = ALL_BODYTYPES
 
 /datum/body_marking_set/tajaran
 	name = "Tajaran"

--- a/code/modules/mob/dead/new_player/body_markings/body_markings.dm
+++ b/code/modules/mob/dead/new_player/body_markings/body_markings.dm
@@ -18,6 +18,8 @@
 	var/always_color_customizable
 	///Whether the body marking sprite is the same for both sexes or not. Only relevant for chest right now.
 	var/gendered = TRUE
+	/// Bodytypes which can access this marking. (This can be bypassed by mismatched parts anyway)
+	var/bodytypes = GENERIC_BODYTYPES
 
 /datum/body_marking/New()
 	if(!default_color)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -1,43 +1,27 @@
 
 	//The mob should have a gender you want before running this proc. Will run fine without H
 /datum/preferences/proc/random_character(gender_override, antag_override = FALSE)
-	if(randomise[RANDOM_SPECIES])
-		random_species()
-	else if(randomise[RANDOM_NAME])
-		real_name = pref_species.random_name(gender,1)
-	if(gender_override && !(randomise[RANDOM_GENDER] || randomise[RANDOM_GENDER_ANTAG] && antag_override))
-		gender = gender_override
-	else
-		gender = pick(MALE,FEMALE,PLURAL)
-	if(randomise[RANDOM_AGE] || randomise[RANDOM_AGE_ANTAG] && antag_override)
-		age = rand(AGE_MIN,AGE_MAX)
-	if(randomise[RANDOM_UNDERWEAR])
-		underwear = random_underwear(gender)
-	if(randomise[RANDOM_UNDERWEAR_COLOR])
-		underwear_color = random_short_color()
-	if(randomise[RANDOM_UNDERSHIRT])
-		undershirt = random_undershirt(gender)
-	if(randomise[RANDOM_SOCKS])
-		socks = random_socks()
-	if(randomise[RANDOM_BACKPACK])
-		backpack = random_backpack()
-	if(randomise[RANDOM_JUMPSUIT_STYLE])
-		jumpsuit_style = pick(GLOB.jumpsuitlist)
-	if(randomise[RANDOM_HAIRSTYLE])
-		hairstyle = random_hairstyle(gender)
-	if(randomise[RANDOM_FACIAL_HAIRSTYLE])
-		facial_hairstyle = random_facial_hairstyle(gender)
-	if(randomise[RANDOM_HAIR_COLOR])
-		hair_color = random_short_color()
-	if(randomise[RANDOM_FACIAL_HAIR_COLOR])
-		facial_hair_color = random_short_color()
-	if(randomise[RANDOM_SKIN_TONE])
-		set_skin_tone(random_skin_tone())
-	if(randomise[RANDOM_EYE_COLOR])
-		eye_color = random_eye_color()
 	if(!pref_species)
 		var/rando_race = pick(GLOB.roundstart_races)
 		set_new_species(rando_race)
+	real_name = pref_species.random_name(gender,1)
+	if(gender_override)
+		gender = gender_override
+	else
+		gender = pick(MALE,FEMALE,PLURAL)
+	age = rand(AGE_MIN,AGE_MAX)
+	underwear = random_underwear(gender, pref_species)
+	underwear_color = random_short_color()
+	undershirt = random_undershirt(gender, pref_species)
+	socks = random_socks(pref_species)
+	backpack = random_backpack()
+	jumpsuit_style = pick(GLOB.jumpsuitlist)
+	hairstyle = random_hairstyle(gender, pref_species)
+	facial_hairstyle = random_facial_hairstyle(gender, pref_species)
+	hair_color = random_short_color()
+	facial_hair_color = random_short_color()
+	set_skin_tone(random_skin_tone())
+	eye_color = random_eye_color()
 	if(gender in list(MALE, FEMALE))
 		body_type = gender
 	else
@@ -48,12 +32,11 @@
 		features[key] = new_features[key]
 	mutant_bodyparts = pref_species.get_random_mutant_bodyparts(features)
 	body_markings = pref_species.get_random_body_markings(features)
+	needs_update = TRUE
 
 /datum/preferences/proc/random_species()
 	var/random_species_type = GLOB.species_list[pick(GLOB.roundstart_races)]
 	set_new_species(random_species_type)
-	if(randomise[RANDOM_NAME])
-		real_name = pref_species.random_name(gender,1)
 
 ///Setup a hardcore random character and calculate their hardcore random score
 /datum/preferences/proc/hardcore_random_setup(mob/living/carbon/human/character, antagonist, is_latejoiner)
@@ -196,11 +179,7 @@
 
 /datum/preferences/proc/set_new_species(new_species_path)
 	pref_species = new new_species_path()
-	var/list/new_features = pref_species.get_random_features() //We do this to keep flavor text, genital sizes etc.
-	for(var/key in new_features)
-		features[key] = new_features[key]
-	mutant_bodyparts = pref_species.get_random_mutant_bodyparts(features)
-	body_markings = pref_species.get_random_body_markings(features)
+	random_character(FALSE, antag_override = FALSE)
 	if(pref_species.use_skintones)
 		features["uses_skintones"] = TRUE
 	//We reset the quirk-based stuff

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -29,12 +29,13 @@
 			var/datum/sprite_accessory/P = path
 			if(initial(P.locked))
 				continue
-		var/datum/sprite_accessory/D = new path()
+		var/datum/sprite_accessory/D = path
+		if(!initial(D.name))
+			continue
 
-		if(D.icon_state)
-			L[D.name] = D
-		else
-			L += D.name
+		D = new path()
+
+		L[D.name] = D
 
 		switch(D.gender)
 			if(MALE)
@@ -117,6 +118,8 @@
 	var/extra2_color_src
 	///If defined, the accessory will be only available to ckeys inside the list. ITS ASSOCIATIVE, ie. ("ckey" = TRUE). For speed
 	var/list/ckey_whitelist
+	/// Bodytypes which can access this accessory. (This can be bypassed by mismatched parts anyway)
+	var/bodytypes = GENERIC_BODYTYPES
 
 /datum/sprite_accessory/New()
 	if(!default_color)

--- a/code/modules/mob/dead/new_player/sprite_accessories/hair.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/hair.dm
@@ -3,6 +3,7 @@
 //////////////////////
 /datum/sprite_accessory/hair
 	icon = 'icons/mob/human_face.dmi'	  // default icon for all hairs
+	bodytypes = BODYTYPE_HUMANOID
 
 	// please make sure they're sorted alphabetically and, where needed, categorized
 	// try to capitalize the names please~
@@ -28,6 +29,7 @@
 /datum/sprite_accessory/hair/bald
 	name = "Bald"
 	icon_state = null
+	bodytypes = ALL_BODYTYPES
 
 /datum/sprite_accessory/hair/balding
 	name = "Balding Hair"
@@ -932,6 +934,7 @@
 /datum/sprite_accessory/facial_hair
 	icon = 'icons/mob/human_face.dmi'
 	gender = MALE // barf (unless you're a dorf, dorfs dig chix w/ beards :P)
+	bodytypes = BODYTYPE_HUMANOID
 
 // please make sure they're sorted alphabetically and categorized
 
@@ -1079,6 +1082,7 @@
 	name = "Shaved"
 	icon_state = null
 	gender = NEUTER
+	bodytypes = ALL_BODYTYPES
 
 /datum/sprite_accessory/facial_hair/sideburns
 	name = "Sideburns"

--- a/code/modules/mob/dead/new_player/sprite_accessories/underwear.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/underwear.dm
@@ -16,6 +16,7 @@
 	name = "Nude"
 	icon_state = null
 	gender = NEUTER
+	bodytypes = ALL_BODYTYPES
 
 /datum/sprite_accessory/underwear/male_briefs
 	name = "Men's Briefs"
@@ -319,6 +320,7 @@
 	name = "Nude"
 	icon_state = null
 	gender = NEUTER
+	bodytypes = ALL_BODYTYPES
 
 // please make sure they're sorted alphabetically and categorized
 
@@ -763,6 +765,7 @@
 /datum/sprite_accessory/socks/nude
 	name = "Nude"
 	icon_state = null
+	bodytypes = ALL_BODYTYPES
 
 // please make sure they're sorted alphabetically and categorized
 

--- a/code/modules/mob/dead/new_player/sprite_accessories/vox.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/vox.dm
@@ -10,6 +10,7 @@
 /datum/sprite_accessory/hair/vox
 	icon = 'icons/mob/sprite_accessory/vox_hair.dmi'
 	recommended_species = list("vox")
+	bodytypes = BODYTYPE_VOX
 
 /datum/sprite_accessory/hair/vox/vox_afro
 	name = "Vox Afro"
@@ -71,6 +72,7 @@
 /datum/sprite_accessory/facial_hair/vox
 	icon = 'icons/mob/sprite_accessory/vox_facial_hair.dmi'
 	recommended_species = list("vox")
+	bodytypes = BODYTYPE_VOX
 
 /datum/sprite_accessory/facial_hair/vox/vox_beard
 	name = "Vox Beard"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -794,11 +794,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if((!client) || (!client.prefs))
 		return
 
-	if(client.prefs.randomise[RANDOM_NAME])
-		client.prefs.real_name = random_unique_name(gender)
-	if(client.prefs.randomise[RANDOM_BODY])
-		client.prefs.random_character(gender)
-
 	if(HAIR in client.prefs.pref_species.species_traits)
 		hairstyle = client.prefs.hairstyle
 		hair_color = brighten_color(client.prefs.hair_color)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -596,7 +596,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 
 	if(H.facial_hairstyle && (FACEHAIR in species_traits) && (!facialhair_hidden || dynamic_fhair_suffix))
 		S = GLOB.facial_hairstyles_list[H.facial_hairstyle]
-		if(S)
+		if(S.icon_state)
 
 			//List of all valid dynamic_fhair_suffixes
 			var/static/list/fextensions
@@ -663,7 +663,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 
 		else if(H.hairstyle && (HAIR in species_traits))
 			S = GLOB.hairstyles_list[H.hairstyle]
-			if(S)
+			if(S.icon_state)
 
 				//List of all valid dynamic_hair_suffixes
 				var/static/list/extensions
@@ -1081,14 +1081,14 @@ GLOBAL_LIST_EMPTY(customizable_races)
 
 ///Proc that will randomise the hair, or primary appearance element (i.e. for moths wings) of a species' associated mob
 /datum/species/proc/randomize_main_appearance_element(mob/living/carbon/human/human_mob)
-	human_mob.hairstyle = random_hairstyle(human_mob.gender)
+	human_mob.hairstyle = random_hairstyle(human_mob.gender, human_mob.dna.species)
 	human_mob.update_hair()
 
 ///Proc that will randomise the underwear (i.e. top, pants and socks) of a species' associated mob
 /datum/species/proc/randomize_active_underwear(mob/living/carbon/human/human_mob)
-	human_mob.undershirt = random_undershirt(human_mob.gender)
-	human_mob.underwear = random_underwear(human_mob.gender)
-	human_mob.socks = random_socks(human_mob.gender)
+	human_mob.undershirt = random_undershirt(human_mob.gender, human_mob.dna.species)
+	human_mob.underwear = random_underwear(human_mob.gender, human_mob.dna.species)
+	human_mob.socks = random_socks(human_mob.dna.species)
 	human_mob.update_body()
 
 /datum/species/proc/spec_life(mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -33,7 +33,6 @@
 /mob/living/simple_animal/hostile/zombie/proc/setup_visuals()
 	var/datum/preferences/dummy_prefs = new
 	dummy_prefs.pref_species = new /datum/species/zombie
-	dummy_prefs.randomise[RANDOM_BODY] = TRUE
 	var/datum/job/J = SSjob.GetJob(zombiejob)
 	var/datum/outfit/O
 	if(J.outfit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Underwear, undershirts and socks now have bodytype restrictions
Hairstyles and facial hairstyles now have bodytype restrictions
Markings and marking sets now have bodytype restrictions
Mutant parts now have bodytype restrictions
All bodytype restrictions can be bypassed with mismatched parts if you wanna make abominations
By the effect of those changes, Voxes will now randomize into their special hair, and their hair will be unable to be picked by people not having mismatched parts (and not be able to be randomized into)
Moved the hairstyle next and previous change arrows before the hairstyle name
Hairstyles now use a smart cache for getting the next/previous one, to ensure the right types are in the pool
Selecting a new species now properly randomizes everything except features
Fixes a small memory leak with initialized sprite accessory datums
Fixed abstract sprite accessory datums being initialized
Fixed new save slot characters not updating your preview
Removed all things related to "randomise pref" TG leftover
Removed duplicate and improved some code in preferences

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Teshari soon?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed a couple minor bugs regarding preferences
code: Backend for bodytype restrictions have been introduced for hairstyles, underwear, markings and mutant parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
