### PR TITLE
Trader Adjustments

### DIFF
--- a/code/modules/trading/bought_goods/food.dm
+++ b/code/modules/trading/bought_goods/food.dm
@@ -1,0 +1,84 @@
+// Alphabetized by trader. Any trader can use these datums, but this keeps things a bit more organized.
+
+/////////Chinese Restaurant/////////
+
+/datum/bought_goods/carpmeat // 75-225
+	name = "carp fillets"
+	cost = 15
+	trading_types = list(/obj/item/food/fishmeat/carp = TRADER_THIS_TYPE)
+	stock_high = 15
+	stock_low = 5
+
+/datum/bought_goods/cabbage // 25-50c
+	name = "cabbages"
+	cost = 5
+	trading_types = list(/obj/item/food/grown/cabbage = TRADER_THIS_TYPE)
+	stock_high = 10
+	stock_low = 5
+
+/datum/bought_goods/pastrybase // 30-60c
+	name = "pastry bases"
+	cost = 3
+	trading_types = list(/obj/item/food/rawpastrybase = TRADER_THIS_TYPE)
+	stock_high = 20
+	stock_low = 10
+
+/////////Farming Apprentice/////////
+
+/datum/bought_goods/eggs // 60-120c
+	name = "eggs"
+	cost = 5
+	trading_types = list(/obj/item/food/egg = TRADER_THIS_TYPE)
+	stock_high = 24
+	stock_low = 12
+
+/datum/bought_goods/produce // 50-100c
+	name = "grown produce"
+	cost = 5
+	trading_types = list(/obj/item/food/grown/ = TRADER_THIS_TYPE)
+	stock_high = 20
+	stock_low = 10
+
+/datum/bought_goods/logs // 60-120c
+	name = "towercap logs"
+	cost = 10
+	trading_types = list(/obj/item/grown/log = TRADER_THIS_TYPE)
+	stock_high = 12
+	stock_low = 6
+
+/////////Pizza Shop Employee/////////
+
+/datum/bought_goods/dough // 50-100c
+	name = "dough"
+	cost = 5
+	trading_types = list(/obj/item/food/dough = TRADER_THIS_TYPE)
+	stock_high = 10
+	stock_low = 5
+
+/datum/bought_goods/tomato // 25-50c
+	name = "tomatos"
+	cost = 5
+	trading_types = list(/obj/item/food/grown/tomato = TRADER_THIS_TYPE)
+	stock_high = 10
+	stock_low = 5
+
+/datum/bought_goods/cheesewheels // 30-75c
+	name = "cheese wheels"
+	cost = 15
+	trading_types = list(/obj/item/food/cheese/wheel = TRADER_THIS_TYPE)
+	stock_high = 5
+	stock_low = 2
+
+/datum/bought_goods/chanterelle // 50-100c
+	name = "chanterelle clusters"
+	cost = 5
+	trading_types = list(/obj/item/food/grown/mushroom/chanterelle = TRADER_THIS_TYPE)
+	stock_high = 20
+	stock_low = 10
+
+/datum/bought_goods/pineapple // 50-100c
+	name = "pineapples"
+	cost = 10
+	trading_types = list(/obj/item/food/grown/pineapple = TRADER_THIS_TYPE)
+	stock_high = 10
+	stock_low = 5

--- a/code/modules/trading/bought_goods/food.dm
+++ b/code/modules/trading/bought_goods/food.dm
@@ -35,7 +35,7 @@
 /datum/bought_goods/produce // 80-160c
 	name = "grown produce"
 	cost = 10
-	trading_types = list(/obj/item/food/grown/ = TRADER_THIS_TYPE)
+	trading_types = list(/obj/item/food/grown = TRADER_SUBTYPES)
 	stock_high = 16
 	stock_low = 8
 

--- a/code/modules/trading/bought_goods/food.dm
+++ b/code/modules/trading/bought_goods/food.dm
@@ -16,10 +16,10 @@
 	stock_high = 10
 	stock_low = 4
 
-/datum/bought_goods/pastrybase // 80-150c
+/datum/bought_goods/batter // 80-150c
 	name = "cake batter"
 	cost = 10
-	trading_types = list(/obj/item/food/rawpastrybase = TRADER_THIS_TYPE)
+	trading_types = list(/obj/item/food/cakebatter = TRADER_THIS_TYPE)
 	stock_high = 15
 	stock_low = 8
 

