### PR TITLE
Changing a turf no longer disintegrates lattices

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -332,7 +332,6 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 /turf/open/AfterChange(flags, oldType)
 	..()
-	RemoveLattice()
 	if(!(flags & (CHANGETURF_IGNORE_AIR | CHANGETURF_INHERIT_AIR)))
 		Assimilate_Air()
 

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -77,9 +77,6 @@
 
 /turf/open/space/TakeTemperature(temp)
 
-/turf/open/space/RemoveLattice()
-	return
-
 /turf/open/space/AfterChange()
 	..()
 	atmos_overlay_types = null

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -401,12 +401,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/open/space/levelupdate()
 	return
 
-// Removes all signs of lattice on the pos of the turf -Donkieyo
-/turf/proc/RemoveLattice()
-	var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-	if(L && (L.flags_1 & INITIALIZED_1))
-		qdel(L)
-
 /turf/proc/Bless()
 	new /obj/effect/blessing(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removing a lattice due to construction is handled here -> https://github.com/hrzntal/horizon/blob/main/code/game/turfs/open/space/space.dm#L145
Fixes https://github.com/hrzntal/horizon/issues/757

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Changing a turf no longer disintegrates lattices and its subtypes (shuttle moving for example)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
