### PR TITLE
Buffs the mech plasma cutter blasts to 25 dmg from 10 dmg

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -28,7 +28,7 @@
 	mine_range = 5
 
 /obj/projectile/plasma/adv/mech
-	damage = 10
+	damage = 25
 	range = 9
 	mine_range = 3
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mining mechs literally cant fight fauna because their guns tickle them because TG made all plasma blasts deal 1/4th of the damage because adv cutters are printable weapons. I dont like the low damage of cutters and adv cutters, but I do agree that they're printable weapons and high damage for them would be bad. But damage of a mech weapon being lower than a TOOLBOX is a joke

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bulky mech weapons shouldn't have a lower damage than a toolbox (and 1/3 of the DPS because of fire rate)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Buffs the mech plasma cutter blasts to 25 dmg from 10 dmg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