--- a/code/modules/trading/bought_goods/food.dm
+++ b/code/modules/trading/bought_goods/food.dm
@@ -2,83 +2,83 @@
 
 /////////Chinese Restaurant/////////
 
-/datum/bought_goods/carpmeat // 75-225
+/datum/bought_goods/carpmeat // 75-150
 	name = "carp fillets"
 	cost = 15
 	trading_types = list(/obj/item/food/fishmeat/carp = TRADER_THIS_TYPE)
-	stock_high = 15
-	stock_low = 5
-
-/datum/bought_goods/cabbage // 25-50c
-	name = "cabbages"
-	cost = 5
-	trading_types = list(/obj/item/food/grown/cabbage = TRADER_THIS_TYPE)
 	stock_high = 10
 	stock_low = 5
 
-/datum/bought_goods/pastrybase // 30-60c
-	name = "pastry bases"
-	cost = 3
+/datum/bought_goods/cabbage // 40-100c
+	name = "cabbages"
+	cost = 10
+	trading_types = list(/obj/item/food/grown/cabbage = TRADER_THIS_TYPE)
+	stock_high = 10
+	stock_low = 4
+
+/datum/bought_goods/pastrybase // 80-150c
+	name = "cake batter"
+	cost = 10
 	trading_types = list(/obj/item/food/rawpastrybase = TRADER_THIS_TYPE)
-	stock_high = 20
-	stock_low = 10
+	stock_high = 15
+	stock_low = 8
 
 /////////Farming Apprentice/////////
 
-/datum/bought_goods/eggs // 60-120c
+/datum/bought_goods/eggs // 80-180c
 	name = "eggs"
-	cost = 5
-	trading_types = list(/obj/item/food/egg = TRADER_THIS_TYPE)
-	stock_high = 24
-	stock_low = 12
-
-/datum/bought_goods/produce // 50-100c
-	name = "grown produce"
-	cost = 5
-	trading_types = list(/obj/item/food/grown/ = TRADER_THIS_TYPE)
-	stock_high = 20
-	stock_low = 10
-
-/datum/bought_goods/logs // 60-120c
-	name = "towercap logs"
 	cost = 10
+	trading_types = list(/obj/item/food/egg = TRADER_THIS_TYPE)
+	stock_high = 18
+	stock_low = 8
+
+/datum/bought_goods/produce // 80-160c
+	name = "grown produce"
+	cost = 10
+	trading_types = list(/obj/item/food/grown/ = TRADER_THIS_TYPE)
+	stock_high = 16
+	stock_low = 8
+
+/datum/bought_goods/logs // 90-150c
+	name = "towercap logs"
+	cost = 15
 	trading_types = list(/obj/item/grown/log = TRADER_THIS_TYPE)
-	stock_high = 12
+	stock_high = 10
 	stock_low = 6
 
 /////////Pizza Shop Employee/////////
 
-/datum/bought_goods/dough // 50-100c
+/datum/bought_goods/dough // 50-120c
 	name = "dough"
-	cost = 5
+	cost = 10
 	trading_types = list(/obj/item/food/dough = TRADER_THIS_TYPE)
-	stock_high = 10
+	stock_high = 12
 	stock_low = 5
 
-/datum/bought_goods/tomato // 25-50c
+/datum/bought_goods/tomato // 50-120c
 	name = "tomatos"
-	cost = 5
+	cost = 10
 	trading_types = list(/obj/item/food/grown/tomato = TRADER_THIS_TYPE)
-	stock_high = 10
+	stock_high = 12
 	stock_low = 5
 
-/datum/bought_goods/cheesewheels // 30-75c
+/datum/bought_goods/cheesewheels // 75-135c
 	name = "cheese wheels"
 	cost = 15
 	trading_types = list(/obj/item/food/cheese/wheel = TRADER_THIS_TYPE)
-	stock_high = 5
-	stock_low = 2
+	stock_high = 9
+	stock_low = 5
 
-/datum/bought_goods/chanterelle // 50-100c
+/datum/bought_goods/chanterelle // 72-144c
 	name = "chanterelle clusters"
-	cost = 5
+	cost = 12
 	trading_types = list(/obj/item/food/grown/mushroom/chanterelle = TRADER_THIS_TYPE)
