### PR TITLE
Adds crates to in-hand crafting. Satchels and Gear Harnesses too.

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -180,6 +180,8 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("leather shoes", /obj/item/clothing/shoes/laceup, 2), \
 	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10), \
 	new/datum/stack_recipe("saddle", /obj/item/saddle, 5), \
+	new/datum/stack_recipe("gear harness", /obj/item/clothing/under/misc/gear_harness, 4), \
+
 ))
 
 /obj/item/stack/sheet/leather/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -181,7 +181,6 @@ GLOBAL_LIST_INIT(leather_recipes, list ( \
 	new/datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10), \
 	new/datum/stack_recipe("saddle", /obj/item/saddle, 5), \
 	new/datum/stack_recipe("gear harness", /obj/item/clothing/under/misc/gear_harness, 4), \
-
 ))
 
 /obj/item/stack/sheet/leather/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -168,7 +168,23 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 50, one_per_turf = 1, on_floor = 1), \
 		new/datum/stack_recipe("vault door assembly", /obj/structure/door_assembly/door_assembly_vault, 6, time = 50, one_per_turf = 1, on_floor = 1), \
 	)), \
+	null, \
+    new /datum/stack_recipe_list("crates & carts", list( \
+        new/datum/stack_recipe("grey crate", /obj/structure/closet/crate, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+        new/datum/stack_recipe("medical crate", /obj/structure/closet/crate/medical, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+        new/datum/stack_recipe("freezer crate", /obj/structure/closet/crate/freezer, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+        new/datum/stack_recipe("internals crate", /obj/structure/closet/crate/internals, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+        new/datum/stack_recipe("hydroponics crate", /obj/structure/closet/crate/hydroponics, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+        new/datum/stack_recipe("radiation crate", /obj/structure/closet/crate/radiation, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+        new/datum/stack_recipe("engineering crate", /obj/structure/closet/crate/engineering, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+        new/datum/stack_recipe("science crate", /obj/structure/closet/crate/science, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("trash cart", /obj/structure/closet/crate/trashcart, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("laundry cart", /obj/structure/closet/crate/trashcart/laundry, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+	)), \
 ))
+
+/obj/structure/closet/crate/trashcart/laundry
+/obj/structure/closet/crate/trashcart
 
 /obj/item/stack/sheet/plasteel
 	name = "plasteel"
@@ -303,6 +319,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("white scarf", /obj/item/clothing/neck/scarf, 1), \
 	null, \
 	new/datum/stack_recipe("backpack", /obj/item/storage/backpack, 4), \
+	new/datum/stack_recipe("satchel", /obj/item/storage/backpack/satchel, 4), \
 	new/datum/stack_recipe("duffel bag", /obj/item/storage/backpack/duffelbag, 6), \
 	null, \
 	new/datum/stack_recipe("plant bag", /obj/item/storage/bag/plants, 4), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -169,15 +169,15 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 		new/datum/stack_recipe("vault door assembly", /obj/structure/door_assembly/door_assembly_vault, 6, time = 50, one_per_turf = 1, on_floor = 1), \
 	)), \
 	null, \
-    new /datum/stack_recipe_list("crates & carts", list( \
-        new/datum/stack_recipe("grey crate", /obj/structure/closet/crate, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-        new/datum/stack_recipe("medical crate", /obj/structure/closet/crate/medical, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-        new/datum/stack_recipe("freezer crate", /obj/structure/closet/crate/freezer, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-        new/datum/stack_recipe("internals crate", /obj/structure/closet/crate/internals, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-        new/datum/stack_recipe("hydroponics crate", /obj/structure/closet/crate/hydroponics, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-        new/datum/stack_recipe("radiation crate", /obj/structure/closet/crate/radiation, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-        new/datum/stack_recipe("engineering crate", /obj/structure/closet/crate/engineering, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-        new/datum/stack_recipe("science crate", /obj/structure/closet/crate/science, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+	new /datum/stack_recipe_list("crates & carts", list( \
+		new/datum/stack_recipe("grey crate", /obj/structure/closet/crate, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("medical crate", /obj/structure/closet/crate/medical, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("freezer crate", /obj/structure/closet/crate/freezer, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("internals crate", /obj/structure/closet/crate/internals, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("hydroponics crate", /obj/structure/closet/crate/hydroponics, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("radiation crate", /obj/structure/closet/crate/radiation, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("engineering crate", /obj/structure/closet/crate/engineering, 2, time = 15, one_per_turf = 1, on_floor = 1), \
+		new/datum/stack_recipe("science crate", /obj/structure/closet/crate/science, 2, time = 15, one_per_turf = 1, on_floor = 1), \
 		new/datum/stack_recipe("trash cart", /obj/structure/closet/crate/trashcart, 2, time = 15, one_per_turf = 1, on_floor = 1), \
 		new/datum/stack_recipe("laundry cart", /obj/structure/closet/crate/trashcart/laundry, 2, time = 15, one_per_turf = 1, on_floor = 1), \
 	)), \

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -14,6 +14,8 @@
 	close_sound = 'sound/machines/crate_close.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 50
+	material_drop = /obj/item/stack/sheet/plasteel
+	material_drop_amount = 2
 	drag_slowdown = 0
 	var/crate_climb_time = 20
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a submenu for plasteel crafting to make most unsecured crate types. Adds Gear Harness and Satchels as craftables as well. Also changes crates to give plasteel. It's -technically- possible for crates to be profitable to craft, but its very little money.

## Why It's Good For The Game

I like organizing. Themed crates help me remain organized.

![dreamseeker_8jQPnicFAH](https://user-images.githubusercontent.com/7543955/125172163-163e9700-e186-11eb-9286-c8958db60191.png)
![ZeDAeC0ASu](https://user-images.githubusercontent.com/7543955/125172166-18a0f100-e186-11eb-997d-7680e51b4c7b.png)


## Changelog
:cl:
balance: Crates drop 2 plasteel instead of 2 iron now.
add: Crates, satchels, and gear harnesses can now be in-hand crafted with plasteel, cloth, and leather.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
