### PR TITLE
Adjust temperature on setting species

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -385,7 +385,10 @@
 		update_hair()
 		update_body_parts()
 		update_mutations_overlay()// no lizard with human hulk overlay please.
-
+	// Adjust body temperatures to not burn special species as they spawn.
+	var/datum/species/my_species = dna.species
+	bodytemperature = my_species.bodytemp_normal
+	coretemperature = my_species.bodytemp_normal
 
 /mob/proc/has_dna()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When a new species is set, its temperatures now will adjust to nominal ones.
This fixes a bug with Avalis getting burnt on spawning.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Avalis no longer burn after being spawned in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
