### PR TITLE
Makes IPC / Vox organs printable.

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -861,3 +861,94 @@
 	construction_time = 150
 	build_path = /obj/effect/mob_spawn/drone
 	category = list("Control Interfaces")
+
+//Synthetic Organs
+/datum/design/robot_eyes
+	name = "Robotic Eyes"
+	desc = "A very basic set of optical sensors with no extra vision modes or functions."
+	id = "robot_eyes"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
+	build_path = /obj/item/organ/eyes/robot_ipc
+	category = list("Robot Parts")
+
+/datum/design/robot_ears
+	name = "Auditory Sensors"
+	desc = "A pair of microphones intended to be installed in a robotic head, that grant the ability to hear."
+	id = "robot_ears"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
+	build_path = /obj/item/organ/ears/robot_ipc
+	category = list("Robot Parts")
+
+/datum/design/robot_tongue
+	name = "Robotic Voicebox"
+	desc = "A voice synthesizer that can interface with organic lifeforms."
+	id = "robot_tongue"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
+	build_path = /obj/item/organ/tongue/robot_ipc
+	category = list("Robot Parts")
+
+/datum/design/robot_heart
+	name = "Hydraulic Pump Engine"
+	desc = "An electronic device that handles the hydraulic pumps, powering one's robotic limbs."
+	id = "robot_heart"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	build_path = /obj/item/organ/heart/robot_ipc
+	category = list("Robot Parts")
+
+/datum/design/robot_liver
+	name = "Reagent Processing Unit"
+	desc = "An electronic device that processes the beneficial chemicals for the synthetic user."
+	id = "robot_liver"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	build_path = /obj/item/organ/liver/robot_ipc
+	category = list("Robot Parts")
+
+/datum/design/robot_lungs
+	name = "Heat Sink"
+	desc = "A device that transfers generated heat to a fluid medium to cool it down. Required to keep your synthetics cool-headed. It's shape resembles lungs."
+	id = "robot_lungs"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	build_path = /obj/item/organ/lungs/robot_ipc
+	category = list("Robot Parts")
+
+/datum/design/robotic_heart
+	name = "IPC Micro Cell"
+	desc = "A specialised cell, for robotic use only. Do not swallow. Stores energy."
+	id = "robot_stomach"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	build_path = /obj/item/organ/stomach/robot_ipc
+	category = list("Robot Parts")
+
+/datum/design/power_cord
+	name = "Power Cord Implant"
+	desc = "An implant allowing synthetics to recharge using APCs."
+	id = "power_cord"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
+	build_path = /obj/item/organ/cyberimp/arm/power_cord
+	category = list("Robot Parts")
+
+/datum/design/vox_lungs
+	name = "Vox Lungs"
+	desc = "A pair of lungs for breathing nitrogen."
+	id = "vox_lungs"
+	build_type = MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	build_path = /obj/item/organ/lungs/vox
+	category = list("Robot Parts")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -87,6 +87,23 @@
 		"sflash",
 	)
 
+/datum/techweb_node/robot_parts
+	id = "robot_organs"
+	starting_node = TRUE
+	display_name = "Robot Parts"
+	description = "Basic `organs` for robotic or synthetic lifeforms."
+	design_ids = list(
+		"robot_eyes",
+		"robot_ears",
+		"robot_tongue",
+		"robot_heart",
+		"robot_liver",
+		"robot_lungs",
+		"robot_stomach",
+		"power_cord",
+		"vox_lungs",
+	)
+
 /datum/techweb_node/mech
 	id = "mecha"
 	starting_node = TRUE

--- a/code/modules/surgery/organs/ipc.dm
+++ b/code/modules/surgery/organs/ipc.dm
@@ -151,7 +151,7 @@
 	organ_flags = ORGAN_SYNTHETIC
 	status = ORGAN_ROBOTIC
 	icon = 'icons/obj/ipc_surgery.dmi'
-	icon_state = "liver-c"
+	icon_state = "liver-ipc"
 	filterToxins = FALSE //We dont filter them, we're immune ot them
 
 /obj/item/organ/cyberimp/arm/power_cord

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -57,6 +57,7 @@
 								"Exosuit Ammunition",
 								"Cyborg Upgrade Modules",
 								"Cybernetics",
+								"Robot Parts",
 								"Implants",
 								"Control Interfaces",
 								"Misc"


### PR DESCRIPTION


## About The Pull Request

- Added IPC/Synth Organs to Mechfab
- Added Vox Lungs to Mechfab
- Fixed IPC lung icon.

## Why It's Good For The Game

It's nice to be able to fix someone after they've been EMP'd. Or if they've lost their arm implant somehow.

## Changelog
:cl:
add: Mechfab can print IPC/Synth/Vox Parts
fix: IPC lungs are now visible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
