### PR TITLE
Creates /turf/open/space/openspace

### DIFF
--- a/_maps/map_files/tradership/tradership2.dmm
+++ b/_maps/map_files/tradership/tradership2.dmm
@@ -654,7 +654,7 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/science)
 "pJ" = (
 /obj/machinery/door/airlock/external,
@@ -700,7 +700,7 @@
 /area/hallway/primary/central)
 "qP" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "qU" = (
 /obj/structure/ladder,
@@ -1079,7 +1079,7 @@
 /obj/docking_port/stationary/huge{
 	name = "FTV Bearcat Cargo Dock"
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "AJ" = (
 /obj/structure/cable,
@@ -1249,7 +1249,7 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/science)
 "Gd" = (
 /obj/structure/closet/crate,
@@ -1282,7 +1282,7 @@
 /area/hallway/primary/central)
 "GV" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "Hd" = (
 /obj/machinery/light/red/directional/south,
@@ -1551,7 +1551,7 @@
 /turf/closed/wall/r_wall,
 /area/construction/storage_wing)
 "Mg" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "Mh" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -1773,7 +1773,7 @@
 "Rh" = (
 /obj/structure/ladder,
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Rr" = (
 /turf/open/floor/plating,
@@ -1964,7 +1964,7 @@
 /area/maintenance/port/aft)
 "Xq" = (
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Xs" = (
 /obj/effect/mapping_helpers/paint_wall/free_trade_union_ship,

--- a/_maps/map_files/tradership/tradership3.dmm
+++ b/_maps/map_files/tradership/tradership3.dmm
@@ -170,7 +170,7 @@
 "cN" = (
 /obj/structure/lattice,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/visible,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "cT" = (
 /obj/structure/cable,
@@ -302,7 +302,7 @@
 	dir = 6
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "eU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -365,7 +365,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "fO" = (
 /obj/structure/cable,
@@ -397,7 +397,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "gf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1161,7 +1161,7 @@
 	name = "FTV Bearcat Starboard Dock";
 	roundstart_template = /datum/map_template/shuttle/crow
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "pF" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
@@ -1705,7 +1705,7 @@
 	dir = 10
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "wZ" = (
 /obj/effect/mapping_helpers/paint_wall/free_trade_union_ship,
@@ -1737,7 +1737,7 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "xw" = (
 /obj/item/radio/intercom/directional/east,
@@ -1863,7 +1863,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "zk" = (
 /obj/item/kirbyplants/random,
@@ -2021,7 +2021,7 @@
 	dir = 9
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Bj" = (
 /obj/machinery/reagentgrinder{
@@ -2192,11 +2192,11 @@
 /turf/open/floor/carpet,
 /area/command/bridge)
 "DB" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "DC" = (
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "DD" = (
 /obj/machinery/door/airlock/external,
@@ -2343,7 +2343,7 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "EI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -2788,7 +2788,7 @@
 /area/hallway/primary/fore)
 "JL" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/visible,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "JM" = (
 /obj/structure/cable,
@@ -2855,7 +2855,7 @@
 "Kz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "KD" = (
 /obj/machinery/light/directional/north,
@@ -3151,7 +3151,7 @@
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Oo" = (
 /obj/structure/table/reinforced,
@@ -3174,7 +3174,7 @@
 	dir = 8;
 	name = "FTV Bearcat Port Dock"
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "OU" = (
 /obj/structure/cable,
@@ -3486,7 +3486,7 @@
 "Tf" = (
 /obj/structure/ladder,
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Th" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/cyan/visible,
@@ -3542,7 +3542,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Uh" = (
 /obj/structure/cable,
@@ -3696,7 +3696,7 @@
 /area/cargo/warehouse/upper)
 "Wg" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "Wm" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -3946,7 +3946,7 @@
 /area/service/hydroponics)
 "Zg" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Zi" = (
 /obj/machinery/light/directional/south,

--- a/_maps/map_files/tradership/tradership4.dmm
+++ b/_maps/map_files/tradership/tradership4.dmm
@@ -93,7 +93,7 @@
 /area/tcommsat/server)
 "lE" = (
 /obj/structure/grille,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "lK" = (
 /obj/machinery/power/smes/engineering,
@@ -108,7 +108,7 @@
 /area/tcommsat/server)
 "mV" = (
 /obj/structure/lattice/catwalk,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "nP" = (
 /obj/machinery/telecomms/bus/preset_four,
@@ -344,7 +344,7 @@
 /area/space/nearstation)
 "Jc" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "JQ" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -368,7 +368,7 @@
 /area/maintenance/solars/port/aft)
 "Nf" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "Ou" = (
 /turf/open/floor/engine/hull/reinforced,
@@ -470,7 +470,7 @@
 /area/maintenance/solars/port/aft)
 "UH" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "UI" = (
 /obj/item/solar_assembly,
@@ -526,7 +526,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "Zw" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "ZG" = (
 /obj/structure/cable,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -836,7 +836,7 @@
 	name = "Tramstation emergency evac bay";
 	width = 32
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "acW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -2987,7 +2987,7 @@
 	roundstart_template = /datum/map_template/shuttle/arrival/box;
 	width = 7
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "akE" = (
 /turf/closed/wall,
@@ -7833,7 +7833,7 @@
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
 	width = 3
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "azn" = (
 /obj/effect/turf_decal/tile/blue{
@@ -13040,7 +13040,7 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aYr" = (
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "aYs" = (
 /obj/effect/spawner/randomsnackvend,
@@ -19986,7 +19986,7 @@
 	dir = 9;
 	network = list("aicore")
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "dDP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -22915,7 +22915,7 @@
 	dir = 2;
 	name = "SS13: Auxiliary Dock, Station-Port"
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "eJT" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -22999,7 +22999,7 @@
 /area/engineering/main)
 "eMA" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "eMU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28156,7 +28156,7 @@
 /area/science/explab)
 "gNY" = (
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "gNZ" = (
 /obj/machinery/nuclearbomb/selfdestruct,
@@ -41079,7 +41079,7 @@
 "lDe" = (
 /obj/structure/grille,
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "lDC" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
@@ -41175,7 +41175,7 @@
 	network = list("aicore")
 	},
 /obj/structure/lattice,
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "lHl" = (
 /obj/machinery/recharge_station,
@@ -42422,7 +42422,7 @@
 	name = "port bay 2";
 	width = 5
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "mkG" = (
 /obj/structure/table,
@@ -53300,7 +53300,7 @@
 	id = "pod_lavaland";
 	name = "lavaland"
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/space)
 "qCf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -58645,7 +58645,7 @@
 	c_tag = "Secure - External AI Upload";
 	dir = 5
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/ai_monitored/turret_protected/ai_upload)
 "sHz" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
@@ -71460,7 +71460,7 @@
 	dir = 5;
 	network = list("aicore")
 	},
-/turf/open/openspace/airless/planetary,
+/turf/open/space/openspace,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "xxS" = (
 /obj/effect/turf_decal/siding/wood/corner{

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -25,9 +25,6 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 /turf/open/openspace/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
-/turf/open/openspace/airless/planetary
-	planetary_atmos = TRUE
-
 /turf/open/openspace/Initialize(mapload, inherited_virtual_z) // handle plane and layer here so that they don't cover other obs/turfs in Dream Maker
 	. = ..()
 	overlays += GLOB.openspace_backdrop_one_for_all //Special grey square for projecting backdrop darkness filter on it.
@@ -48,6 +45,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 /turf/open/openspace/zAirOut()
 	return TRUE
 
+/// CODE DUPLICATED IN `code\game\turfs\open\space\space.dm`!!
 /turf/open/openspace/zPassIn(atom/movable/A, direction, turf/source)
 	if(direction == DOWN)
 		for(var/obj/O in contents)
@@ -61,6 +59,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 		return TRUE
 	return FALSE
 
+/// CODE DUPLICATED IN `code\game\turfs\open\space\space.dm`!!
 /turf/open/openspace/zPassOut(atom/movable/A, direction, turf/destination)
 	if(A.anchored)
 		return FALSE

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -194,3 +194,53 @@
 			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 			return TRUE
 	return FALSE
+
+/turf/open/space/openspace
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "invisible"
+
+/turf/open/space/openspace/Initialize(mapload) // handle plane and layer here so that they don't cover other obs/turfs in Dream Maker
+	. = ..()
+	overlays += GLOB.openspace_backdrop_one_for_all //Special grey square for projecting backdrop darkness filter on it.
+	icon_state = "invisible"
+	return INITIALIZE_HINT_LATELOAD
+
+/turf/open/space/openspace/LateInitialize()
+	. = ..()
+	AddElement(/datum/element/turf_z_transparency, FALSE)
+
+/turf/open/space/openspace/zAirIn()
+	return TRUE
+
+/turf/open/space/openspace/zAirOut()
+	return TRUE
+
+/// CODE DUPLICATED IN `code\game\turfs\open\openspace.dm`!!
+/turf/open/space/openspace/zPassIn(atom/movable/A, direction, turf/source)
+	if(direction == DOWN)
+		for(var/obj/O in contents)
+			if(O.obj_flags & BLOCK_Z_IN_DOWN || O.obj_flags & FULL_BLOCK_Z_ABOVE)
+				return FALSE
+		return TRUE
+	if(direction == UP)
+		for(var/obj/O in contents)
+			if(O.obj_flags & BLOCK_Z_IN_UP || O.obj_flags & FULL_BLOCK_Z_BELOW)
+				return FALSE
+		return TRUE
+	return FALSE
+
+/// CODE DUPLICATED IN `code\game\turfs\open\openspace.dm`!!
+/turf/open/space/openspace/zPassOut(atom/movable/A, direction, turf/destination)
+	if(A.anchored)
+		return FALSE
+	if(direction == DOWN)
+		for(var/obj/O in contents)
+			if(O.obj_flags & BLOCK_Z_OUT_DOWN || O.obj_flags & FULL_BLOCK_Z_BELOW)
+				return FALSE
+		return TRUE
+	if(direction == UP)
+		for(var/obj/O in contents)
+			if(O.obj_flags & BLOCK_Z_OUT_UP || O.obj_flags & FULL_BLOCK_Z_ABOVE)
+				return FALSE
+		return TRUE
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/63559
Previously the openspace turf for space was a simulated planetary tile, which had a memory, initialization and performance cost.
Not only that but that was a cause of a bug of openspace space tiles actually being mutable, and you could see SM waste flow onto the roof of Bearcat.

Removes `/turf/open/openspace/airless/planetary` so nobody uses it instead of the proper one

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Creates /turf/open/space/openspace to properly simulate openspace space behaviours and help on performance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
