### PR TITLE
Removes coughing from nicotine withdrawal

### DIFF
--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -251,11 +251,7 @@
 /datum/addiction/nicotine/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	affected_carbon.Jitter(10 * delta_time)
-	if(DT_PROB(10, delta_time))
-		affected_carbon.emote("cough")
 
 /datum/addiction/nicotine/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, delta_time)
 	. = ..()
 	affected_carbon.Jitter(15 * delta_time)
-	if(DT_PROB(15, delta_time))
-		affected_carbon.emote("cough")


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin

Tagged as fix because this is just utter deranged shit.

## Why It's Good For The Game
Because 
- It's non-sensical
- its "fun" to *cough every 2 seconds because you didnt smoke for a minute.

## Changelog
:cl: Avunia Takiya
fix: Removed coughing from nicotine withdrawal stages.
/:cl:
