### PR TITLE
Game options only available after init

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -56,7 +56,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	var/queue_priority_count_bg = 0 //Same, but for background subsystems
 	var/map_loading = FALSE //!Are we loading in a new map?
 
-	var/current_runlevel //!for scheduling different subsystems for different stages of the round
+	var/current_runlevel = RUNLEVEL_INIT //!for scheduling different subsystems for different stages of the round
 	var/sleep_offline_after_initializations = TRUE
 
 	var/static/restart_clear = 0
@@ -205,8 +205,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	to_chat(world, SPAN_BOLDANNOUNCE("[msg]"))
 	log_world(msg)
 
-	if (!current_runlevel)
-		SetRunLevel(1)
+	if (current_runlevel == RUNLEVEL_INIT)
+		SetRunLevel(RUNLEVEL_LOBBY)
+
+	update_new_players_ui()
 
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
@@ -626,3 +628,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	for (var/thing in subsystems)
 		var/datum/controller/subsystem/SS = thing
 		SS.OnConfigLoad()
+
+/// Updates the UI for all new players, called after initializations of the subsystems.
+/datum/controller/master/proc/update_new_players_ui()
+	for(var/mob/dead/new_player/new_guy as anything in GLOB.new_player_list)
+		new_guy.new_player_panel()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -247,6 +247,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/ShowChoices(mob/user)
 	if(!user || !user.client)
 		return
+	if(Master.current_runlevel == RUNLEVEL_INIT)
+		return
 	if(slot_randomized)
 		load_character(default_slot) // Reloads the character slot. Prevents random features from overwriting the slot if saved.
 		slot_randomized = FALSE
@@ -1512,6 +1514,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		all_quirks = list()
 
 /datum/preferences/Topic(href, href_list, hsrc) //yeah, gotta do this I guess..
+	if(Master.current_runlevel == RUNLEVEL_INIT)
+		return
 	. = ..()
 	if(href_list["close"])
 		var/client/C = usr.client

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -47,15 +47,15 @@
 /mob/dead/new_player/proc/new_player_panel()
 	if (client?.interviewee)
 		return
+	if(Master.current_runlevel == RUNLEVEL_INIT)
+		return
 
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/lobby)
 	asset_datum.send(client)
 	var/list/output = list("<center>")
-	var/greeting_title = "New Player Options"
 
-	if(SSmapping && SSmapping.config)
-		output += "[SSmapping.config.get_map_info()]<HR>"
-		greeting_title = "Welcome to [SSmapping.config.map_name]"
+	output += "[SSmapping.config.get_map_info()]<HR>"
+	var/greeting_title = "Welcome to [SSmapping.config.map_name]"
 
 	output += "<p><a href='byond://?src=[REF(src)];show_preferences=1'>Setup Character</a></p>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Game options are only available after server initialization
The new player popup will appear after the server has initialized
closes https://github.com/hrzntal/horizon/issues/723

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Game options are now only available after init
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
