### PR TITLE
Climbing over things, railing fix

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -38,11 +38,10 @@
 		examine_texts += SPAN_NOTICE("[source] looks climbable.")
 
 /datum/element/climbable/proc/can_climb(atom/source, mob/user)
-	if(climb_over)
-		if(source.loc != user.loc)
-			var/turf/neighboring_turf = get_step(source.loc,source.dir)
-			if(user.loc != neighboring_turf)
-				return FALSE
+	if(climb_over && source.loc != user.loc)
+		var/turf/neighboring_turf = get_step(source.loc,source.dir)
+		if(user.loc != neighboring_turf)
+			return FALSE
 	return TRUE
 
 /datum/element/climbable/proc/attack_hand(atom/climbed_thing, mob/user)

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -39,14 +39,10 @@
 
 /datum/element/climbable/proc/can_climb(atom/source, mob/user)
 	if(climb_over)
-		if(source.loc == user.loc)
-			return TRUE
-		else
+		if(source.loc != user.loc)
 			var/turf/neighboring_turf = get_step(source.loc,source.dir)
 			if(user.loc != neighboring_turf)
 				return FALSE
-			else
-				return TRUE
 	return TRUE
 
 /datum/element/climbable/proc/attack_hand(atom/climbed_thing, mob/user)

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -5,10 +5,12 @@
 	var/climb_time = (2 SECONDS)
 	///Stun duration for when you get onto the object
 	var/climb_stun = (2 SECONDS)
+	/// Whether you climb OVER a thing, implies it is directional and will invoke extra checks / verb changes
+	var/climb_over = FALSE
 	///Assoc list of object being climbed on - climbers.  This allows us to check who needs to be shoved off a climbable object when its clicked on.
 	var/list/current_climbers
 
-/datum/element/climbable/Attach(datum/target, climb_time, climb_stun)
+/datum/element/climbable/Attach(datum/target, climb_time, climb_stun, climb_over)
 	. = ..()
 
 	if(!isatom(target) || isarea(target))
@@ -17,6 +19,8 @@
 		src.climb_time = climb_time
 	if(climb_stun)
 		src.climb_stun = climb_stun
+	if(climb_over)
+		src.climb_over = climb_over
 
 	RegisterSignal(target, COMSIG_ATOM_ATTACK_HAND, .proc/attack_hand)
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/on_examine)
@@ -34,6 +38,15 @@
 		examine_texts += SPAN_NOTICE("[source] looks climbable.")
 
 /datum/element/climbable/proc/can_climb(atom/source, mob/user)
+	if(climb_over)
+		if(source.loc == user.loc)
+			return TRUE
+		else
+			var/turf/neighboring_turf = get_step(source.loc,source.dir)
+			if(user.loc != neighboring_turf)
+				return FALSE
+			else
+				return TRUE
 	return TRUE
 
 /datum/element/climbable/proc/attack_hand(atom/climbed_thing, mob/user)
@@ -53,8 +66,9 @@
 	if(!can_climb(climbed_thing, user))
 		return
 	climbed_thing.add_fingerprint(user)
-	user.visible_message(SPAN_WARNING("[user] starts climbing onto [climbed_thing]."), \
-								SPAN_NOTICE("You start climbing onto [climbed_thing]..."))
+	var/climb_verb = climb_over ? "over" : "onto"
+	user.visible_message(SPAN_WARNING("[user] starts climbing [climb_verb] [climbed_thing]."), \
+								SPAN_NOTICE("You start climbing [climb_verb] [climbed_thing]..."))
 	var/adjusted_climb_time = climb_time
 	var/adjusted_climb_stun = climb_stun
 	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)) //climbing takes twice as long without help from the hands.
@@ -69,19 +83,24 @@
 		if(QDELETED(climbed_thing)) //Checking if structure has been destroyed
 			return
 		if(do_climb(climbed_thing, user))
-			user.visible_message(SPAN_WARNING("[user] climbs onto [climbed_thing]."), \
-								SPAN_NOTICE("You climb onto [climbed_thing]."))
-			log_combat(user, climbed_thing, "climbed onto")
+			user.visible_message(SPAN_WARNING("[user] climbs [climb_verb] [climbed_thing]."), \
+								SPAN_NOTICE("You climb [climb_verb] [climbed_thing]."))
+			log_combat(user, climbed_thing, "climbed [climb_verb]")
 			if(adjusted_climb_stun)
 				user.Stun(adjusted_climb_stun)
 		else
-			to_chat(user, SPAN_WARNING("You fail to climb onto [climbed_thing]."))
+			to_chat(user, SPAN_WARNING("You fail to climb [climb_verb] [climbed_thing]."))
 	LAZYREMOVEASSOC(current_climbers, climbed_thing, user)
 
 
 /datum/element/climbable/proc/do_climb(atom/climbed_thing, mob/living/user)
 	climbed_thing.density = FALSE
-	. = step(user, get_dir(user,climbed_thing.loc))
+	var/dir
+	if(climb_over && climbed_thing.loc == user.loc)
+		dir = climbed_thing.dir
+	else
+		dir = get_dir(user,climbed_thing.loc)
+	. = step(user, dir)
 	climbed_thing.density = TRUE
 
 ///Handles climbing onto the atom when you click-drag

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -19,7 +19,7 @@
 	. = ..()
 	ini_dir = dir
 	if(climbable)
-		AddElement(/datum/element/climbable)
+		AddElement(/datum/element/climbable, null, null, TRUE)
 
 	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
 	init_connect_loc_element()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Climbable element now has a climb_over argument.
With that argument it will only allow climbs from within and opposing the atom (based off dir), and will properly move climbers on the other side if they're on the atom they're climbing

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Climbable element now has the functionality of climbing over things
fix: Fixed climbing over railings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