-	stock_high = 20
-	stock_low = 10
+	stock_high = 12
+	stock_low = 6
 
-/datum/bought_goods/pineapple // 50-100c
+/datum/bought_goods/pineapple // 60-130c
 	name = "pineapples"
 	cost = 10
 	trading_types = list(/obj/item/food/grown/pineapple = TRADER_THIS_TYPE)
-	stock_high = 10
-	stock_low = 5
+	stock_high = 13
+	stock_low = 6

--- a/code/modules/trading/sold_goods/food.dm
+++ b/code/modules/trading/sold_goods/food.dm
@@ -1,14 +1,6 @@
-/datum/sold_goods/pizzabox
-	cost = 200
-	trading_types = list(/obj/item/pizzabox/margherita = TRADER_THIS_TYPE,
-						/obj/item/pizzabox/vegetable = TRADER_THIS_TYPE,
-						/obj/item/pizzabox/mushroom = TRADER_THIS_TYPE,
-						/obj/item/pizzabox/meat = TRADER_THIS_TYPE,
-						/obj/item/pizzabox/pineapple = TRADER_THIS_TYPE)
+// Alphabetized by trader. Any trader can use these datums, but this keeps things a bit more organized.
 
-/datum/sold_goods/pizzabox/two
-/datum/sold_goods/pizzabox/three
-/datum/sold_goods/pizzabox/four
+/////////Chinese Restaurant/////////
 
 /datum/sold_goods/meatkebab
 	path = /obj/item/food/kebab/monkey
@@ -22,20 +14,22 @@
 /datum/sold_goods/cupramen
 	path = /obj/item/reagent_containers/food/drinks/dry_ramen
 
+/////////Farming Apprentice/////////
+
 /datum/sold_goods/cow
 	cost = 350
 	path = /mob/living/simple_animal/cow
 
 /datum/sold_goods/goat
-	cost = 180
+	cost = 220
 	path = /mob/living/simple_animal/hostile/retaliate/goat
 
 /datum/sold_goods/chicken
-	cost = 75
+	cost = 100
 	path = /mob/living/simple_animal/chick
 
 /datum/sold_goods/wheat
-	cost = 60
+	cost = 20
 	path = /obj/item/food/grown/wheat
 
 /datum/sold_goods/pumpkin
@@ -43,5 +37,19 @@
 	path = /obj/item/food/grown/pumpkin
 
 /datum/sold_goods/corn
-	cost = 100
+	cost = 35
 	path = /obj/item/food/grown/corn
+
+/////////Pizza Shop Employee/////////
+
+/datum/sold_goods/pizzabox
+	cost = 200
+	trading_types = list(/obj/item/pizzabox/margherita = TRADER_THIS_TYPE,
+						/obj/item/pizzabox/vegetable = TRADER_THIS_TYPE,
+						/obj/item/pizzabox/mushroom = TRADER_THIS_TYPE,
+						/obj/item/pizzabox/meat = TRADER_THIS_TYPE,
+						/obj/item/pizzabox/pineapple = TRADER_THIS_TYPE)
+
+/datum/sold_goods/pizzabox/two
+/datum/sold_goods/pizzabox/three
+/datum/sold_goods/pizzabox/four

--- a/code/modules/trading/sold_goods/goods.dm
+++ b/code/modules/trading/sold_goods/goods.dm
@@ -21,16 +21,29 @@
 /////////Atmospheric Shop Employee/////////
 
 /datum/sold_goods/belt/nitrogen
-	cost = 160
+	cost = 100
 	path = /obj/item/tank/internals/nitrogen/belt
+	stock_high = 5
+	stock_low = 3
 
 /datum/sold_goods/belt/plasma
 	cost = 180
 	path = /obj/item/tank/internals/plasmaman/belt
+	stock_high = 5
+	stock_low = 3
 
 /datum/sold_goods/emergency_oxygen
-	cost = 90
+	cost = 60
 	path = /obj/item/tank/internals/emergency_oxygen
+	stock_high = 5
+	stock_low = 3
+
+/datum/sold_goods/voidsuit
+	name = "vintage space suit"
+	cost = 1250
+	path = /obj/item/storage/box/hero/astronaut
+	stock_high = 1
+	stock_low = 1
 
 /////////Clothing Store Employee/////////
 
@@ -357,8 +370,10 @@
 /////////Rock'n'Drill Mining Inc/////////
 
 /datum/sold_goods/mining_kit
-	cost = 850
+	cost = 350
 	path = /obj/item/storage/backpack/duffelbag/mining_conscript/basic
+	stock_high = 4
+	stock_low = 2
 
 /datum/sold_goods/liquid_pump
 	cost = 700

--- a/code/modules/trading/traders/food.dm
+++ b/code/modules/trading/traders/food.dm
@@ -1,14 +1,16 @@
 /datum/trader/pizzaria
 	name = "Pizza Shop Employee"
 	possible_origins = list("Papa Joe's", "Pizza Ship", "Dominator Pizza", "Little Kaezars", "Pizza Planet", "Cheese Louise", "Pizza Police")
-	trade_flags = TRADER_MONEY|TRADER_SELLS_GOODS
+	trade_flags = TRADER_MONEY|TRADER_SELLS_GOODS|TRADER_BUYS_GOODS
 	speech = list("hail"    = "Hello! Welcome to ORIGIN, may I take your order?",
 				"hail_deny"         = "Beeeep... I'm sorry, your connection has been severed.",
 
 				"trade_complete"    = "Thank you for choosing ORIGIN!",
 				"trade_no_goods"    = "I'm sorry but we only take cash.",
+				"trade_found_unwanted" = "We only need ingredients, man.",
 				"trade_not_enough"  = "Uhh... that's not enough money for pizza.",
 				"how_much"          = "That pizza will cost you VALUE credits.",
+				"what_want"         = "We could use a bit more...",
 
 				"compliment_deny"   = "That's a bit forward, don't you think?",
 				"compliment_accept" = "Thanks, sir! You're very nice!",
@@ -18,19 +20,27 @@
 								/datum/sold_goods/pizzabox/two = 100,
 								/datum/sold_goods/pizzabox/three = 100,
 								/datum/sold_goods/pizzabox/four = 100)
+	possible_bought_goods = list(/datum/bought_goods/dough = 100,
+								/datum/bought_goods/tomato = 100,
+								/datum/bought_goods/cheesewheels = 100,
+								/datum/bought_goods/chanterelle = 100,
+								/datum/bought_goods/pineapple = 100)
 	target_sold_goods_amount = 4
+	target_bought_goods_amount = 3
 
 /datum/trader/chinese
 	name = "Chinese Restaurant"
 	possible_origins = list("Captain Panda Bistro", "888 Shanghai Kitchen", "Mr. Lee's Greater Hong Kong", "The House of the Venerable and Inscrutable Colonel", "Lucky Dragon")
-	trade_flags = TRADER_MONEY|TRADER_SELLS_GOODS
+	trade_flags = TRADER_MONEY|TRADER_SELLS_GOODS|TRADER_BUYS_GOODS
 	speech = list("hail"     = "There are two things constant in life, death and Chinese food. How may I help you?",
 				"hail_deny"          = "We do not take orders from rude customers.",
 
 				"trade_complete"     = "Thank you, sir, for your patronage.",
 				"trade_no_goods"     = "I only accept money transfers.",
+				"trade_found_unwanted" = "We don't need that, sorry.",
 				"trade_not_enough"   = "No, I am sorry, that is not possible. I need to make a living.",
 				"how_much"           = "I give you ITEM, for VALUE CURRENCY. No more, no less.",
+				"what_want"         = "We could use a bit more...",
 
 				"compliment_deny"    = "That was an odd thing to say. You are very odd.",
 				"compliment_accept"  = "Good philosophy, see good in bad, I like.",
@@ -40,7 +50,11 @@
 								/datum/sold_goods/monkeysoup = 100,
 								/datum/sold_goods/ricepudding = 100,
 								/datum/sold_goods/cupramen = 100)
+	possible_bought_goods = list(/datum/bought_goods/carpmeat = 100,
+								/datum/bought_goods/cabbage = 100,
+								/datum/bought_goods/pastrybase = 100)
 	target_sold_goods_amount = 5
