### PR TITLE
Adds a pocket crowbar to the internals box

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -165,7 +165,7 @@
 	new /obj/item/radio/off(src)
 
 // Syndie survival box
-/obj/item/storage/box/survival/syndie //why is this its own thing if it's just the engi box with a syndie mask and medipen?
+/obj/item/storage/box/survival/syndie //why is this its own thing if it's just the engi box with a syndie mask and medipen? // Good question.
 	name = "extended-capacity survival box"
 	desc = "A box with the bare essentials of ensuring the survival of you and others. This one is labelled to contain an extended-capacity tank."
 	mask_type = /obj/item/clothing/mask/gas/syndicate
@@ -863,6 +863,8 @@
 		new /obj/item/tank/internals/nitrogen/belt/emergency(src)
 	else
 		new /obj/item/tank/internals/emergency_oxygen(src)
+
+	new /obj/item/crowbar(src)
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -135,6 +135,8 @@
 	else
 		new /obj/item/tank/internals/emergency_oxygen(src)
 
+	new /obj/item/crowbar(src)
+
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)
 		new /obj/item/radio/off(src)


### PR DESCRIPTION
## Why It's Good For The Game
A lot of things require a crowbar to be at hand, even just for survival.
This remedies those situations.

An even smaller version is to be added later to replace this bandaid, with a special "emergency crowbar"

## Changelog
:cl: Avunia Takiya
qol: Your internals box now contains a pocket crowbar for emergencies. Please handle with care.
/:cl:
