### PR TITLE
Better returns for emoting without the first parameter

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -463,16 +463,17 @@
 		return FALSE
 	else if(!params)
 		custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+		if(!custom_emote)
+			return FALSE
 		if(custom_emote && !check_invalid(user, custom_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
+			if(!type)
+				return FALSE
 			switch(type)
 				if("Visible")
 					custom_emote_type = EMOTE_VISIBLE
 				if("Hearable")
 					custom_emote_type = EMOTE_AUDIBLE
-				else
-					tgui_alert(usr,"Unable to use this emote, must be either hearable or visible.")
-					return
 	else
 		custom_emote = params
 		if(type_override)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can no longer sent empty messages with the second emote input.
The second emote input returns better without an annoying tgui box appearing

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Better returns for emoting without the first parameter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
