### PR TITLE
Two new planetary ruins.

### DIFF
--- a/_maps/RandomRuins/Planet/abandoned_containment.dmm
+++ b/_maps/RandomRuins/Planet/abandoned_containment.dmm
@@ -1,0 +1,157 @@
+"aZ" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/pod,/area/ruin/unpowered)
+"bx" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/obj/machinery/light/small/broken{dir = 1},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"bz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/chem_master,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"cd" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/departments/medbay/alt{pixel_x = 32},/obj/structure/rubble/large,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"cn" = (/turf/template_noop,/area/template_noop)
+"cz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/shower{dir = 1},/obj/structure/curtain,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"cA" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/obj/structure/closet/crate/secure/gear,/obj/item/gun/energy/laser/retro,/obj/effect/spawner/lootdrop/away_loot,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"cO" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"cS" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/remains/human,/turf/open/floor/pod,/area/ruin/unpowered)
+"dk" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/broken,/obj/effect/spawner/lootdrop/grille_or_trash,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"dz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/crate_spawner,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"el" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/door/window{dir = 8},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"eM" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"eP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 4},/obj/structure/frame/computer,/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"gg" = (/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"gl" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/obj/structure/closet/crate,/obj/effect/spawner/lootdrop/maintenance/three,/obj/effect/spawner/lootdrop/away_loot,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"gB" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"gC" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/bodybag,/obj/machinery/light/small/directional,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"gI" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/toolbox,/obj/structure/rack,/obj/effect/spawner/lootdrop/tool,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"gN" = (/obj/structure/sign/departments/cargo{pixel_x = -31},/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"gW" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/large,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"hU" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/obj/item/pen{pixel_x = -15},/obj/machinery/light/small/directional,/obj/effect/spawner/lootdrop/alcohol_bottle,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"iq" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 4},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"iC" = (/obj/structure/window/reinforced/spawner/east,/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/portable_atmospherics/pump,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"kn" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/broken{dir = 8},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"lv" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"lw" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/clothing/mask/gas,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"mq" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/machinery/power/apc/auto_name/west{start_charge = 0},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"mx" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"mI" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"mV" = (/obj/structure/cable,/obj/effect/spawner/structure/window/survival_pod,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"nN" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/scalpel,/obj/item/cautery,/obj/item/book/manual/wiki/surgery,/obj/structure/window/reinforced/spawner{dir = 8},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"nX" = (/obj/machinery/door/airlock/hatch{locked = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/pod,/area/ruin/unpowered)
+"oe" = (/obj/effect/decal/cleanable/dirt/dust,/mob/living/simple_animal/hostile/alien/queen,/turf/open/floor/pod,/area/ruin/unpowered)
+"oU" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/medium,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"pO" = (/obj/machinery/door/airlock/grunge,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"qF" = (/obj/structure/bed/maint,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"rs" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/food_packaging,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"rI" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/wardrobe/white/medical,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"ss" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/food_packaging,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"sI" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/power/port_gen/pacman,/obj/structure/cable,/obj/effect/turf_decal/trimline/yellow/warning,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"tb" = (/obj/effect/decal/cleanable/dirt/dust,/obj/item/soap/nanotrasen,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"tJ" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/frame/machine,/obj/item/circuitboard/machine/autolathe,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"tK" = (/obj/structure/chair/office,/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/button/door/directional/west{id = "containment_4"},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"tP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/reagent_containers/glass/beaker,/obj/effect/spawner/lootdrop/bomb_supply,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"uV" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/obj/machinery/light/small/broken{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"vf" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/wardrobe/science_white,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"vi" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/chem_dispenser,/obj/machinery/light/small/directional,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"wb" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"wi" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/departments/science{pixel_x = -31},/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"xX" = (/turf/closed/mineral/random/jungle,/area/template_noop)
+"yP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/computer/operating,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"yU" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/medium,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"zA" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Al" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/gibspawner/human/bodypartless,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"Aw" = (/obj/structure/sign/warning{pixel_y = 30},/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/template_noop)
+"AA" = (/obj/structure/bed/maint,/obj/item/bedsheet/random,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"AL" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/machinery/light/small/directional{dir = 1},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Bv" = (/obj/structure/closet,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/maintenance/three,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Bz" = (/obj/structure/bed/maint,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"BA" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/structure/window/reinforced/spawner{dir = 8},/obj/machinery/door/window,/obj/item/clothing/suit/space/hardsuit/ancient,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"BI" = (/obj/machinery/door/airlock/grunge,/obj/structure/barricade/wooden/crude,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"BZ" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/effect/decal/cleanable/oil,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Cb" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/machinery/light/small/broken,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Cs" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"Cw" = (/obj/machinery/door/airlock/grunge{locked = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"CD" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"DB" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 4},/obj/effect/turf_decal/trimline/yellow/warning,/obj/item/stack/sheet/mineral/plasma{amount = 5},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"DR" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/eyewear,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"DW" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sink/kitchen,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"DY" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/obj/structure/frame/machine,/obj/effect/turf_decal/trimline/yellow/warning,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Em" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/glowstick,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Eo" = (/obj/machinery/door/airlock/grunge{locked = 1},/obj/structure/barricade/wooden/crude,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"FF" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/bed,/obj/item/bedsheet/cmo,/obj/structure/curtain,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"FX" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"Gf" = (/obj/structure/sign/departments/engineering{pixel_x = 32},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Gh" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Gr" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/obj/machinery/light/small/broken,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"HG" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table/optable,/obj/machinery/light/small/directional{dir = 1},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"Ia" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/light/small/broken{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Ik" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"Im" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/frame/machine,/obj/structure/frame/machine,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Kf" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/chair/office{dir = 4},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Kh" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/obj/machinery/power/terminal{dir = 4},/obj/structure/cable,/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Kj" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 4},/obj/effect/decal/remains/human,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"Kx" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/obj/structure/closet/crate,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/spawner/lootdrop/away_loot,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"KU" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/blood,/obj/effect/decal/remains/human,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"LC" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/spawner/lootdrop/tool,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"LY" = (/turf/closed/mineral/random/jungle,/area/ruin/unpowered)
+"ME" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/bed,/obj/item/bedsheet/blue,/obj/structure/curtain,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"ML" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"MP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/item/kitchen/knife/hunting,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"MS" = (/obj/structure/bed/maint,/obj/effect/decal/cleanable/dirt/dust,/obj/item/bedsheet/random,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"NC" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/chair/office,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"On" = (/turf/closed/wall/concrete,/area/ruin/unpowered)
+"Ov" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/large,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Pp" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"PF" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"PJ" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 1},/turf/open/floor/pod,/area/ruin/unpowered)
+"Qf" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/mecha_wreckage/ripley,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Qz" = (/obj/effect/decal/cleanable/oil/streak,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"QT" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"QV" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/effect/spawner/lootdrop/space/fancytool/engineonly,/obj/item/stack/cable_coil,/obj/effect/spawner/lootdrop/tool,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"QW" = (/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"RN" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/toolcloset,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"SL" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"SN" = (/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/template_noop)
+"SO" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Tw" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"Us" = (/obj/effect/spawner/structure/window/reinforced,/obj/machinery/door/poddoor/shutters{id = "containment_4"},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Uu" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/portable_atmospherics/scrubber,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"UX" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/obj/item/folder,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Vh" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/frame/computer,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Vn" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/toilet,/obj/structure/curtain,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Vp" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/remains/human,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Vv" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/effect/spawner/lootdrop/eyewear,/obj/effect/spawner/lootdrop/headgear,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"VF" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/crate/freezer/blood,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"Xe" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Xo" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/material,/obj/effect/spawner/lootdrop/material,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Yw" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/warning/xeno_mining{pixel_x = -1; pixel_y = 31},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"YK" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/power/smes,/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"Zn" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
+"Zt" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/poster/contraband/power{pixel_y = 32},/obj/structure/cable,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
+"Zz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+
+(1,1,1) = {"
+cncncncncncncncncncncncncncncncncncncncncncncncncncncncncncn
+cncncncncncncncncncncncncncncncnxXxXxXxXcncncncnxXxXxXxXcncn
+cncncncncncncncnxXxXxXxXxXxXcncnxXxXxXxXxXxXcnxXxXxXxXxXxXcn
+cncncncncncnxXxXxXxXxXxXxXxXcnxXxXxXxXxXxXxXxXxXxXxXxXxXxXcn
+cncncncncnxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXcn
+cncncncncncnxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXcn
+cncncncncnxXxXxXOnOnOnOnOnOnOnOnOnOnOnOnOnOnxXxXxXxXcnxXcncn
+cncncncnxXxXxXxXOnAASOSLqFOnVvUuOnDWFXVnVnOnxXxXxXcncnxXcncn
+cncncncnxXxXxXxXOnknVpDRzApOzAmxpOQWCsCsKjOnxXxXxXcncncncncn
+cncncnxXxXxXxXxXOnBzMLBvMSOnPFzAOntbCsczczOnxXxXxXxXcncncncn
+cncncnxXxXxXxXxXOnOnOnOnOnOncOmxOnOnOnOnOnOnxXxXxXxXxXxXcncn
+cncncncnxXxXxXxXxXxXxXxXxXOnoUzAOnxXxXxXxXxXxXxXxXxXxXxXxXxX
+cncncncnxXLYLYLYLYOnOnOnOnOnmxmxOnOnOnOnOnOnOnOnOnxXxXxXxXcn
+cncncnxXxXLYLYLYyUzAzAbxQfOnzArsOngIQVDYsIDBRNBAOnxXxXxXcncn
+cncncnxXxXLYLYLYKxXezAzAmxCwzAmxpOmxmxzACbmxzAGhOnxXxXcncncn
+cncnxXxXxXLYLYLYLYLYOvmxGhOngNGfOneMQTOnmVOnQziqOnxXcncncncn
+cnxXxXxXxXLYLYLYLYcAzAglzAOnzAmxOnmqBZZtALGhzAXoOnxXcncncncn
+cnxXxXxXxXOnLYLYdkgWmxCDGhOndzmxOntJZzKhYKePKfLCOnxXxXcncncn
+cncnxXxXxXOnOnOnOnOnOnOnOnOnmxcOOnOnOnOnOnOnOnOnOnxXxXcncncn
+cncnxXxXxXOncSPJUsImVhIamxpOzAmxCwmIuVrIVFnNHGyPOnxXxXcncncn
+cncnxXxXxXOnoeaZUszAmxzAzAOnwicdOnEmmIzAzAIkmImIOnxXxXcncncn
+cnxXxXxXxXOnUsnXOnmxQTmxzAOnKUMPOnzAzAssmIelAlmIOnxXcncncncn
+cnxXxXxXxXOntKmxYwzAmxNCtPOnmxmxOnzAmImIzAwbgBZnOnxXcncncncn
+cnxXxXxXxXOnUXhUiCvfbzvilwOnmxzAOnMEgClvFFTwGrPpOnxXxXcncncn
+xXxXxXxXxXOnOnOnOnOnOnOnOnOnggzAOnOnOnOnOnOnOnOnOnxXxXcncncn
+xXxXxXxXxXxXxXxXxXxXxXxXxXOnEoBIOnxXxXxXxXxXxXxXxXxXxXcncncn
+cncnxXxXxXxXxXxXxXxXxXxXxXAwSNSNSNxXxXxXxXcnxXxXxXxXxXcncncn
+xXcnxXxXxXxXxXxXxXxXxXcncncncncncncnxXcncncncncnxXxXxXxXcncn
+xXxXxXxXxXxXxXcncncncncncncncncncncncncncncncncnxXxXxXxXcncn
+cncnxXxXcncncncncncncncncncncncncncncncncncncncncncnxXxXcncn
+"}

--- a/_maps/RandomRuins/Planet/abandoned_containment.dmm
+++ b/_maps/RandomRuins/Planet/abandoned_containment.dmm
@@ -1,157 +1,1756 @@
-"aZ" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/pod,/area/ruin/unpowered)
-"bx" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/obj/machinery/light/small/broken{dir = 1},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"bz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/chem_master,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"cd" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/departments/medbay/alt{pixel_x = 32},/obj/structure/rubble/large,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"cn" = (/turf/template_noop,/area/template_noop)
-"cz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/shower{dir = 1},/obj/structure/curtain,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"cA" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/obj/structure/closet/crate/secure/gear,/obj/item/gun/energy/laser/retro,/obj/effect/spawner/lootdrop/away_loot,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"cO" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"cS" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/remains/human,/turf/open/floor/pod,/area/ruin/unpowered)
-"dk" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/broken,/obj/effect/spawner/lootdrop/grille_or_trash,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"dz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/crate_spawner,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"el" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/door/window{dir = 8},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"eM" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"eP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 4},/obj/structure/frame/computer,/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"gg" = (/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"gl" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/obj/structure/closet/crate,/obj/effect/spawner/lootdrop/maintenance/three,/obj/effect/spawner/lootdrop/away_loot,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"gB" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"gC" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/bodybag,/obj/machinery/light/small/directional,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"gI" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/toolbox,/obj/structure/rack,/obj/effect/spawner/lootdrop/tool,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"gN" = (/obj/structure/sign/departments/cargo{pixel_x = -31},/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"gW" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/large,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"hU" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/obj/item/pen{pixel_x = -15},/obj/machinery/light/small/directional,/obj/effect/spawner/lootdrop/alcohol_bottle,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"iq" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 4},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"iC" = (/obj/structure/window/reinforced/spawner/east,/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/portable_atmospherics/pump,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"kn" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/broken{dir = 8},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"lv" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"lw" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/clothing/mask/gas,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"mq" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/machinery/power/apc/auto_name/west{start_charge = 0},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"mx" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"mI" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"mV" = (/obj/structure/cable,/obj/effect/spawner/structure/window/survival_pod,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"nN" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/scalpel,/obj/item/cautery,/obj/item/book/manual/wiki/surgery,/obj/structure/window/reinforced/spawner{dir = 8},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"nX" = (/obj/machinery/door/airlock/hatch{locked = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/pod,/area/ruin/unpowered)
-"oe" = (/obj/effect/decal/cleanable/dirt/dust,/mob/living/simple_animal/hostile/alien/queen,/turf/open/floor/pod,/area/ruin/unpowered)
-"oU" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/medium,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"pO" = (/obj/machinery/door/airlock/grunge,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"qF" = (/obj/structure/bed/maint,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"rs" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/food_packaging,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"rI" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/wardrobe/white/medical,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"ss" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/food_packaging,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"sI" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/power/port_gen/pacman,/obj/structure/cable,/obj/effect/turf_decal/trimline/yellow/warning,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"tb" = (/obj/effect/decal/cleanable/dirt/dust,/obj/item/soap/nanotrasen,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"tJ" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/frame/machine,/obj/item/circuitboard/machine/autolathe,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"tK" = (/obj/structure/chair/office,/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/button/door/directional/west{id = "containment_4"},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"tP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/reagent_containers/glass/beaker,/obj/effect/spawner/lootdrop/bomb_supply,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"uV" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/obj/machinery/light/small/broken{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"vf" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/wardrobe/science_white,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"vi" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/chem_dispenser,/obj/machinery/light/small/directional,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"wb" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"wi" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/departments/science{pixel_x = -31},/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"xX" = (/turf/closed/mineral/random/jungle,/area/template_noop)
-"yP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/computer/operating,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"yU" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/medium,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"zA" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Al" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/gibspawner/human/bodypartless,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"Aw" = (/obj/structure/sign/warning{pixel_y = 30},/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/template_noop)
-"AA" = (/obj/structure/bed/maint,/obj/item/bedsheet/random,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"AL" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/machinery/light/small/directional{dir = 1},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Bv" = (/obj/structure/closet,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/maintenance/three,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Bz" = (/obj/structure/bed/maint,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"BA" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/structure/window/reinforced/spawner{dir = 8},/obj/machinery/door/window,/obj/item/clothing/suit/space/hardsuit/ancient,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"BI" = (/obj/machinery/door/airlock/grunge,/obj/structure/barricade/wooden/crude,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"BZ" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/effect/decal/cleanable/oil,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Cb" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/obj/machinery/light/small/broken,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Cs" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"Cw" = (/obj/machinery/door/airlock/grunge{locked = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"CD" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"DB" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 4},/obj/effect/turf_decal/trimline/yellow/warning,/obj/item/stack/sheet/mineral/plasma{amount = 5},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"DR" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/eyewear,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"DW" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sink/kitchen,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"DY" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/obj/structure/frame/machine,/obj/effect/turf_decal/trimline/yellow/warning,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Em" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/glowstick,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Eo" = (/obj/machinery/door/airlock/grunge{locked = 1},/obj/structure/barricade/wooden/crude,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"FF" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/bed,/obj/item/bedsheet/cmo,/obj/structure/curtain,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"FX" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"Gf" = (/obj/structure/sign/departments/engineering{pixel_x = 32},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Gh" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Gr" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/obj/machinery/light/small/broken,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"HG" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table/optable,/obj/machinery/light/small/directional{dir = 1},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"Ia" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/light/small/broken{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Ik" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"Im" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/frame/machine,/obj/structure/frame/machine,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Kf" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/chair/office{dir = 4},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Kh" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/obj/machinery/power/terminal{dir = 4},/obj/structure/cable,/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Kj" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 4},/obj/effect/decal/remains/human,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"Kx" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/obj/structure/closet/crate,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/spawner/lootdrop/away_loot,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"KU" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/blood,/obj/effect/decal/remains/human,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"LC" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/spawner/lootdrop/tool,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"LY" = (/turf/closed/mineral/random/jungle,/area/ruin/unpowered)
-"ME" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/bed,/obj/item/bedsheet/blue,/obj/structure/curtain,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"ML" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"MP" = (/obj/effect/decal/cleanable/dirt/dust,/obj/item/kitchen/knife/hunting,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"MS" = (/obj/structure/bed/maint,/obj/effect/decal/cleanable/dirt/dust,/obj/item/bedsheet/random,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"NC" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/chair/office,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"On" = (/turf/closed/wall/concrete,/area/ruin/unpowered)
-"Ov" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rubble/large,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Pp" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"PF" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 8},/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"PJ" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/small/directional{dir = 1},/turf/open/floor/pod,/area/ruin/unpowered)
-"Qf" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/mecha_wreckage/ripley,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Qz" = (/obj/effect/decal/cleanable/oil/streak,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"QT" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"QV" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/effect/spawner/lootdrop/space/fancytool/engineonly,/obj/item/stack/cable_coil,/obj/effect/spawner/lootdrop/tool,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"QW" = (/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"RN" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/toolcloset,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"SL" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"SN" = (/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/template_noop)
-"SO" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Tw" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/window/reinforced/spawner{dir = 8},/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"Us" = (/obj/effect/spawner/structure/window/reinforced,/obj/machinery/door/poddoor/shutters{id = "containment_4"},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Uu" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/portable_atmospherics/scrubber,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"UX" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/obj/item/folder,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Vh" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/frame/computer,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Vn" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/toilet,/obj/structure/curtain,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Vp" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/remains/human,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Vv" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/effect/spawner/lootdrop/eyewear,/obj/effect/spawner/lootdrop/headgear,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"VF" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/closet/crate/freezer/blood,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"Xe" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/box,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Xo" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/material,/obj/effect/spawner/lootdrop/material,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Yw" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/warning/xeno_mining{pixel_x = -1; pixel_y = 31},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"YK" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/power/smes,/obj/effect/turf_decal/trimline/yellow/warning{dir = 1},/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"Zn" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/effect/spawner/lootdrop/medicine,/turf/open/floor/holofloor/white,/area/ruin/unpowered)
-"Zt" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/poster/contraband/power{pixel_y = 32},/obj/structure/cable,/turf/open/floor/iron/dark/smooth_large,/area/ruin/unpowered)
-"Zz" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod,
+/area/ruin/unpowered)
+"bx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"bz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/chem_master,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"cd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = 32
+	},
+/obj/structure/rubble/large,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"cn" = (
+/turf/template_noop,
+/area/template_noop)
+"cz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"cA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/gun/energy/laser/retro,
+/obj/effect/spawner/lootdrop/away_loot,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"cO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"cS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/pod,
+/area/ruin/unpowered)
+"dk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"dz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"el" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/window{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"eM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"eP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/obj/structure/frame/computer,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"gg" = (
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"gl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/away_loot,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"gB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"gC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/bodybag,
+/obj/machinery/light/small/directional,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"gI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/toolbox,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/tool,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"gN" = (
+/obj/structure/sign/departments/cargo{
+	pixel_x = -31
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"gW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rubble/large,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"hU" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/pen{
+	pixel_x = -15
+	},
+/obj/machinery/light/small/directional,
+/obj/effect/spawner/lootdrop/alcohol_bottle,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"iq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"iC" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"kn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"lv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"lw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"mq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west{
+	start_charge = 0
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"mx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"mI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"mV" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"nN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/cautery,
+/obj/item/book/manual/wiki/surgery,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"nX" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod,
+/area/ruin/unpowered)
+"oe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/alien/queen,
+/turf/open/floor/pod,
+/area/ruin/unpowered)
+"oU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rubble/medium,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"pO" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"qF" = (
+/obj/structure/bed/maint,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"rs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/food_packaging,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"rI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/wardrobe/white/medical,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"ss" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/food_packaging,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"sI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"tb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"tJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/autolathe,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"tK" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door/directional/west{
+	id = "containment_4"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"tP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker,
+/obj/effect/spawner/lootdrop/bomb_supply,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"uV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"vf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/wardrobe/science_white,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"vi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/chem_dispenser,
+/obj/machinery/light/small/directional,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"wb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"wi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/departments/science{
+	pixel_x = -31
+	},
+/obj/machinery/light/small/directional{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"xX" = (
+/turf/closed/mineral/random/jungle,
+/area/template_noop)
+"yP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/operating,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"yU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rubble/medium,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"zA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Al" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"Aw" = (
+/obj/structure/sign/warning{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/template_noop)
+"AA" = (
+/obj/structure/bed/maint,
+/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"AL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/light/small/directional{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Bv" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Bz" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"BA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/machinery/door/window,
+/obj/item/clothing/suit/space/hardsuit/ancient,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"BI" = (
+/obj/machinery/door/airlock/grunge,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"BZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Cb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/machinery/light/small/broken,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Cs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"Cw" = (
+/obj/machinery/door/airlock/grunge{
+	locked = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"CD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"DB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"DR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/eyewear,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"DW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/kitchen,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"DY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/trimline/yellow/warning,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Em" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Eo" = (
+/obj/machinery/door/airlock/grunge{
+	locked = 1
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"FF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed,
+/obj/item/bedsheet/cmo,
+/obj/structure/curtain,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"FX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"Gf" = (
+/obj/structure/sign/departments/engineering{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Gh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Gr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/medicine,
+/obj/machinery/light/small/broken,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"HG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/optable,
+/obj/machinery/light/small/directional{
+	dir = 1
+	},
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"Ia" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Ik" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"Im" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/structure/frame/machine,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Kf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Kh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Kj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"Kx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/away_loot,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"KU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"LC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/tool,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"LY" = (
+/turf/closed/mineral/random/jungle,
+/area/ruin/unpowered)
+"ME" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/structure/curtain,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"ML" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"MP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kitchen/knife/hunting,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"MS" = (
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/bedsheet/random,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"NC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"On" = (
+/turf/closed/wall/concrete,
+/area/ruin/unpowered)
+"Ov" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rubble/large,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Pp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/medicine,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"PF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"PJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/ruin/unpowered)
+"Qf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/mecha_wreckage/ripley,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Qz" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"QT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"QV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/space/fancytool/engineonly,
+/obj/item/stack/cable_coil,
+/obj/effect/spawner/lootdrop/tool,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"QW" = (
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"RN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"SL" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"SN" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/template_noop)
+"SO" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Tw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/medicine,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"Us" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "containment_4"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Uu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"UX" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/folder,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Vh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/computer,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Vn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/toilet,
+/obj/structure/curtain,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Vp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Vv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/eyewear,
+/obj/effect/spawner/lootdrop/headgear,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"VF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"Xe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Xo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/material,
+/obj/effect/spawner/lootdrop/material,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Yw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = -1;
+	pixel_y = 31
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"YK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/smes,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"Zn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/medicine,
+/turf/open/floor/holofloor/white,
+/area/ruin/unpowered)
+"Zt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/power{
+	pixel_y = 32
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/ruin/unpowered)
+"Zz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
-cncncncncncncncncncncncncncncncncncncncncncncncncncncncncncn
-cncncncncncncncncncncncncncncncnxXxXxXxXcncncncnxXxXxXxXcncn
-cncncncncncncncnxXxXxXxXxXxXcncnxXxXxXxXxXxXcnxXxXxXxXxXxXcn
-cncncncncncnxXxXxXxXxXxXxXxXcnxXxXxXxXxXxXxXxXxXxXxXxXxXxXcn
-cncncncncnxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXcn
-cncncncncncnxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXxXcn
-cncncncncnxXxXxXOnOnOnOnOnOnOnOnOnOnOnOnOnOnxXxXxXxXcnxXcncn
-cncncncnxXxXxXxXOnAASOSLqFOnVvUuOnDWFXVnVnOnxXxXxXcncnxXcncn
-cncncncnxXxXxXxXOnknVpDRzApOzAmxpOQWCsCsKjOnxXxXxXcncncncncn
-cncncnxXxXxXxXxXOnBzMLBvMSOnPFzAOntbCsczczOnxXxXxXxXcncncncn
-cncncnxXxXxXxXxXOnOnOnOnOnOncOmxOnOnOnOnOnOnxXxXxXxXxXxXcncn
-cncncncnxXxXxXxXxXxXxXxXxXOnoUzAOnxXxXxXxXxXxXxXxXxXxXxXxXxX
-cncncncnxXLYLYLYLYOnOnOnOnOnmxmxOnOnOnOnOnOnOnOnOnxXxXxXxXcn
-cncncnxXxXLYLYLYyUzAzAbxQfOnzArsOngIQVDYsIDBRNBAOnxXxXxXcncn
-cncncnxXxXLYLYLYKxXezAzAmxCwzAmxpOmxmxzACbmxzAGhOnxXxXcncncn
-cncnxXxXxXLYLYLYLYLYOvmxGhOngNGfOneMQTOnmVOnQziqOnxXcncncncn
-cnxXxXxXxXLYLYLYLYcAzAglzAOnzAmxOnmqBZZtALGhzAXoOnxXcncncncn
-cnxXxXxXxXOnLYLYdkgWmxCDGhOndzmxOntJZzKhYKePKfLCOnxXxXcncncn
-cncnxXxXxXOnOnOnOnOnOnOnOnOnmxcOOnOnOnOnOnOnOnOnOnxXxXcncncn
-cncnxXxXxXOncSPJUsImVhIamxpOzAmxCwmIuVrIVFnNHGyPOnxXxXcncncn
-cncnxXxXxXOnoeaZUszAmxzAzAOnwicdOnEmmIzAzAIkmImIOnxXxXcncncn
-cnxXxXxXxXOnUsnXOnmxQTmxzAOnKUMPOnzAzAssmIelAlmIOnxXcncncncn
-cnxXxXxXxXOntKmxYwzAmxNCtPOnmxmxOnzAmImIzAwbgBZnOnxXcncncncn
-cnxXxXxXxXOnUXhUiCvfbzvilwOnmxzAOnMEgClvFFTwGrPpOnxXxXcncncn
-xXxXxXxXxXOnOnOnOnOnOnOnOnOnggzAOnOnOnOnOnOnOnOnOnxXxXcncncn
-xXxXxXxXxXxXxXxXxXxXxXxXxXOnEoBIOnxXxXxXxXxXxXxXxXxXxXcncncn
-cncnxXxXxXxXxXxXxXxXxXxXxXAwSNSNSNxXxXxXxXcnxXxXxXxXxXcncncn
-xXcnxXxXxXxXxXxXxXxXxXcncncncncncncnxXcncncncncnxXxXxXxXcncn
-xXxXxXxXxXxXxXcncncncncncncncncncncncncncncncncnxXxXxXxXcncn
-cncnxXxXcncncncncncncncncncncncncncncncncncncncncncnxXxXcncn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+xX
+xX
+cn
+xX
+xX
+cn
+"}
+(2,1,1) = {"
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+xX
+xX
+cn
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+cn
+cn
+xX
+cn
+"}
+(3,1,1) = {"
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+"}
+(4,1,1) = {"
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+xX
+xX
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+"}
+(5,1,1) = {"
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+cn
+"}
+(6,1,1) = {"
+cn
+cn
+cn
+cn
+xX
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+LY
+LY
+LY
+LY
+LY
+On
+On
+On
+On
+On
+On
+On
+On
+xX
+xX
+xX
+xX
+cn
+"}
+(7,1,1) = {"
+cn
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+LY
+LY
+LY
+LY
+LY
+LY
+On
+cS
+oe
+Us
+tK
+UX
+On
+xX
+xX
+xX
+xX
+cn
+"}
+(8,1,1) = {"
+cn
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+LY
+LY
+LY
+LY
+LY
+LY
+On
+PJ
+aZ
+nX
+mx
+hU
+On
+xX
+xX
+xX
+cn
+cn
+"}
+(9,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+On
+On
+On
+On
+xX
+LY
+yU
+Kx
+LY
+LY
+dk
+On
+Us
+Us
+On
+Yw
+iC
+On
+xX
+xX
+xX
+cn
+cn
+"}
+(10,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+AA
+kn
+Bz
+On
+xX
+On
+zA
+Xe
+LY
+cA
+gW
+On
+Im
+zA
+mx
+zA
+vf
+On
+xX
+xX
+xX
+cn
+cn
+"}
+(11,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+SO
+Vp
+ML
+On
+xX
+On
+zA
+zA
+Ov
+zA
+mx
+On
+Vh
+mx
+QT
+mx
+bz
+On
+xX
+xX
+xX
+cn
+cn
+"}
+(12,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+SL
+DR
+Bv
+On
+xX
+On
+bx
+zA
+mx
+gl
+CD
+On
+Ia
+zA
+mx
+NC
+vi
+On
+xX
+xX
+cn
+cn
+cn
+"}
+(13,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+qF
+zA
+MS
+On
+xX
+On
+Qf
+mx
+Gh
+zA
+Gh
+On
+mx
+zA
+zA
+tP
+lw
+On
+xX
+xX
+cn
+cn
+cn
+"}
+(14,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+On
+pO
+On
+On
+On
+On
+On
+Cw
+On
+On
+On
+On
+pO
+On
+On
+On
+On
+On
+On
+Aw
+cn
+cn
+cn
+"}
+(15,1,1) = {"
+cn
+cn
+cn
+cn
+xX
+xX
+On
+Vv
+zA
+PF
+cO
+oU
+mx
+zA
+zA
+gN
+zA
+dz
+mx
+zA
+wi
+KU
+mx
+mx
+gg
+Eo
+SN
+cn
+cn
+cn
+"}
+(16,1,1) = {"
+cn
+cn
+cn
+xX
+xX
+xX
+On
+Uu
+mx
+zA
+mx
+zA
+mx
+rs
+mx
+Gf
+mx
+mx
+cO
+mx
+cd
+MP
+mx
+zA
+zA
+BI
+SN
+cn
+cn
+cn
+"}
+(17,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+On
+On
+pO
+On
+On
+On
+On
+On
+pO
+On
+On
+On
+On
+Cw
+On
+On
+On
+On
+On
+On
+SN
+cn
+cn
+cn
+"}
+(18,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+On
+DW
+QW
+tb
+On
+xX
+On
+gI
+mx
+eM
+mq
+tJ
+On
+mI
+Em
+zA
+zA
+ME
+On
+xX
+xX
+cn
+cn
+cn
+"}
+(19,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+On
+FX
+Cs
+Cs
+On
+xX
+On
+QV
+mx
+QT
+BZ
+Zz
+On
+uV
+mI
+zA
+mI
+gC
+On
+xX
+xX
+xX
+cn
+cn
+"}
+(20,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+On
+Vn
+Cs
+cz
+On
+xX
+On
+DY
+zA
+On
+Zt
+Kh
+On
+rI
+zA
+ss
+mI
+lv
+On
+xX
+xX
+cn
+cn
+cn
+"}
+(21,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+Vn
+Kj
+cz
+On
+xX
+On
+sI
+Cb
+mV
+AL
+YK
+On
+VF
+zA
+mI
+zA
+FF
+On
+xX
+xX
+cn
+cn
+cn
+"}
+(22,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+On
+On
+On
+On
+On
+xX
+On
+DB
+mx
+On
+Gh
+eP
+On
+nN
+Ik
+el
+wb
+Tw
+On
+xX
+cn
+cn
+cn
+cn
+"}
+(23,1,1) = {"
+cn
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+On
+RN
+zA
+Qz
+zA
+Kf
+On
+HG
+mI
+Al
+gB
+Gr
+On
+xX
+xX
+cn
+cn
+cn
+"}
+(24,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+On
+BA
+Gh
+iq
+Xo
+LC
+On
+yP
+mI
+mI
+Zn
+Pp
+On
+xX
+xX
+cn
+cn
+cn
+"}
+(25,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+On
+On
+On
+On
+On
+On
+On
+On
+On
+On
+On
+On
+On
+xX
+xX
+xX
+xX
+cn
+"}
+(26,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+cn
+"}
+(27,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+cn
+cn
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+cn
+cn
+xX
+xX
+xX
+xX
+cn
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+"}
+(28,1,1) = {"
+cn
+xX
+xX
+xX
+xX
+xX
+xX
+xX
+cn
+cn
+xX
+xX
+xX
+xX
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+xX
+xX
+xX
+"}
+(29,1,1) = {"
+cn
+cn
+xX
+xX
+xX
+xX
+cn
+cn
+cn
+cn
+cn
+xX
+xX
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+"}
+(30,1,1) = {"
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+xX
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
 "}

--- a/_maps/RandomRuins/Planet/weather_station.dmm
+++ b/_maps/RandomRuins/Planet/weather_station.dmm
@@ -1,85 +1,628 @@
-"bU" = (/obj/structure/table,/obj/machinery/microwave,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"cI" = (/obj/structure/closet/wardrobe,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"dV" = (/obj/structure/fence,/obj/effect/spawner/clear,/turf/template_noop,/area/template_noop)
-"ey" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
-"eI" = (/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"eY" = (/obj/structure/chair/office{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"fz" = (/obj/effect/turf_decal/trimline/yellow/filled/warning,/obj/structure/rack,/obj/effect/spawner/lootdrop/powercell,/obj/effect/spawner/lootdrop/toolbox,/turf/open/floor/plating,/area/ruin/unpowered)
-"fA" = (/obj/structure/table,/obj/item/reagent_containers/food/drinks/coffee,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"fM" = (/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 8},/obj/structure/closet/crate,/obj/item/mop,/obj/item/reagent_containers/glass/bucket,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"fP" = (/obj/machinery/power/solar,/obj/structure/cable,/obj/structure/cable,/turf/open/floor/iron/solarpanel,/area/template_noop)
-"fT" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/paper_bin,/obj/item/pen,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"gd" = (/turf/open/floor/plating,/area/ruin/unpowered)
-"gy" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/directional/south,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"gJ" = (/obj/machinery/portable_atmospherics/scrubber,/turf/open/floor/plating/rust,/area/ruin/unpowered)
-"iJ" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/carpet/green,/area/ruin/unpowered)
-"lt" = (/obj/machinery/power/apc/auto_name/north{start_charge = 0},/obj/structure/cable,/obj/structure/table,/obj/item/storage/box/drinkingglasses,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"mm" = (/turf/open/floor/carpet/green,/area/ruin/unpowered)
-"nh" = (/obj/structure/closet/firecloset/full,/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 8},/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"oQ" = (/obj/item/kirbyplants/random,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"rn" = (/obj/machinery/light/directional/north,/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"rw" = (/obj/effect/turf_decal/trimline/yellow/filled/warning,/obj/machinery/portable_atmospherics/canister/air,/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 4},/obj/machinery/power/terminal{dir = 8},/obj/structure/cable,/turf/open/floor/plating,/area/ruin/unpowered)
-"sh" = (/obj/structure/table,/obj/machinery/light/directional/south,/obj/item/plate{pixel_x = -7},/obj/item/kitchen/fork{pixel_x = 7},/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"sl" = (/obj/structure/closet/crate/bin,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"ta" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"tD" = (/obj/machinery/computer,/obj/machinery/light/directional/north,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"tE" = (/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"un" = (/obj/item/chair,/turf/open/floor/carpet/green,/area/ruin/unpowered)
-"uZ" = (/turf/closed/wall/concrete,/area/ruin/unpowered)
-"vc" = (/obj/machinery/light_switch/directional/west,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"wz" = (/obj/structure/table,/obj/item/flashlight/lamp,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"wG" = (/obj/machinery/shower{dir = 4},/obj/structure/curtain,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"xE" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
-"Af" = (/turf/template_noop,/area/template_noop)
-"AN" = (/obj/structure/sink{dir = 8; pixel_x = 11},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"Cd" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"Dp" = (/obj/structure/cable,/obj/machinery/power/tracker,/turf/open/floor/iron/solarpanel,/area/template_noop)
-"Eu" = (/obj/effect/spawner/clear,/obj/structure/fence{dir = 8},/turf/template_noop,/area/template_noop)
-"EN" = (/obj/machinery/power/smes,/obj/structure/cable,/obj/effect/turf_decal/trimline/yellow/filled/warning,/turf/open/floor/plating,/area/ruin/unpowered)
-"Gr" = (/obj/structure/toilet{dir = 4},/obj/machinery/light/directional/north,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
-"HA" = (/obj/effect/spawner/clear,/obj/effect/spawner/clear,/obj/structure/fence/corner{dir = 10},/turf/template_noop,/area/template_noop)
-"In" = (/obj/machinery/light/directional/north,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"It" = (/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"Kz" = (/obj/structure/table,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"KI" = (/obj/machinery/power/solar_control{dir = 8},/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"KM" = (/obj/structure/table,/obj/item/modular_computer/laptop/preset/civilian,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"LI" = (/obj/machinery/door/airlock/grunge,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"MM" = (/obj/structure/bed,/obj/item/bedsheet/black,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"Nd" = (/obj/machinery/door/airlock/grunge,/turf/open/floor/plating,/area/ruin/unpowered)
-"NQ" = (/obj/structure/fence{dir = 8},/obj/effect/spawner/clear,/turf/template_noop,/area/template_noop)
-"Og" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 8},/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 1},/obj/structure/reagent_dispensers/watertank,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"Oo" = (/obj/effect/spawner/clear,/obj/effect/spawner/clear,/obj/structure/fence/corner{dir = 6},/turf/template_noop,/area/template_noop)
-"OV" = (/obj/effect/decal/cleanable/garbage,/turf/template_noop,/area/template_noop)
-"Qe" = (/obj/machinery/power/solar,/obj/structure/cable,/turf/open/floor/iron/solarpanel,/area/template_noop)
-"QX" = (/obj/machinery/vending/coffee,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"SK" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/template_noop)
-"TR" = (/obj/structure/cable,/obj/machinery/door/airlock/grunge,/turf/open/floor/plating,/area/ruin/unpowered)
-"Un" = (/obj/structure/sign/poster/official/work_for_a_future{pixel_x = -31},/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"Ur" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"UJ" = (/obj/structure/table,/obj/item/storage/box/donkpockets,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"Vv" = (/obj/machinery/door/airlock/grunge,/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"VW" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/ruin/unpowered)
-"Wv" = (/obj/structure/table,/obj/structure/closet/mini_fridge,/obj/item/reagent_containers/food/drinks/waterbottle/large,/obj/item/reagent_containers/food/drinks/waterbottle/large,/obj/item/reagent_containers/food/drinks/waterbottle/large,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"Xk" = (/obj/structure/filingcabinet,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"XY" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
-"YU" = (/obj/machinery/light/small/directional/north,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/item/pickaxe,/obj/item/clothing/mask/gas/explorer,/obj/item/tank/internals/emergency_oxygen/double,/turf/open/floor/plating,/area/ruin/unpowered)
-"Zc" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/unpowered)
-"ZZ" = (/obj/machinery/light_switch/directional/south,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bU" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"cI" = (
+/obj/structure/closet/wardrobe,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"dV" = (
+/obj/structure/fence,
+/obj/effect/spawner/clear,
+/turf/template_noop,
+/area/template_noop)
+"ey" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"eI" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"eY" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"fz" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/powercell,
+/obj/effect/spawner/lootdrop/toolbox,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"fA" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"fM" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"fP" = (
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel,
+/area/template_noop)
+"fT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"gd" = (
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"gy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"gJ" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating/rust,
+/area/ruin/unpowered)
+"iJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ruin/unpowered)
+"lt" = (
+/obj/machinery/power/apc/auto_name/north{
+	start_charge = 0
+	},
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"mm" = (
+/turf/open/floor/carpet/green,
+/area/ruin/unpowered)
+"nh" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"oQ" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"rn" = (
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"rw" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"sh" = (
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/obj/item/plate{
+	pixel_x = -7
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 7
+	},
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"sl" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"ta" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"tD" = (
+/obj/machinery/computer,
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"tE" = (
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"un" = (
+/obj/item/chair,
+/turf/open/floor/carpet/green,
+/area/ruin/unpowered)
+"uZ" = (
+/turf/closed/wall/concrete,
+/area/ruin/unpowered)
+"vc" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"wz" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"wG" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"xE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"Af" = (
+/turf/template_noop,
+/area/template_noop)
+"AN" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"Cd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"Dp" = (
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/turf/open/floor/iron/solarpanel,
+/area/template_noop)
+"Eu" = (
+/obj/effect/spawner/clear,
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"EN" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Gr" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/freezer,
+/area/ruin/unpowered)
+"HA" = (
+/obj/effect/spawner/clear,
+/obj/effect/spawner/clear,
+/obj/structure/fence/corner{
+	dir = 10
+	},
+/turf/template_noop,
+/area/template_noop)
+"In" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"It" = (
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"Kz" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"KI" = (
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"KM" = (
+/obj/structure/table,
+/obj/item/modular_computer/laptop/preset/civilian,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"LI" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"MM" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"Nd" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"NQ" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/obj/effect/spawner/clear,
+/turf/template_noop,
+/area/template_noop)
+"Og" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"Oo" = (
+/obj/effect/spawner/clear,
+/obj/effect/spawner/clear,
+/obj/structure/fence/corner{
+	dir = 6
+	},
+/turf/template_noop,
+/area/template_noop)
+"OV" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/template_noop,
+/area/template_noop)
+"Qe" = (
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel,
+/area/template_noop)
+"QX" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"SK" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/template_noop)
+"TR" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Un" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -31
+	},
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"Ur" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"UJ" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"Vv" = (
+/obj/machinery/door/airlock/grunge,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"VW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Wv" = (
+/obj/structure/table,
+/obj/structure/closet/mini_fridge,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"Xk" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"XY" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
+"YU" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"Zc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ZZ" = (
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/smooth,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
-AfAfAfAfAfHANQNQNQNQEuNQNQNQOo
-AfAfAfAfAfdVAfAfQeeyDpSKQeOVdV
-AfuZZcZcZcuZAfAfQeSKQeeyQeAfdV
-AfZcfAtDKMZcAfAfQeSKQeSKfPAfdV
-AfZcfTeYItZcAfAfQeeyQeeyfPAfdV
-AfZcoQtaXkZcAfAfxESKeySKeyAfdV
-AfuZUrLIUruZuZuZZcZcZcuZTRuZuZ
-AfuZvctaInQXltuZfzENrwrnXYKIuZ
-AfuZbUmmiJiJeIuZUnCdtaItItOgZc
-AfuZUJiJunmmeIVvCdXYtaIttafMZc
-AfuZKzWvshtasluZItItZZgytanhuZ
-AfuZuZuZuZLIuZuZLIuZuZuZNduZuZ
-AfAfAfuZGrtEuZwztatauZYUgdgJuZ
-AfAfAfuZwGANuZcIItMMuZVWVWVWuZ
-AfAfAfuZuZuZuZuZZcuZuZuZNduZuZ
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+Af
+"}
+(2,1,1) = {"
+Af
+Af
+uZ
+Zc
+Zc
+Zc
+uZ
+uZ
+uZ
+uZ
+uZ
+uZ
+Af
+Af
+Af
+"}
+(3,1,1) = {"
+Af
+Af
+Zc
+fA
+fT
+oQ
+Ur
+vc
+bU
+UJ
+Kz
+uZ
+Af
+Af
+Af
+"}
+(4,1,1) = {"
+Af
+Af
+Zc
+tD
+eY
+ta
+LI
+ta
+mm
+iJ
+Wv
+uZ
+uZ
+uZ
+uZ
+"}
+(5,1,1) = {"
+Af
+Af
+Zc
+KM
+It
+Xk
+Ur
+In
+iJ
+un
+sh
+uZ
+Gr
+wG
+uZ
+"}
+(6,1,1) = {"
+HA
+dV
+uZ
+Zc
+Zc
+Zc
+uZ
+QX
+iJ
+mm
+ta
+LI
+tE
+AN
+uZ
+"}
+(7,1,1) = {"
+NQ
+Af
+Af
+Af
+Af
+Af
+uZ
+lt
+eI
+eI
+sl
+uZ
+uZ
+uZ
+uZ
+"}
+(8,1,1) = {"
+NQ
+Af
+Af
+Af
+Af
+Af
+uZ
+uZ
+uZ
+Vv
+uZ
+uZ
+wz
+cI
+uZ
+"}
+(9,1,1) = {"
+NQ
+Qe
+Qe
+Qe
+Qe
+xE
+Zc
+fz
+Un
+Cd
+It
+LI
+ta
+It
+Zc
+"}
+(10,1,1) = {"
+NQ
+ey
+SK
+SK
+ey
+SK
+Zc
+EN
+Cd
+XY
+It
+uZ
+ta
+MM
+uZ
+"}
+(11,1,1) = {"
+Eu
+Dp
+Qe
+Qe
+Qe
+ey
+Zc
+rw
+ta
+ta
+ZZ
+uZ
+uZ
+uZ
+uZ
+"}
+(12,1,1) = {"
+NQ
+SK
+ey
+SK
+ey
+SK
+uZ
+rn
+It
+It
+gy
+uZ
+YU
+VW
+uZ
+"}
+(13,1,1) = {"
+NQ
+Qe
+Qe
+fP
+fP
+ey
+TR
+XY
+It
+ta
+ta
+Nd
+gd
+VW
+Nd
+"}
+(14,1,1) = {"
+NQ
+OV
+Af
+Af
+Af
+Af
+uZ
+KI
+Og
+fM
+nh
+uZ
+gJ
+VW
+uZ
+"}
+(15,1,1) = {"
+Oo
+dV
+dV
+dV
+dV
+dV
+uZ
+uZ
+Zc
+Zc
+uZ
+uZ
+uZ
+uZ
+uZ
 "}

--- a/_maps/RandomRuins/Planet/weather_station.dmm
+++ b/_maps/RandomRuins/Planet/weather_station.dmm
@@ -1,0 +1,85 @@
+"bU" = (/obj/structure/table,/obj/machinery/microwave,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"cI" = (/obj/structure/closet/wardrobe,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"dV" = (/obj/structure/fence,/obj/effect/spawner/clear,/turf/template_noop,/area/template_noop)
+"ey" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
+"eI" = (/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"eY" = (/obj/structure/chair/office{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"fz" = (/obj/effect/turf_decal/trimline/yellow/filled/warning,/obj/structure/rack,/obj/effect/spawner/lootdrop/powercell,/obj/effect/spawner/lootdrop/toolbox,/turf/open/floor/plating,/area/ruin/unpowered)
+"fA" = (/obj/structure/table,/obj/item/reagent_containers/food/drinks/coffee,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"fM" = (/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 8},/obj/structure/closet/crate,/obj/item/mop,/obj/item/reagent_containers/glass/bucket,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"fP" = (/obj/machinery/power/solar,/obj/structure/cable,/obj/structure/cable,/turf/open/floor/iron/solarpanel,/area/template_noop)
+"fT" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/table,/obj/item/paper_bin,/obj/item/pen,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"gd" = (/turf/open/floor/plating,/area/ruin/unpowered)
+"gy" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/directional/south,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"gJ" = (/obj/machinery/portable_atmospherics/scrubber,/turf/open/floor/plating/rust,/area/ruin/unpowered)
+"iJ" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/carpet/green,/area/ruin/unpowered)
+"lt" = (/obj/machinery/power/apc/auto_name/north{start_charge = 0},/obj/structure/cable,/obj/structure/table,/obj/item/storage/box/drinkingglasses,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"mm" = (/turf/open/floor/carpet/green,/area/ruin/unpowered)
+"nh" = (/obj/structure/closet/firecloset/full,/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 8},/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"oQ" = (/obj/item/kirbyplants/random,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"rn" = (/obj/machinery/light/directional/north,/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"rw" = (/obj/effect/turf_decal/trimline/yellow/filled/warning,/obj/machinery/portable_atmospherics/canister/air,/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 4},/obj/machinery/power/terminal{dir = 8},/obj/structure/cable,/turf/open/floor/plating,/area/ruin/unpowered)
+"sh" = (/obj/structure/table,/obj/machinery/light/directional/south,/obj/item/plate{pixel_x = -7},/obj/item/kitchen/fork{pixel_x = 7},/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"sl" = (/obj/structure/closet/crate/bin,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"ta" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"tD" = (/obj/machinery/computer,/obj/machinery/light/directional/north,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"tE" = (/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"un" = (/obj/item/chair,/turf/open/floor/carpet/green,/area/ruin/unpowered)
+"uZ" = (/turf/closed/wall/concrete,/area/ruin/unpowered)
+"vc" = (/obj/machinery/light_switch/directional/west,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"wz" = (/obj/structure/table,/obj/item/flashlight/lamp,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"wG" = (/obj/machinery/shower{dir = 4},/obj/structure/curtain,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"xE" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
+"Af" = (/turf/template_noop,/area/template_noop)
+"AN" = (/obj/structure/sink{dir = 8; pixel_x = 11},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"Cd" = (/obj/effect/decal/cleanable/dirt/dust,/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"Dp" = (/obj/structure/cable,/obj/machinery/power/tracker,/turf/open/floor/iron/solarpanel,/area/template_noop)
+"Eu" = (/obj/effect/spawner/clear,/obj/structure/fence{dir = 8},/turf/template_noop,/area/template_noop)
+"EN" = (/obj/machinery/power/smes,/obj/structure/cable,/obj/effect/turf_decal/trimline/yellow/filled/warning,/turf/open/floor/plating,/area/ruin/unpowered)
+"Gr" = (/obj/structure/toilet{dir = 4},/obj/machinery/light/directional/north,/turf/open/floor/iron/freezer,/area/ruin/unpowered)
+"HA" = (/obj/effect/spawner/clear,/obj/effect/spawner/clear,/obj/structure/fence/corner{dir = 10},/turf/template_noop,/area/template_noop)
+"In" = (/obj/machinery/light/directional/north,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"It" = (/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"Kz" = (/obj/structure/table,/obj/effect/spawner/lootdrop/garbage_spawner,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"KI" = (/obj/machinery/power/solar_control{dir = 8},/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"KM" = (/obj/structure/table,/obj/item/modular_computer/laptop/preset/civilian,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"LI" = (/obj/machinery/door/airlock/grunge,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"MM" = (/obj/structure/bed,/obj/item/bedsheet/black,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"Nd" = (/obj/machinery/door/airlock/grunge,/turf/open/floor/plating,/area/ruin/unpowered)
+"NQ" = (/obj/structure/fence{dir = 8},/obj/effect/spawner/clear,/turf/template_noop,/area/template_noop)
+"Og" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 8},/obj/effect/turf_decal/trimline/yellow/filled/warning{dir = 1},/obj/structure/reagent_dispensers/watertank,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"Oo" = (/obj/effect/spawner/clear,/obj/effect/spawner/clear,/obj/structure/fence/corner{dir = 6},/turf/template_noop,/area/template_noop)
+"OV" = (/obj/effect/decal/cleanable/garbage,/turf/template_noop,/area/template_noop)
+"Qe" = (/obj/machinery/power/solar,/obj/structure/cable,/turf/open/floor/iron/solarpanel,/area/template_noop)
+"QX" = (/obj/machinery/vending/coffee,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"SK" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating/rust,/area/template_noop)
+"TR" = (/obj/structure/cable,/obj/machinery/door/airlock/grunge,/turf/open/floor/plating,/area/ruin/unpowered)
+"Un" = (/obj/structure/sign/poster/official/work_for_a_future{pixel_x = -31},/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"Ur" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"UJ" = (/obj/structure/table,/obj/item/storage/box/donkpockets,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"Vv" = (/obj/machinery/door/airlock/grunge,/obj/structure/cable,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"VW" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/ruin/unpowered)
+"Wv" = (/obj/structure/table,/obj/structure/closet/mini_fridge,/obj/item/reagent_containers/food/drinks/waterbottle/large,/obj/item/reagent_containers/food/drinks/waterbottle/large,/obj/item/reagent_containers/food/drinks/waterbottle/large,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"Xk" = (/obj/structure/filingcabinet,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"XY" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+"YU" = (/obj/machinery/light/small/directional/north,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/rack,/obj/item/pickaxe,/obj/item/clothing/mask/gas/explorer,/obj/item/tank/internals/emergency_oxygen/double,/turf/open/floor/plating,/area/ruin/unpowered)
+"Zc" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/unpowered)
+"ZZ" = (/obj/machinery/light_switch/directional/south,/turf/open/floor/iron/smooth,/area/ruin/unpowered)
+
+(1,1,1) = {"
+AfAfAfAfAfHANQNQNQNQEuNQNQNQOo
+AfAfAfAfAfdVAfAfQeeyDpSKQeOVdV
+AfuZZcZcZcuZAfAfQeSKQeeyQeAfdV
+AfZcfAtDKMZcAfAfQeSKQeSKfPAfdV
+AfZcfTeYItZcAfAfQeeyQeeyfPAfdV
+AfZcoQtaXkZcAfAfxESKeySKeyAfdV
+AfuZUrLIUruZuZuZZcZcZcuZTRuZuZ
+AfuZvctaInQXltuZfzENrwrnXYKIuZ
+AfuZbUmmiJiJeIuZUnCdtaItItOgZc
+AfuZUJiJunmmeIVvCdXYtaIttafMZc
+AfuZKzWvshtasluZItItZZgytanhuZ
+AfuZuZuZuZLIuZuZLIuZuZuZNduZuZ
+AfAfAfuZGrtEuZwztatauZYUgdgJuZ
+AfAfAfuZwGANuZcIItMMuZVWVWVWuZ
+AfAfAfuZuZuZuZuZZcuZuZuZNduZuZ
+"}

--- a/code/modules/map_content/ruins/planetary/planet_ruins.dm
+++ b/code/modules/map_content/ruins/planetary/planet_ruins.dm
@@ -134,3 +134,19 @@
 	cost = 5
 	suffix = "mining_facility.dmm"
 	planet_requirements = PLANET_HABITABLE
+
+/datum/map_template/ruin/planetary/abandoned_containment
+	name = "Abandoned Containment"
+	id = "abandoned_containment"
+	description = "A long abandoned base containing a dangerous secret."
+	cost = 5
+	suffix = "abandoned_containment.dmm"
+	planet_requirements = PLANET_HABITABLE
+
+/datum/map_template/ruin/planetary/weather_station
+	name = "Weather Station"
+	id = "weather_station"
+	description = "A dormant weather research station."
+	cost = 5
+	suffix = "weather_station.dmm"
+	planet_requirements = PLANET_HABITABLE


### PR DESCRIPTION
Adds two new planetary ruins to the game, one medium sized, and one small.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Two new planetary, randomly spawnable ruins are added.
One is an adandoned base, containing several decent loot spawns, an ancient hardsuit, and a dangerous secret.
The second is a dormant weather research outpost, lying silent until the next labcoat settles in for a months-long shift.

## Why It's Good For The Game

Exploration variety is good, and having loot able to be found is helpful and exciting for players looking for salvage-oriented gameplay.

## Changelog
:cl:
add: Added two new planetary ruins, abandoned_containment and weather_station, as well as the code to spawn them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
