### PR TITLE
Jukebox system upgrades, GUI upgrades. Put a donk on it

### DIFF
--- a/code/datums/jukebox_datums.dm
+++ b/code/datums/jukebox_datums.dm
@@ -129,6 +129,11 @@
 	else
 		sound_to_update.status &= ~SOUND_MUTE
 
+	if(!played_track.?boombox.paused)
+		sound_to_update |= SOUND_PAUSED
+	else
+		sound_to_update &= ~SOUND_PAUSED
+
 	/// At close range we dont set a position of the sound.
 	if(distance <= JUKEBOX_NO_POSITIONAL_RANGE)
 		sound_to_update.x = 0

--- a/tgui/packages/tgui/interfaces/Boombox.tsx
+++ b/tgui/packages/tgui/interfaces/Boombox.tsx
@@ -1,0 +1,161 @@
+/**
+ * @file
+ * @copyright 2022 Horizon Community <https://hrzn.fun>
+ * @copyright 2022 Alexander 'Avunia' Takiya <https://takiya.eu>
+ * @author Alexander 'Avunia' Takiya
+ * @license MIT
+ */
+
+import { sortBy } from 'common/collections';
+import { useBackend, useLocalState } from "../backend";
+import { BlockQuote, Box, Button, Input, Knob, Section, Stack } from '../components';
+import { Window } from "../layouts";
+
+type JukeboxData = {
+  volume: number;
+  playing_track: JukeboxTrack;
+  selected_track: JukeboxTrack;
+  songs: JukeboxTrack[];
+}
+
+type JukeboxTrack = {
+  artist: string;
+  title: string;
+  length: number;
+  bpm: number;
+  ref: string;
+}
+
+export const BoomboxTopControls = (props, context) => {
+  const { act, data } = useBackend<JukeboxData>(context);
+  const {
+    volume,
+    playing_track,
+    selected_track,
+  } = data;
+  return (
+    <Stack horizontal>
+      <Stack.Item>
+        <Button
+          icon={playing_track ? 'stop' : 'play'}
+          content={playing_track ? "Stop" : "Play"}
+          fluid
+          onClick={() => act('toggle_play')}
+          lineHeight={3}
+          disabled={selected_track === null}
+          width={8}
+          textAlign="center"
+        />
+      </Stack.Item>
+      <Stack.Item grow>
+        {playing_track
+          ? (
+            <BlockQuote>
+              Now Playing:<br />
+              <i>{playing_track.artist} - {playing_track.title}</i>
+            </BlockQuote>
+          ) : (
+            <BlockQuote>
+              Ready to play the hottest hits...
+            </BlockQuote>
+          )}
+      </Stack.Item>
+      <Stack.Item>
+        <Knob
+          size={1.5}
+          value={volume}
+          unit="%"
+          minValue={0}
+          maxValue={100}
+          step={1}
+          stepPixelSize={1}
+          onDrag={(e, new_volume) => act('set_volume', {
+            volume: new_volume,
+          })}
+        />
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+export const BoomboxListpicker = (props, context) => {
+  const { act, data } = useBackend<JukeboxData>(context);
+  const {
+    selected_track,
+    songs,
+  } = data;
+  const [displayedArray, setDisplayedArray] = useLocalState(
+    context, 'displayed_array', songs);
+  const [selectedButton, setSelectedButton] = useLocalState(
+    context, 'selected_button', selected_track);
+
+  return (
+    <Stack fill vertical>
+      <Stack.Item>
+        <Input
+          fluid
+          onInput={(e, value: string) => setDisplayedArray(
+            songs.filter(val => (
+              (`${val.artist} ${val.title}`).toLowerCase()
+                .search(value.toLowerCase()) !== -1
+            ))
+          )}
+        />
+      </Stack.Item>
+      <Stack.Item grow>
+        <Section
+          fill
+          scrollable
+          className="ListInput__Section"
+          tabIndex={0}
+        >
+          {displayedArray.map(button => (
+            <Button
+              key={button.title}
+              fluid
+              color="transparent"
+              id={button.title}
+              selected={selectedButton === button}
+              onClick={() => {
+                setSelectedButton(button);
+                act("select_track", { track: selectedButton.ref });
+              }}>
+              {button.artist} - {button.title}
+            </Button>
+          ))}
+        </Section>
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+export const Boombox = (props, context) => {
+  const { act, data } = useBackend<JukeboxData>(context);
+  const {
+    volume,
+    playing_track,
+    selected_track,
+    songs,
+  } = data;
+  return (
+    <Window
+      title="Pawasonic Double Deck Blaster"
+      width={580}
+      height={400}>
+      <Window.Content>
+        <Stack vertical fill>
+          <Stack.Item>
+            <BoomboxTopControls />
+          </Stack.Item>
+          <Stack.Item grow>
+            <Stack horizontal fill>
+              <Stack.Item grow>
+                <BoomboxListpicker />
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
## About The Pull Request
Updates the jukebox backend to be more performant
Adds better GUIs to the jukebox and boombox.
Adds a few other features to either of them, to make them more suited for their intended usage.

## Todo list
- [x] Update Boombox backend to support TGUI
- [ ] Add Boombox GUI based on TGUI
- [ ] Update Jukebox GUI
- [x] Add pause function to jukebox system
- [ ] Fix jukebox rescaling effects
  - Fixes #110
  - Fixes #639

Extended goals:
- [ ] Attempt to load track metadata via taglib
- [ ] Update radiant dance machine to mark X - test particle effects
- [ ] Show progress bar for current song

## Why It's Good For The Game
Music makes the world go round 🎶


## Changelog
<TODO: Update this when done>
:cl: Avunia Takiya
add: Added pause feature to boombox
add: Added new GUI for boombox
refactor: Jukebox and Boombox are now more performant
/:cl:
<\/TODO>
