### PR TITLE
Fixes asynchronous emote overwrite bug

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -93,11 +93,12 @@
  *
  * Returns TRUE if it was able to run the emote, FALSE otherwise.
  */
-/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE)
+/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE, override_message, override_emote_type)
 	. = TRUE
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
-	var/msg = select_message_type(user, message, intentional)
+	var/message_to_use = override_message || message
+	var/msg = select_message_type(user, message_to_use, intentional)
 	if(params && message_param)
 		msg = select_param(user, params)
 
@@ -127,7 +128,8 @@
 			if(ghost.stat == DEAD && ghost.client && user.client && (ghost.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers(user_turf, emote_distance)))
 				ghost.show_message(SPAN_EMOTE("[FOLLOW_LINK(ghost, user)] [dchatmsg]"))
 
-	if(emote_type == EMOTE_AUDIBLE)
+	var/emote_type_to_use = override_emote_type || emote_type
+	if(emote_type_to_use == EMOTE_AUDIBLE)
 		user.audible_message(msg, deaf_message = SPAN_EMOTE("You see how <b>[user]</b> [msg]"), audible_message_flags = EMOTE_MESSAGE, hearing_distance = emote_distance, show_ghosts = show_ghosts)
 	else
 		user.visible_message(msg, blind_message = SPAN_EMOTE("You hear how <b>[user]</b> [msg]"), visible_message_flags = EMOTE_MESSAGE, vision_distance = emote_distance, show_ghosts = show_ghosts)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -36,7 +36,7 @@
 	key = "help"
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer, /mob/living/silicon/ai)
 
-/datum/emote/help/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/help/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	var/list/keys = list()
 	var/list/message = list("Available emotes, you can use them with say \"*emote\": ")
@@ -61,7 +61,7 @@
 	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer, /mob/living/silicon/ai)
 
-/datum/emote/flip/run_emote(mob/user, params , type_override, intentional)
+/datum/emote/flip/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(.)
 		user.SpinAnimation(7,1)
@@ -95,7 +95,7 @@
 	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
 
-/datum/emote/spin/run_emote(mob/user, params ,  type_override, intentional)
+/datum/emote/spin/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(.)
 		user.spin(20, 1)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -101,7 +101,7 @@
 	key_third_person = "circles"
 	hands_use_check = TRUE
 
-/datum/emote/living/carbon/circle/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/circle/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!length(user.get_empty_held_indexes()))
 		to_chat(user, SPAN_WARNING("You don't have any free hands to make a circle with."))
@@ -116,7 +116,7 @@
 	hands_use_check = TRUE
 	cooldown = 3 SECONDS // to prevent endless table slamming
 
-/datum/emote/living/carbon/slap/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/slap/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!.)
 		return
@@ -132,7 +132,7 @@
 	key_third_person = "noogies"
 	hands_use_check = TRUE
 
-/datum/emote/living/carbon/noogie/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/noogie/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -115,7 +115,7 @@
 	key_third_person = "wags"
 	message = "wags their tail."
 
-/datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!.)
 		return
@@ -146,7 +146,7 @@
 	key_third_person = "wings"
 	message = "their wings."
 
-/datum/emote/living/carbon/human/wing/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/human/wing/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(.)
 		var/mob/living/carbon/human/H = user

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -46,7 +46,7 @@
 	message = "collapses!"
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/collapse/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/collapse/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
@@ -82,7 +82,7 @@
 	cooldown = (15 SECONDS)
 	stat_allowed = HARD_CRIT
 
-/datum/emote/living/deathgasp/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/deathgasp/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	var/mob/living/simple_animal/S = user
 	if(istype(S) && S.deathmessage)
 		message_simple = S.deathmessage
@@ -105,7 +105,7 @@
 	key_third_person = "faints"
 	message = "faints."
 
-/datum/emote/living/faint/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/faint/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
@@ -118,7 +118,7 @@
 	hands_use_check = TRUE
 	var/wing_time = 20
 /* Fix this later
-/datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/flap/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(. && ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -197,7 +197,7 @@
 	key_third_person = "kisses"
 	cooldown = 3 SECONDS
 
-/datum/emote/living/kiss/run_emote(mob/living/user, params, type_override, intentional)
+/datum/emote/living/kiss/run_emote(mob/living/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!.)
 		return
@@ -256,7 +256,7 @@
 	message_param = "points at %t."
 	hands_use_check = TRUE
 
-/datum/emote/living/point/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/point/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	message_param = initial(message_param) // reset
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -335,7 +335,7 @@
 	message = "sniffs."
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/sniff/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/sniff/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(.)
 		var/turf/open/current_turf = get_turf(user)
@@ -377,7 +377,7 @@
 	message = "puts their hands on their head and falls to the ground, they surrender%s!"
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/surrender/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/surrender/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
@@ -437,7 +437,6 @@
 	key_third_person = "custom"
 	message = null
 	var/subtle = FALSE
-	var/anti_ghost = FALSE
 
 /datum/emote/living/custom/can_run_emote(mob/user, status_check, intentional)
 	. = ..() && intentional
@@ -449,7 +448,7 @@
 		return TRUE
 	return FALSE
 
-/datum/emote/living/custom/run_emote(mob/user, params, type_override = null, intentional = FALSE)
+/datum/emote/living/custom/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	var/custom_emote
 	var/custom_emote_type
 	if(!can_run_emote(user, TRUE, intentional))
@@ -480,11 +479,9 @@
 			custom_emote_type = type_override
 	if(subtle)
 		custom_emote = "<i>[custom_emote]</i>"
-	message = custom_emote
-	emote_type = custom_emote_type
+	override_message = custom_emote
+	override_emote_type = custom_emote_type
 	. = ..()
-	message = null
-	emote_type = EMOTE_VISIBLE
 
 /datum/emote/living/custom/replace_pronoun(mob/user, message)
 	return message

--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -7,7 +7,7 @@
 	key = "blank"
 	var/emotion = AI_EMOTION_BLANK
 
-/datum/emote/ai/emotion_display/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/ai/emotion_display/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!.)
 		return
@@ -79,7 +79,7 @@
 	key = "friendcomputer"
 	emotion = AI_EMOTION_FRIEND_COMPUTER
 
-/datum/emote/ai/emotion_display/friend_computer/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/ai/emotion_display/friend_computer/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -26,7 +26,7 @@
 	key = "moodnone"
 	var/mood = null
 
-/datum/emote/slime/mood/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/slime/mood/run_emote(mob/user, params, type_override, intentional, override_message, override_emote_type)
 	. = ..()
 	if(!.)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Running emotes is actually asynchronous because they're invoked by player input which is called by internal byond magic which can happen in the middle of a proc during a byond operation.
A variable set to a singleton may not be what it was intended to be when the proc is supposed to finish running, due to another person invoking the same emote in the same time.
This is what caused that outrageous "ERP swap" bug.

This PR makes it a local argument

Also removed an unused variable from *me emote that I forgot to commit a removal in Subtler PR

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes asynchronous emote overwrite bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
