### PR TITLE
Revert "Removes telegraph messages from weather"

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -183,6 +183,8 @@
 	for(var/M in GLOB.player_list)
 		var/turf/mob_turf = get_turf(M)
 		if(mob_turf && my_controller.mapzone.is_in_bounds(mob_turf))
+			if(telegraph_message)
+				to_chat(M, telegraph_message)
 			if(telegraph_sound)
 				SEND_SOUND(M, sound(telegraph_sound))
 	addtimer(CALLBACK(src, .proc/start), telegraph_duration)


### PR DESCRIPTION
Reverts hrzntal/horizon#690

This removed the telegraph messages that are important to proper functioning of radiation storm event and preparing for other calamities planetside

I don't want them removed until a better thought out solution is introduced