### PR TITLE
Emission caps for pollution

### DIFF
--- a/code/__DEFINES/pollution.dm
+++ b/code/__DEFINES/pollution.dm
@@ -32,3 +32,6 @@
 
 #define POLLUTANT_APPEARANCE_THICKNESS_THRESHOLD 30
 #define THICKNESS_ALPHA_COEFFICIENT 0.0025
+
+//Cap for active emitters that can be running for a very long time
+#define POLLUTION_ACTIVE_EMITTER_CAP 400

--- a/code/__DEFINES/pollution.dm
+++ b/code/__DEFINES/pollution.dm
@@ -34,4 +34,4 @@
 #define THICKNESS_ALPHA_COEFFICIENT 0.0025
 
 //Cap for active emitters that can be running for a very long time
-#define POLLUTION_ACTIVE_EMITTER_CAP 400
+#define POLLUTION_ACTIVE_EMITTER_CAP 300

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -320,12 +320,16 @@
 		return
 	new /obj/effect/abstract/turf_fire(src, power)
 
-/turf/open/PolluteTurf(pollution_type, amount)
+/turf/open/PolluteTurf(pollution_type, amount, cap)
 	if(!pollution)
 		pollution = new(src)
+	if(cap && pollution.total_amount >= cap)
+		return
 	pollution.AddPollutant(pollution_type, amount)
 
-/turf/open/PolluteListTurf(list/pollutions)
+/turf/open/PolluteListTurf(list/pollutions, cap)
 	if(!pollution)
 		pollution = new(src)
+	if(cap && pollution.total_amount >= cap)
+		return
 	pollution.AddPollutantList(pollutions)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -666,10 +666,10 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/proc/IgniteTurf(power)
 	return
 
-/turf/proc/PolluteTurf(pollution_type, amount)
+/turf/proc/PolluteTurf(pollution_type, amount, cap)
 	return
 
-/turf/proc/PolluteListTurf(list/pollutions)
+/turf/proc/PolluteListTurf(list/pollutions, cap)
 	return
 
 /turf/proc/IsTransparent()

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -292,7 +292,7 @@
 		extinguish()
 		return
 	var/turf/my_turf = get_turf(src)
-	my_turf.PolluteListTurf(list(/datum/pollutant/smoke = 20, /datum/pollutant/carbon_air_pollution = 5))
+	my_turf.PolluteListTurf(list(/datum/pollutant/smoke = 20, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_ACTIVE_EMITTER_CAP)
 	if(!grill)
 		Burn(delta_time)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added an option to cap the pollution emission, and does so for Bonfires, since they're a powerful pollution emitter that can be running effortlessly for a very long time

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Added emission caps for pollution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
