### PR TITLE
Asay for deadmins through a verb

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -326,6 +326,13 @@ Turf and target are separate in case you want to teleport some distance from a t
 		if(M.ckey == key)
 			return M
 
+/proc/get_client_by_ckey(key)
+	if(!key)
+		return
+	for(var/client/checked_client as anything in GLOB.clients)
+		if(checked_client.ckey == key)
+			return checked_client
+
 //Returns the atom sitting on the turf.
 //For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
 //Optional arg 'type' to stop once it reaches a specific type instead of a turf.

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_EMPTY(clients) //all clients
 GLOBAL_LIST_EMPTY(admins) //all clients whom are admins
 GLOBAL_PROTECT(admins)
 GLOBAL_LIST_EMPTY(deadmins) //all ckeys who have used the de-admin verb.
+GLOBAL_LIST_EMPTY(asay_deadmins) //all ckey of admins who can asay while deadminned. Ckeys for persistance during disconnects and to not hold refs
 
 GLOBAL_LIST_EMPTY(directory) //all ckeys with associated client
 GLOBAL_LIST_EMPTY(stealthminID) //reference list with IDs that store ckeys, for stealthmins

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -259,6 +259,12 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	))
 GLOBAL_PROTECT(admin_verbs_hideable)
 
+GLOBAL_LIST_INIT(admin_verbs_deadmins, list(
+	/client/proc/readmin,
+	/client/proc/deadmin_asay
+	))
+GLOBAL_PROTECT(admin_verbs_deadmins)
+
 /client/proc/add_admin_verbs()
 	if(holder)
 		control_freak = CONTROL_FREAK_SKIN | CONTROL_FREAK_MACROS

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -102,7 +102,7 @@ GLOBAL_PROTECT(href_token)
 	var/client/C
 	if ((C = owner) || (C = GLOB.directory[target]))
 		disassociate()
-		add_verb(C, /client/proc/readmin)
+		add_verb(C, GLOB.admin_verbs_deadmins)
 
 /datum/admins/proc/associate(client/client)
 	if(IsAdminAdvancedProcCall())
@@ -140,7 +140,8 @@ GLOBAL_PROTECT(href_token)
 	owner = client
 	owner.holder = src
 	owner.add_admin_verbs()
-	remove_verb(owner, /client/proc/readmin)
+	remove_verb(owner, GLOB.admin_verbs_deadmins)
+	GLOB.asay_deadmins -= client.ckey //Remove from asay deadmins
 	owner.init_verbs() //re-initialize the verb list
 	GLOB.admins |= client
 

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -2,7 +2,8 @@
 	set category = "Admin"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = TRUE
-	if(!check_rights(0))
+	var/deadminned_asayer = (ckey in GLOB.asay_deadmins) ? TRUE : FALSE
+	if(!deadminned_asayer && !check_rights(0))
 		return
 
 	msg = emoji_parse(copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN))
@@ -12,8 +13,13 @@
 	mob.log_talk(msg, LOG_ASAY)
 	msg = keywords_lookup(msg)
 	var/custom_asay_color = (CONFIG_GET(flag/allow_admin_asaycolor) && prefs.asaycolor) ? "<font color=[prefs.asaycolor]>" : "<font color='#FF4500'>"
-	msg = "[SPAN_ADMINSAY("[SPAN_PREFIX("ADMIN:")] <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: [custom_asay_color]<span class='message linkify'>[msg]")]</span>[custom_asay_color ? "</font>":null]"
-	to_chat(GLOB.admins,
+	msg = "[SPAN_ADMINSAY("[SPAN_PREFIX("ADMIN:")] <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)][deadminned_asayer ? "(D)" : ""]: [custom_asay_color]<span class='message linkify'>[msg]")]</span>[custom_asay_color ? "</font>":null]"
+	var/list/recipients = GLOB.admins.Copy()
+	for(var/recipient_key in GLOB.asay_deadmins)
+		var/client/recipient = get_client_by_ckey(recipient_key)
+		if(recipient)
+			recipients |= recipient
+	to_chat(recipients,
 		type = MESSAGE_TYPE_ADMINCHAT,
 		html = msg,
 		confidential = TRUE)

--- a/code/modules/admin/verbs/deadmin_asay.dm
+++ b/code/modules/admin/verbs/deadmin_asay.dm
@@ -1,0 +1,16 @@
+/client/proc/deadmin_asay()
+	set name = "Toggle Deadmin Asay"
+	set category = "Admin"
+	set desc = "Toggle access to asay while deadminned."
+	var/new_state
+	if(ckey in GLOB.asay_deadmins)
+		new_state = FALSE
+		GLOB.asay_deadmins -= ckey
+		remove_verb(src, /client/proc/cmd_admin_say)
+	else
+		new_state = TRUE
+		GLOB.asay_deadmins += ckey
+		add_verb(src, /client/proc/cmd_admin_say)
+	message_admins("[key_name_admin(usr)] [new_state ? "enabled" : "disabled"] their asay while deadminned.")
+	to_chat(usr, "<span class='infoplain'>You will [new_state ? "now" : "no longer"] be able to asay while deadminned.</span>")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Deadmin Asay", "[new_state ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1638,6 +1638,7 @@
 #include "code\modules\admin\verbs\BrokenInhands.dm"
 #include "code\modules\admin\verbs\cinematic.dm"
 #include "code\modules\admin\verbs\commandreport.dm"
+#include "code\modules\admin\verbs\deadmin_asay.dm"
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows deadminned admins to toggle the use of asay through a verb.
Activation/Deactivation notices other admins.
Deadminned admins talking in asay will have a (D) near their ckey.

Not implemented in the best way, because the admin framework is just a mess. This is the best we get.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Asay for deadmins through a verb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
