### PR TITLE
FTV Bearcat missing equipment + fixes

### DIFF
--- a/_maps/map_files/tradership/tradership1.dmm
+++ b/_maps/map_files/tradership/tradership1.dmm
@@ -139,6 +139,7 @@
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eP" = (
@@ -203,6 +204,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gU" = (
@@ -219,6 +221,7 @@
 "gX" = (
 /obj/machinery/light/dim/directional/east,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hq" = (
@@ -861,11 +864,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "Cz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
+"CB" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "CD" = (
@@ -1015,6 +1024,7 @@
 "Jx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "JO" = (
@@ -1405,6 +1415,7 @@
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "TU" = (
@@ -1486,6 +1497,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"Vt" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "VW" = (
 /obj/structure/cable,
 /obj/effect/spawner/randomcolavend,
@@ -32872,7 +32887,7 @@ vF
 kc
 su
 YP
-kg
+Vt
 gX
 kg
 Kv
@@ -33383,7 +33398,7 @@ Kr
 rt
 Kr
 Kr
-Iy
+CB
 wF
 pB
 QR

--- a/_maps/map_files/tradership/tradership2.dmm
+++ b/_maps/map_files/tradership/tradership2.dmm
@@ -1819,8 +1819,8 @@
 	},
 /area/commons/dorms/barracks)
 "YM" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/white,
 /area/science)
 "YR" = (

--- a/_maps/map_files/tradership/tradership2.dmm
+++ b/_maps/map_files/tradership/tradership2.dmm
@@ -180,10 +180,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"fW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "gh" = (
-/obj/structure/rack,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "gq" = (
@@ -243,6 +250,7 @@
 "hF" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/railing/corner,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "hV" = (
@@ -291,6 +299,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/engine,
 /area/science/research/abandoned)
+"jE" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/commons/vacant_room)
 "jM" = (
 /obj/effect/landmark/latejoin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -628,6 +640,10 @@
 /obj/item/metal_density_scanner,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"rd" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/construction/storage_wing)
 "rn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -702,6 +718,7 @@
 /area/science)
 "tl" = (
 /obj/machinery/airalarm/directional/south,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/commons/vacant_room)
 "tX" = (
@@ -789,6 +806,7 @@
 /area/commons/dorms)
 "vS" = (
 /obj/item/radio/intercom/directional/south,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "vV" = (
@@ -911,8 +929,8 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "zv" = (
-/obj/structure/rack,
 /obj/machinery/light_switch/directional/north,
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
 "zF" = (
@@ -1064,6 +1082,7 @@
 /area/cargo/warehouse)
 "DO" = (
 /obj/machinery/airalarm/directional/south,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "Eh" = (
@@ -1272,6 +1291,7 @@
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron,
 /area/construction/storage_wing)
 "Kt" = (
@@ -1856,6 +1876,7 @@
 /area/commons/cryopods)
 "ZY" = (
 /obj/machinery/airalarm/directional/south,
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
 
@@ -33596,10 +33617,10 @@ sk
 My
 KW
 sk
-OX
+sk
 NA
 sk
-sk
+OX
 sk
 sk
 pR
@@ -33867,7 +33888,7 @@ Zj
 Gd
 Kp
 BI
-xD
+rd
 Me
 Mg
 Mg
@@ -35655,7 +35676,7 @@ Uc
 Ph
 nb
 Js
-Zz
+fW
 Zz
 AN
 nb
@@ -36172,7 +36193,7 @@ WG
 zG
 WG
 WG
-Rr
+jE
 Qc
 Rr
 Ny

--- a/_maps/map_files/tradership/tradership3.dmm
+++ b/_maps/map_files/tradership/tradership3.dmm
@@ -39,7 +39,8 @@
 "aJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = medbay_shutter1
+	id = "medbay_shutter1";
+	id_tag = null
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
@@ -55,8 +56,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aS" = (
-/obj/item/kirbyplants/dead,
 /obj/machinery/light_switch/directional/north,
+/obj/item/kirbyplants/dead,
 /turf/open/floor/plating,
 /area/hallway/primary/central/fore)
 "bb" = (
@@ -83,6 +84,7 @@
 /area/engineering/atmos)
 "bz" = (
 /obj/machinery/atmospherics/components/binary/pump/on/scrubbers/visible,
+/obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "bA" = (
@@ -189,6 +191,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"dg" = (
+/obj/structure/cable,
+/obj/structure/closet/radiation,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/engineering/main)
 "dm" = (
 /obj/machinery/requests_console/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -251,8 +259,8 @@
 /area/commons/lounge)
 "ek" = (
 /obj/machinery/button/door/directional/east{
-	id = 1;
-	id_tag = medbay_shutter1;
+	id = "medbay_shutter1";
+	id_tag = null;
 	name = "Privacy Shutter";
 	pixel_x = 9
 	},
@@ -365,6 +373,7 @@
 "fQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "fU" = (
@@ -391,6 +400,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"gk" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/openspace/airless/planetary,
+/area/space)
 "gt" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -419,6 +435,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"gM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/space_heater,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "gP" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room"
@@ -504,6 +525,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ib" = (
@@ -536,6 +558,9 @@
 "iD" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/pipe_dispenser,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "iF" = (
@@ -592,10 +617,23 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/command/bridge)
+"jc" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/plating,
+/area/hallway/primary/central/aft)
 "jf" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"jg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medbay_shutter1";
+	id_tag = null
+	},
+/turf/open/floor/plating,
+/area/medical/medbay)
 "jh" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/light/directional/east,
@@ -965,6 +1003,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"nW" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/hallway/primary/central/fore)
 "nZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
@@ -1006,6 +1048,7 @@
 "or" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ot" = (
@@ -1369,6 +1412,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"ut" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "uu" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -1451,6 +1498,17 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
+"uK" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "uL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -1928,6 +1986,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "BR" = (
@@ -1950,6 +2009,7 @@
 "BV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/cold/directional/east,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "Cc" = (
@@ -2483,6 +2543,18 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"Id" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "supermatter_blast"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "Ig" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2493,6 +2565,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating/airless,
 /area/hallway/primary/central)
+"Ik" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "Im" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
 	dir = 4
@@ -2846,6 +2923,10 @@
 /obj/structure/chair/office,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"Mh" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/hallway/primary/central/fore)
 "Mk" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
@@ -2854,6 +2935,12 @@
 "Mn" = (
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"Mo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "Mt" = (
 /obj/machinery/airalarm/engine{
 	dir = 1;
@@ -2966,8 +3053,8 @@
 /turf/closed/wall,
 /area/hallway/primary/central/aft)
 "OM" = (
-/obj/structure/closet/toolcloset,
 /obj/machinery/light_switch/directional/north,
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "OO" = (
@@ -3059,9 +3146,19 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "Qf" = (
-/obj/machinery/door/poddoor,
+/obj/machinery/door/poddoor{
+	id = "supermatter_blast"
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"Qj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "Ql" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3097,6 +3194,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"QB" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "QN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/closed/wall/r_wall,
@@ -3560,7 +3661,7 @@
 	name = "meeting room blast door"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/plating,
 /area/command/meeting_room)
 "XH" = (
 /obj/machinery/door/airlock/atmos,
@@ -28320,7 +28421,7 @@ DB
 DB
 DB
 DB
-DB
+gk
 DB
 DB
 DB
@@ -33733,9 +33834,9 @@ DT
 Dc
 oi
 or
-MP
+Mo
 uO
-uO
+uK
 AE
 rQ
 LO
@@ -34251,7 +34352,7 @@ NM
 XP
 dT
 gy
-gy
+gM
 Vm
 va
 EB
@@ -34508,7 +34609,7 @@ hO
 KX
 Xx
 Th
-Xx
+Ik
 sF
 sF
 sF
@@ -35000,7 +35101,7 @@ Hr
 GV
 GV
 fO
-Pw
+jc
 GV
 GV
 GV
@@ -35539,7 +35640,7 @@ Pa
 mI
 mI
 mI
-mI
+QB
 kr
 xZ
 xZ
@@ -35789,7 +35890,7 @@ yU
 wL
 Ai
 ne
-iB
+dg
 Yk
 me
 Cu
@@ -36313,7 +36414,7 @@ ZG
 ZG
 ZG
 IA
-Ey
+Id
 xZ
 hF
 vU
@@ -37576,7 +37677,7 @@ hC
 zE
 Lf
 FF
-CD
+Qj
 JM
 BS
 nC
@@ -37816,12 +37917,12 @@ sa
 VW
 VW
 kg
-kg
-kg
+nW
+Mh
 Oy
 fe
 QQ
-GV
+ut
 aH
 NF
 Pw
@@ -38087,7 +38188,7 @@ oX
 MS
 MS
 CU
-aJ
+jg
 Ll
 aJ
 ek

--- a/_maps/map_files/tradership/tradership3.dmm
+++ b/_maps/map_files/tradership/tradership3.dmm
@@ -558,9 +558,7 @@
 "iD" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/pipe_dispenser,
-/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "iF" = (

--- a/_maps/map_files/tradership/tradership4.dmm
+++ b/_maps/map_files/tradership/tradership4.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aw" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "bU" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/airless,
@@ -199,6 +203,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"vy" = (
+/obj/machinery/button/elevator{
+	id = "CARGOLIFT";
+	pixel_x = 27
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "vS" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -246,7 +257,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only,
-/turf/closed/wall,
+/turf/open/openspace,
 /area/maintenance/solars/port/aft)
 "zC" = (
 /turf/open/floor/plating/airless,
@@ -339,6 +350,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"Lg" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "MK" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -374,10 +389,6 @@
 "QM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/lattice/catwalk,
-/obj/machinery/button/elevator{
-	id = "CARGOLIFT";
-	pixel_x = 27
-	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/openspace,
 /area/maintenance/solars/port/aft)
@@ -33547,7 +33558,7 @@ oE
 nZ
 oE
 oE
-rQ
+vy
 yH
 IE
 IE
@@ -34064,8 +34075,8 @@ Ou
 oE
 oE
 HJ
-rQ
-rQ
+aw
+Lg
 oE
 oE
 oE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added:
Fire closets
Oxygen closets
Fire extinguisher cabinets
Engineer closet
Atmos closet
Electrical supplies closet (contain insuls)
Welding supplies closet
Portable scrubbers
Space heaters
Some more water tanks here and there

Fixes the SM blast door being opened by medbay shutter, and now it has its own button
The circuit imprinter is no longer a sci departmental one, but instead an omni one, so people don't have to flip it (or be confused) every shift

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a lot of missing equipment to the FTV Bearcat
fix: Fixed SM shutters opening from the medbay privacy button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
