### PR TITLE
Mirage border fully componentized

### DIFF
--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -1,5 +1,6 @@
 /datum/component/mirage_border
 	can_transfer = TRUE
+	var/turf/target_turf
 	var/obj/effect/abstract/mirage_holder/holder
 
 /datum/component/mirage_border/Initialize(turf/target, direction, range=world.view)
@@ -11,6 +12,7 @@
 
 	holder = new(parent)
 
+	target_turf = target
 	var/x = target.x
 	var/y = target.y
 	var/z = target.z
@@ -24,17 +26,68 @@
 	if(direction & WEST)
 		holder.pixel_x -= world.icon_size * range
 
+	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/on_entered)
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_GHOST, .proc/on_attack_ghost)
+
 /datum/component/mirage_border/Destroy()
+	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ENTERED))
 	QDEL_NULL(holder)
 	return ..()
 
 /datum/component/mirage_border/PreTransfer()
 	holder.moveToNullspace()
+	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACK_GHOST, COMSIG_ATOM_ENTERED))
 
 /datum/component/mirage_border/PostTransfer()
 	if(!isturf(parent))
 		return COMPONENT_INCOMPATIBLE
+	target_turf = parent
 	holder.forceMove(parent)
+	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/on_entered)
+	RegisterSignal(parent, COMSIG_ATOM_ATTACK_GHOST, .proc/on_attack_ghost)
+
+/datum/component/mirage_border/proc/on_entered(atom/source, atom/movable/AM)
+	SIGNAL_HANDLER
+	var/turf/desired_turf = target_turf
+	var/tx = desired_turf.x
+	var/ty = desired_turf.y
+	var/itercount = 0
+	while(desired_turf.density || istype(desired_turf.loc,/area/shuttle)) // Extend towards the center of the map, trying to look for a better place to arrive
+		if (itercount++ >= 100)
+			log_game("SPACE Z-TRANSIT ERROR: Could not find a safe place to land [AM] within 100 iterations.")
+			break
+		if (tx < 128)
+			tx++
+		else
+			tx--
+		if (ty < 128)
+			ty++
+		else
+			ty--
+		desired_turf = locate(tx, ty, desired_turf.z)
+
+	AM.forceMove(desired_turf)
+	var/atom/movable/pulling = AM.pulling
+	var/atom/movable/puller = AM
+
+	while(pulling != null)
+		var/next_pulling = pulling.pulling
+
+		var/turf/T = get_step(puller.loc, turn(puller.dir, 180))
+		pulling.can_be_z_moved = FALSE
+		pulling.forceMove(T)
+		puller.start_pulling(pulling)
+		pulling.can_be_z_moved = TRUE
+
+		puller = pulling
+		pulling = next_pulling
+
+	AM.newtonian_move(AM.inertia_dir)
+	AM.inertia_moving = TRUE
+
+/datum/component/mirage_border/proc/on_attack_ghost(datum/source, mob/dead/observer/ghost)
+	SIGNAL_HANDLER
+	ghost.forceMove(target_turf)
 
 /obj/effect/abstract/mirage_holder
 	name = "Mirage holder"

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -8,10 +8,6 @@
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 700000
 
-	var/destination_z
-	var/destination_x
-	var/destination_y
-
 	var/static/datum/gas_mixture/immutable/space/space_gas = new
 	plane = PLANE_SPACE
 	layer = SPACE_LAYER
@@ -73,12 +69,6 @@
 	ComponentInitialize()
 
 	return INITIALIZE_HINT_NORMAL
-
-//ATTACK GHOST IGNORING PARENT RETURN VALUE
-/turf/open/space/attack_ghost(mob/dead/observer/user)
-	if(destination_z)
-		var/turf/T = locate(destination_x, destination_y, destination_z)
-		user.forceMove(T)
 
 /turf/open/space/Initalize_Atmos(times_fired)
 	return
@@ -159,52 +149,6 @@
 		else
 			to_chat(user, SPAN_WARNING("The plating is going to need some support! Place metal rods first."))
 
