### PR TITLE
Removes the liquid pump from the mining trader

### DIFF
--- a/code/modules/trading/sold_goods/goods.dm
+++ b/code/modules/trading/sold_goods/goods.dm
@@ -375,10 +375,6 @@
 	stock_high = 4
 	stock_low = 2
 
-/datum/sold_goods/liquid_pump
-	cost = 700
-	path = /obj/machinery/plumbing/liquid_pump
-
 /datum/sold_goods/stack/iron_ten
 	stock_high = 3
 	stock_low = 10

--- a/code/modules/trading/traders/goods.dm
+++ b/code/modules/trading/traders/goods.dm
@@ -268,9 +268,8 @@
 								/datum/sold_goods/stack/uranium_ten = 100,
 								/datum/sold_goods/stack/plasma_ten = 100,
 								/datum/sold_goods/stack/diamond_five = 100,
-								/datum/sold_goods/mining_kit = 100,
-								/datum/sold_goods/liquid_pump = 100)
-	target_sold_goods_amount = 7
+								/datum/sold_goods/mining_kit = 100)
+	target_sold_goods_amount = 6
 	target_bought_goods_amount = 5
 
 /datum/trader/petshop


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You buy it and it spawns anchored to the ground and there's nothing you can do with it anyway without a chemistry plumber, which if you have, there's no reason for you to buy the pump because the plumber can spawn those

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removes the liquid pump from the mining trader
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
