### PR TITLE
Fixes scraped turfs not having planetary atmospherics

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -28,6 +28,8 @@
  */
 /turf/open/space/Initialize(mapload, inherited_virtual_z)
 	SHOULD_CALL_PARENT(FALSE)
+	if(inherited_virtual_z)
+		virtual_z = inherited_virtual_z
 	icon_state = SPACE_ICON_STATE
 	air = space_gas
 	vis_contents.Cut() //removes inherited overlays
@@ -36,9 +38,6 @@
 	if(flags_1 & INITIALIZED_1)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	flags_1 |= INITIALIZED_1
-
-	if(inherited_virtual_z)
-		virtual_z = inherited_virtual_z
 
 	if (length(smoothing_groups))
 		sortTim(smoothing_groups) //In case it's not properly ordered, let's avoid duplicate entries with the same values.

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -88,13 +88,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
  */
 /turf/Initialize(mapload, inherited_virtual_z)
 	SHOULD_CALL_PARENT(FALSE)
+	if(inherited_virtual_z)
+		virtual_z = inherited_virtual_z
 	HandleInitialGasString()
 	if(flags_1 & INITIALIZED_1)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	flags_1 |= INITIALIZED_1
-
-	if(inherited_virtual_z)
-		virtual_z = inherited_virtual_z
 
 	assemble_baseturfs()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's the mining bug with the air pressure thing that recently cropped up because of virtual levels. Turns out `HandleInitialGasString()` needs virtual level information, and it was inherited a tiny bit later

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes scraped turfs not having planetary atmospherics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
