### PR TITLE
Changed Vulture Descriptions

### DIFF
--- a/code/modules/shuttle/sold_shuttles.dm
+++ b/code/modules/shuttle/sold_shuttles.dm
@@ -26,8 +26,8 @@
 
 /datum/sold_shuttle/vulture
 	name = "MS Vulture"
-	desc = "A medium sized mining shuttle, equipped with living quarters."
-	detailed_desc = "It's medium sized and is equipped with three propulsion engines, canisters of co2 and oxygen, a portable generator, two mining lasers, a transporter and some emergency supplies. It has quarters and a restroom"
+	desc = "A medium sized mining shuttle, equipped with a living quarter."
+	detailed_desc = "It's medium sized and is equipped with three propulsion engines, canisters of co2 and oxygen, a portable generator, two mining lasers, a transporter and some emergency supplies. It has a singular living quarter and a restroom""
 	shuttle_id = "common_vulture"
 	cost = 7500
 	allowed_docks = list(DOCKS_MEDIUM_UPWARDS)

--- a/code/modules/shuttle/sold_shuttles.dm
+++ b/code/modules/shuttle/sold_shuttles.dm
@@ -27,7 +27,7 @@
 /datum/sold_shuttle/vulture
 	name = "MS Vulture"
 	desc = "A medium sized mining shuttle, equipped with a living quarter."
-	detailed_desc = "It's medium sized and is equipped with three propulsion engines, canisters of co2 and oxygen, a portable generator, two mining lasers, a transporter and some emergency supplies. It has a singular living quarter and a restroom""
+	detailed_desc = "It's medium sized and is equipped with three propulsion engines, canisters of co2 and oxygen, a portable generator, two mining lasers, a transporter and some emergency supplies. It has a singular living quarter and a restroom"
 	shuttle_id = "common_vulture"
 	cost = 7500
 	allowed_docks = list(DOCKS_MEDIUM_UPWARDS)


### PR DESCRIPTION
Summary
Corrects spelling error within MS Vulture's Description and Detailed Desc in Sold_Shuttles.DM 

Purpose of change
While playing with four of my friends on the Bearcat Map. We've bought the Vulture Shuttle which states that it has "Living Quarters" but it instead has one. 

Describe the solution
This simply fixes an inconvenience in lines 29 and 30 

Describe alternatives you've considered
Not submitting this pull request cause I'm a scared boi.

Testing
Compiles Correctly and once within Shuttle Console. States the new description including detailed.

Additional context
![image](https://user-images.githubusercontent.com/34495205/139787294-11b582b0-8ff0-44dd-803d-d798ebb14c86.png)


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Fixed an inaccuracy in Vulture shuttle description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