-/turf/open/space/Entered(atom/movable/A)
-	. = ..()
-	if ((!(A) || src != A.loc))
-		return
-
-	if(destination_z && destination_x && destination_y && !(A.pulledby || !A.can_be_z_moved))
-		var/tx = destination_x
-		var/ty = destination_y
-		var/turf/DT = locate(tx, ty, destination_z)
-		var/itercount = 0
-		while(DT.density || istype(DT.loc,/area/shuttle)) // Extend towards the center of the map, trying to look for a better place to arrive
-			if (itercount++ >= 100)
-				log_game("SPACE Z-TRANSIT ERROR: Could not find a safe place to land [A] within 100 iterations.")
-				break
-			if (tx < 128)
-				tx++
-			else
-				tx--
-			if (ty < 128)
-				ty++
-			else
-				ty--
-			DT = locate(tx, ty, destination_z)
-
-		var/atom/movable/pulling = A.pulling
-		var/atom/movable/puller = A
-		A.forceMove(DT)
-
-		while (pulling != null)
-			var/next_pulling = pulling.pulling
-
-			var/turf/T = get_step(puller.loc, turn(puller.dir, 180))
-			pulling.can_be_z_moved = FALSE
-			pulling.forceMove(T)
-			puller.start_pulling(pulling)
-			pulling.can_be_z_moved = TRUE
-
-			puller = pulling
-			pulling = next_pulling
-
-		//now we're on the new z_level, proceed the space drifting
-		stoplag()//Let a diagonal move finish, if necessary
-		A.newtonian_move(A.inertia_dir)
-		A.inertia_moving = TRUE
-
-
 /turf/open/space/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)
 	return
 
@@ -215,11 +159,6 @@
 	if(locate(/obj/structure/lattice/catwalk, src))
 		return TRUE
 	return FALSE
-
-/turf/open/space/is_transition_turf()
-	if(destination_x || destination_y || destination_z)
-		return TRUE
-
 
 /turf/open/space/acid_act(acidpwr, acid_volume)
 	return FALSE
@@ -251,12 +190,3 @@
 			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 			return TRUE
 	return FALSE
-
-/turf/open/space/ReplaceWithLattice()
-	var/dest_x = destination_x
-	var/dest_y = destination_y
-	var/dest_z = destination_z
-	..()
-	destination_x = dest_x
-	destination_y = dest_y
-	destination_z = dest_z

--- a/code/modules/mapping/space_management/space_transition.dm
+++ b/code/modules/mapping/space_management/space_transition.dm
@@ -121,10 +121,14 @@
 					D = D.neigbours["[dirside]"]
 				zdestination = D.z_value
 			D = I
-			for(var/turf/open/space/S in turfblock)
-				S.destination_x = x_pos_transition[side] == 1 ? S.x : x_pos_transition[side]
-				S.destination_y = y_pos_transition[side] == 1 ? S.y : y_pos_transition[side]
-				S.destination_z = zdestination
+			for(var/turfcheck in turfblock)
+				//Only space and openspace turfs can be mirage level transits
+				if(!isspaceturf(turfcheck) && !isopenspaceturf(turfcheck))
+					continue
+				var/turf/open/S = turfcheck
+				var/destination_x = x_pos_transition[side] == 1 ? S.x : x_pos_transition[side]
+				var/destination_y = y_pos_transition[side] == 1 ? S.y : y_pos_transition[side]
+				var/destination_z = zdestination
 				
 				// Mirage border code
 				var/mirage_dir
@@ -139,5 +143,5 @@
 				if(!mirage_dir)
 					continue
 
-				var/turf/place = locate(S.destination_x, S.destination_y, S.destination_z)
+				var/turf/place = locate(destination_x, destination_y, destination_z)
 				S.AddComponent(/datum/component/mirage_border, place, mirage_dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have made it so the behaviour of border transit is fully within this component, however there is an issue. That transit behaviour should not only apply to the mirage turf, but also to all behind it and there isn't an easy way to do (mostly due to memory sinks, we're handling 8,100 turfs per level for this behaviour), but I can think of a couple ideas:
1. Element holding no information but calculating everything it has to do when something steps on it.
 - While only instantiating 1 element, we'll still will be creating 16,000 lists per level to hold the signals and element reference
2. Global bounding box, checking whether ghosts are clicking out of the bounds of the map (guaranteed transit space), or things entering there
 - Almost no memory cost, but somewhat of a performance cost
3. Each mirage border component managing signals to the line of turfs (8) behind it.
- 8,000 lists per level to hold the signals and janky code to manage it, probably most performant of the options?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mirage borders now work with all types of turfs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
