### PR TITLE
Offsets directional lights to fit onto our walls

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -70,6 +70,22 @@
 	if(building)
 		setDir(ndir)
 
+/obj/structure/light_construct/setDir(new_dir)
+	. = ..()
+	switch(dir)
+		if(NORTH)
+			pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
+			pixel_x = 0
+		if(EAST)
+			pixel y = 0
+			pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
+		if(WEST)
+			pixel_y = 0
+			pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
+		if(SOUTH)
+			pixel_y = 0
+			pixel_x = 0
+
 /obj/structure/light_construct/Destroy()
 	QDEL_NULL(cell)
 	return ..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -15,6 +15,11 @@
 #define LIGHT_DRAIN_TIME 25
 #define LIGHT_POWER_GAIN 35
 
+// How far we should adjust the sprites to fit on the walls.
+#define LIGHT_NORTH_PIXEL_Y_OFFSET 22
+#define LIGHT_EAST_PIXEL_X_OFFSET 12
+#define LIGHT_WEST_PIXEL_X_OFFSET -12
+
 //How many reagents the lights can hold
 #define LIGHT_REAGENT_CAPACITY 5
 
@@ -1043,237 +1048,295 @@
 // The directions are backwards on the lights we have now
 /obj/machinery/light/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Broken tube
 /obj/machinery/light/broken/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/broken/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/broken/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/broken/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Tube construct
 /obj/structure/light_construct/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/structure/light_construct/directional/south
 	dir = SOUTH
 
 /obj/structure/light_construct/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/structure/light_construct/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Tube frames
 /obj/machinery/light/built/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/built/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/built/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/built/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- No nightlight tubes
 /obj/machinery/light/no_nightlight/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/no_nightlight/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/no_nightlight/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/no_nightlight/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Warm light tubes
 /obj/machinery/light/warm/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/warm/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/warm/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/warm/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- No nightlight warm light tubes
 /obj/machinery/light/warm/no_nightlight/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/warm/no_nightlight/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/warm/no_nightlight/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/warm/no_nightlight/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Cold light tubes
 /obj/machinery/light/cold/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/cold/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/cold/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/cold/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- No nightlight cold light tubes
 /obj/machinery/light/cold/no_nightlight/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/cold/no_nightlight/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/cold/no_nightlight/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/cold/no_nightlight/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Red tubes
 /obj/machinery/light/red/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/red/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/red/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/red/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Blacklight tubes
 /obj/machinery/light/blacklight/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/blacklight/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/blacklight/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/blacklight/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Dim tubes
 /obj/machinery/light/dim/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/dim/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/dim/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/dim/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 
 // -------- Bulb lights
 /obj/machinery/light/small/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/small/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/small/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/small/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Bulb construct
 /obj/structure/light_construct/small/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/structure/light_construct/small/directional/south
 	dir = SOUTH
 
 /obj/structure/light_construct/small/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/structure/light_construct/small/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Bulb frames
 /obj/machinery/light/small/built/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/small/built/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/small/built/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/small/built/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Broken bulbs
 /obj/machinery/light/small/broken/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/small/broken/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/small/broken/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/small/broken/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Red bulbs
 /obj/machinery/light/small/red/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/small/red/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/small/red/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/small/red/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 // ---- Blacklight bulbs
 /obj/machinery/light/small/blacklight/directional/north
 	dir = NORTH
+	pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 
 /obj/machinery/light/small/blacklight/directional/south
 	dir = SOUTH
 
 /obj/machinery/light/small/blacklight/directional/east
 	dir = EAST
+	pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 
 /obj/machinery/light/small/blacklight/directional/west
 	dir = WEST
+	pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
 
 #undef LIGHT_DRAIN_TIME
 #undef LIGHT_POWER_GAIN
+
+#undef LIGHT_NORTH_PIXEL_Y_OFFSET
+#undef LIGHT_EAST_PIXEL_X_OFFSET
+#undef LIGHT_WEST_PIXEL_X_OFFSET

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -77,7 +77,7 @@
 			pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
 			pixel_x = 0
 		if(EAST)
-			pixel y = 0
+			pixel_y = 0
 			pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
 		if(WEST)
 			pixel_y = 0

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -277,6 +277,22 @@
 	/// Whether we take time to turn on/update lighting, unless update() is called with an instant argument
 	var/delayed = TRUE
 
+/obj/machinery/light/setDir(new_dir)
+	. = ..()
+	switch(dir)
+		if(NORTH)
+			pixel_y = LIGHT_NORTH_PIXEL_Y_OFFSET
+			pixel_x = 0
+		if(EAST)
+			pixel_y = 0
+			pixel_x = LIGHT_EAST_PIXEL_X_OFFSET
+		if(WEST)
+			pixel_y = 0
+			pixel_x = LIGHT_WEST_PIXEL_X_OFFSET
+		if(SOUTH)
+			pixel_y = 0
+			pixel_x = 0
+
 /obj/machinery/light/broken
 	status = LIGHT_BROKEN
 	icon_state = "tube-broken"


### PR DESCRIPTION
## About The Pull Request
• Adds a define for each pixel-shift for easy changing for `NORTH`, `EAST` and `WEST` directionals.
• Sets offsets for north lights to 22, and East and West to 12 and -12 respectively.

## Why It's Good For The Game
Looks better for the lights to be on the top of the walls instead of on the floor at the bottom of the walls.
![image](https://user-images.githubusercontent.com/53862927/151662601-ad33f74d-afee-47b1-9fab-af4802fe86a5.png)
![image](https://user-images.githubusercontent.com/53862927/151662626-73c629b2-5276-4377-af91-c722638252ea.png)

## Issues
Obviously, any wall mounts placed by TG prior to TG #58809 where directional mounts were introduced have a chance of being janky if placed on a wall a light is meant to be on.
![image](https://user-images.githubusercontent.com/53862927/151662547-fbb79167-25dd-4777-8300-8cf15e7b5030.png)

## Changelog
:cl:
qol: Lights are now by default pixel-shifted onto the walls and windows.
/:cl:
