### PR TITLE
Better cooldown for disposal flush sound

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -20,7 +20,7 @@
 	var/flushing = 0 // true if flushing in progress
 	var/flush_every_ticks = 30 //Every 30 ticks it will look whether it is ready to flush
 	var/flush_count = 0 //this var adds 1 once per tick. When it reaches flush_every_ticks it resets and tries to flush.
-	var/last_sound = 0
+	var/next_sound = 0
 	var/obj/structure/disposalconstruct/stored
 	// create a new disposal
 	// find the attached trunk (if present) and init gas resvr.
@@ -207,9 +207,9 @@
 	flushing = TRUE
 	flushAnimation()
 	sleep(10)
-	if(last_sound < world.time + 1)
+	if(next_sound < world.time)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, FALSE, FALSE)
-		last_sound = world.time
+		next_sound = world.time + 1 SECONDS
 	sleep(5)
 	if(QDELETED(src))
 		return

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -209,7 +209,7 @@
 	sleep(10)
 	if(next_sound < world.time)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, FALSE, FALSE)
-		next_sound = world.time + 1 SECONDS
+		next_sound = world.time + 2 SECONDS
 	sleep(5)
 	if(QDELETED(src))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This used to prevent the sounds played from the same tick, because conveyor belts moved everything in a belt to another one at the same time, but now they move things over time to prevent lag, and this cooldown doesnt stop the sound issue anymore.
Changing the cooldown from 1 tick to 2 seconds will prevent the sound issue

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Flushing things via disposals can no longer ear violate you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