+	target_bought_goods_amount = 3
 	var/list/fortunes = list("Today it's up to you to create the peacefulness you long for.",
 							"If you refuse to accept anything but the best, you very often get it.",
 							"A smile is your passport into the hearts of others.",
@@ -60,20 +74,20 @@
 	fortune.name = "Fortune"
 	fortune.info = pick(fortunes)
 
-
-
 /datum/trader/farmer
 	name = "Farming Apprentice"
 	possible_origins = list("Uncle Ben's", "Manure Mounds", "Farmzilla", "Pepperidge Farms", "Johnson's Grand Animal Emporium", "Feral Farms")
-	trade_flags = TRADER_MONEY|TRADER_SELLS_GOODS
+	trade_flags = TRADER_MONEY|TRADER_SELLS_GOODS|TRADER_BUYS_GOODS
 	speech = list(
 		"hail" = "Hello! Welcome to ORIGIN, may I take your order?",
 		"hail_deny" = "Beeeep... I'm sorry, your connection has been severed.",
 
 		"trade_complete" = "Welcome to ORIGIN!",
 		"trade_no_goods" = "Let's see what we're working with...",
+		"trade_found_unwanted" = "I can't really do anything with that.",
 		"trade_not_enough" = "This is a prime cut of steak you know. Do you know how much it costs to raise a cow? Do you know how many medals this beautiful animal -",
-		"how_much" = "This here animal will run ya VALUE in hard cash.",
+		"how_much" = "This here will run ya VALUE in hard cash.",
+		"what_want"         = "Well... I could use some...",
 
 		"compliment_deny" = "At least let me take a shower first.",
 		"compliment_accept" = "Mighty fine of you, care to roll in the hay in a bit?",
@@ -86,6 +100,9 @@
 		/datum/sold_goods/chicken = 100,
 		/datum/sold_goods/wheat = 100,
 		/datum/sold_goods/corn = 100,
-		/datum/sold_goods/pumpkin = 100,
-	)
+		/datum/sold_goods/pumpkin = 100,)
+	possible_bought_goods = list(/datum/bought_goods/eggs = 100,
+								/datum/bought_goods/produce = 100,
+								/datum/bought_goods/logs = 100)
 	target_sold_goods_amount = 6
+	target_bought_goods_amount = 3

--- a/code/modules/trading/traders/food.dm
+++ b/code/modules/trading/traders/food.dm
@@ -52,7 +52,7 @@
 								/datum/sold_goods/cupramen = 100)
 	possible_bought_goods = list(/datum/bought_goods/carpmeat = 100,
 								/datum/bought_goods/cabbage = 100,
-								/datum/bought_goods/pastrybase = 100)
+								/datum/bought_goods/batter = 100)
 	target_sold_goods_amount = 5
 	target_bought_goods_amount = 3
 	var/list/fortunes = list("Today it's up to you to create the peacefulness you long for.",

--- a/code/modules/trading/traders/goods.dm
+++ b/code/modules/trading/traders/goods.dm
@@ -307,10 +307,12 @@
 
 /datum/trader/atmospherics
 	name = "Atmospheric Shop Employee"
+	trade_flags = TRADER_MONEY|TRADER_SELLS_GOODS
 	possible_origins = list("Fill Up Tanker", "Gasser'up", "Tank Topper", "Uncle Joe's Jenkem Emporium")
 	possible_sold_goods = list(
 		/datum/sold_goods/belt/nitrogen = 100,
 		/datum/sold_goods/belt/plasma = 100,
 		/datum/sold_goods/emergency_oxygen = 100,
+		/datum/sold_goods/voidsuit = 100,
 	)
-	target_bought_goods_amount = 3
+	target_sold_goods_amount = 5

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3667,6 +3667,7 @@
 #include "code\modules\trading\_trader.dm"
 #include "code\modules\trading\trade_hub_overmap.dm"
 #include "code\modules\trading\trade_machines.dm"
+#include "code\modules\trading\bought_goods\food.dm"
 #include "code\modules\trading\bought_goods\goods.dm"
 #include "code\modules\trading\sold_goods\food.dm"
 #include "code\modules\trading\sold_goods\goods.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Organized sold food file.
- Adjust farming apprentice prices.
- Adjust basic mining kit price.
- Adjust atmos trader prices.
- Added space suit to atmos trader.
- Food Traders will buy (some) ingredients or products.
- Fixed a tiny error with atmos vendor. (wrong variable?)

Tested it a few times last night, everything -should- be working.

## Why It's Good For The Game

Adds a way to get space suits. Also allows the chef and botanist to contribute to Bearcat Economy

## Changelog
:cl:
add: Food traders will buy select goods.
add: Atmos traders now carry a space suit.
balance: Adjusted multiple trader prices.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
