### PR TITLE
Obstructed low walls cant be deleted through explosions

### DIFF
--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -23,6 +23,12 @@
 	/// Typecache of airlocks to apply a neighboring stripe overlay to
 	var/static/list/airlock_typecache
 
+/obj/structure/low_wall/ex_act(severity)
+	// Obstructed low walls cant be deleted through explosions
+	if(is_top_obstructed())
+		return
+	return ..()
+
 /obj/structure/low_wall/examine(mob/user)
 	. = ..()
 	. += SPAN_NOTICE("You could <b>weld</b> it down.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Very likely an explosion would kill a low wall but not the window which seems very weird

Now low walls can't be exploded while their top is obstructed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Obstructed low walls cant be deleted through explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
