### PR TITLE
pickweight maintenance and fixes

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -206,29 +206,17 @@
 		result = first ^ second
 	return result
 
-//Picks a random element from a list based on a weighting system:
-//1. Adds up the total of weights for each element
-//2. Gets a number between 1 and that total
-//3. For each element in the list, subtracts its weighting from that number
-//4. If that makes the number 0 or less, return that element.
-//Will output null sometimes if you use decimals (e.g. 0.1 instead of 10) as rand() uses integers, not floats
+/**
+ * Picks a random element from a list based on a weighting system.
+ * For example, given the following list:
+ * A = 6, B = 3, C = 1, D = 0
+ * A would have a 60% chance of being picked,
+ * B would have a 30% chance of being picked,
+ * C would have a 10% chance of being picked,
+ * and D would have a 0% chance of being picked.
+ * You should only pass integers in.
+ */
 /proc/pickweight(list/L)
-	var/total = 0
-	var/item
-	for (item in L)
-		if (!L[item])
-			L[item] = 1
-		total += L[item]
-
-	total = rand(1, total)
-	for (item in L)
-		total -=L [item]
-		if (total <= 0)
-			return item
-
-	return null
-
-/proc/pickweightAllowZero(list/L) //The original pickweight proc will sometimes pick entries with zero weight.  I'm not sure if changing the original will break anything, so I left it be.
 	var/total = 0
 	var/item
 	for (item in L)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -264,7 +264,7 @@
 	var/datum/ai_laws/lawtype
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
 	while(!lawtype && law_weights.len)
-		var/possible_id = pickweightAllowZero(law_weights)
+		var/possible_id = pickweight(law_weights)
 		lawtype = lawid_to_type(possible_id)
 		if(!lawtype)
 			law_weights -= possible_id

--- a/code/datums/looping_sounds/item_sounds.dm
+++ b/code/datums/looping_sounds/item_sounds.dm
@@ -37,22 +37,22 @@
 #undef RAD_GEIGER_HIGH
 
 /datum/looping_sound/reverse_bear_trap
-	mid_sounds = list('sound/effects/clock_tick.ogg')
+	mid_sounds = list('sound/effects/clock_tick.ogg' = 1)
 	mid_length = 3.5
 	volume = 25
 
 
 /datum/looping_sound/reverse_bear_trap_beep
-	mid_sounds = list('sound/machines/beep.ogg')
+	mid_sounds = list('sound/machines/beep.ogg' = 1)
 	mid_length = 60
 	volume = 10
 
 /datum/looping_sound/siren
-	mid_sounds = list('sound/items/weeoo1.ogg')
+	mid_sounds = list('sound/items/weeoo1.ogg' = 1)
 	mid_length = 15
 	volume = 20
 
 /datum/looping_sound/tape_recorder_hiss
-	mid_sounds = list('sound/items/taperecorder/taperecorder_hiss_mid.ogg')
-	start_sound = list('sound/items/taperecorder/taperecorder_hiss_start.ogg')
+	mid_sounds = list('sound/items/taperecorder/taperecorder_hiss_mid.ogg' = 1)
+	start_sound = list('sound/items/taperecorder/taperecorder_hiss_start.ogg' = 1)
 	volume = 10

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -85,7 +85,7 @@
 
 /datum/looping_sound/jackpot
 	mid_length = 11
-	mid_sounds = list('sound/machines/roulettejackpot.ogg')
+	mid_sounds = list('sound/machines/roulettejackpot.ogg' = 1)
 	volume = 85
 	vary = TRUE
 

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -328,7 +328,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
  */
 /obj/machinery/computer/arcade/orion_trail/proc/encounter_event(path, gamer, gamer_skill, gamer_skill_level, gamer_skill_rands)
 	if(!path)
-		event = pickweightAllowZero(events)
+		event = pickweight(events)
 	else
 		for(var/datum/orion_event/instance as anything in events)
 			if(instance.type == path)

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -12,9 +12,9 @@
 	if(loot?.len)
 		var/loot_spawned = 0
 		while((lootcount-loot_spawned) && loot.len)
-			var/lootspawn = pickweight(loot)
+			var/lootspawn = pickweight(fill_with_ones(loot))
 			while(islist(lootspawn))
-				lootspawn = pickweight(lootspawn)
+				lootspawn = pickweight(fill_with_ones(lootspawn))
 			if(!lootdoubles)
 				loot.Remove(lootspawn)
 
@@ -559,9 +559,9 @@
 		stat_table[item] /= loot_count
 
 /obj/item/loot_table_maker/proc/pick_loot(lootpool) //selects path from loot table and returns it
-	var/lootspawn = pickweight(lootpool)
+	var/lootspawn = pickweight(fill_with_ones(lootpool))
 	while(islist(lootspawn))
-		lootspawn = pickweight(lootspawn)
+		lootspawn = pickweight(fill_with_ones(lootspawn))
 	return lootspawn
 
 /obj/effect/spawner/lootdrop/space
@@ -1173,3 +1173,18 @@
 	name = "5x cash spawner"
 	fan_out_items = TRUE
 	lootcount = 5
+
+// Lets loot tables be both list(a, b, c), as well as list(a = 3, b = 2, c = 2)
+/proc/fill_with_ones(list/table)
+	if (!islist(table))
+		return table
+
+	var/list/final_table = list()
+
+	for (var/key in table)
+		if (table[key])
+			final_table[key] = table[key]
+		else
+			final_table[key] = 1
+
+	return final_table

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -241,7 +241,7 @@
 	defer_change = TRUE
 	mineralSpawnChanceList = list(
 		/obj/item/stack/ore/uranium = 35, /obj/item/stack/ore/diamond = 30, /obj/item/stack/ore/gold = 45, /obj/item/stack/ore/titanium = 45,
-		/obj/item/stack/ore/silver = 50, /obj/item/stack/ore/plasma = 50, /obj/item/stack/ore/bluespace_crystal)
+		/obj/item/stack/ore/silver = 50, /obj/item/stack/ore/plasma = 50, /obj/item/stack/ore/bluespace_crystal = 1)
 
 /turf/closed/mineral/random/low_chance
 	icon_state = "rock_lowchance"

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium=5, /obj/ef
 
 GLOBAL_LIST_INIT(meteorsB, list(/obj/effect/meteor/meaty=5, /obj/effect/meteor/meaty/xeno=1)) //for meaty ore event
 
-GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
+GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust = 1)) //for space dust event
 
 
 ///////////////////////////////

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -20,7 +20,7 @@
 	maxbodytemp = 400
 	unsuitable_atmos_damage = 0.5
 	animal_species = /mob/living/simple_animal/pet/cat
-	childtype = list(/mob/living/simple_animal/pet/cat/kitten)
+	childtype = list(/mob/living/simple_animal/pet/cat/kitten = 1)
 	butcher_results = list(/obj/item/food/meat/slab = 1, /obj/item/organ/ears/cat = 1, /obj/item/organ/tail/cat = 1, /obj/item/stack/sheet/animalhide/cat = 1)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/62940 and https://github.com/tgstation/tgstation/pull/63035
This fixes an issue that caused our storyteller to pick a weight 0 event of LONE OPERATIVE.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed pickweight sometimes picking badly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
