### PR TITLE
Re-adds hardsuits and spacesuits to cargo packs

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -223,6 +223,23 @@
 	crate_name = "radiation protection crate"
 	crate_type = /obj/structure/closet/crate/radiation
 
+/datum/supply_pack/emergency/emergency_spacesuits
+	name = "Emergency Spacesuits (Fragile)"
+	desc = "Are there bombs going off left and right? Are there meteors shooting around the station? Well then! Here's two fragile space suits for emergencies. Comes with oxygen tanks and masks."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(
+		/obj/item/tank/internals/oxygen,
+		/obj/item/tank/internals/oxygen,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/suit/space/fragile,
+		/obj/item/clothing/suit/space/fragile,
+		/obj/item/clothing/head/helmet/space/fragile,
+		/obj/item/clothing/head/helmet/space/fragile
+		)
+	crate_name = "emergency crate"
+	crate_type = /obj/structure/closet/crate/internals
+
 /datum/supply_pack/emergency/spacesuit
 	name = "Space Suit Crate"
 	desc = "Contains one aging suit from Space-Goodwill and a jetpack. Requires EVA access to open."
@@ -269,6 +286,17 @@
 	group = "Security"
 	access = ACCESS_SECURITY
 	crate_type = /obj/structure/closet/crate/secure/gear
+
+/datum/supply_pack/security/sec_hardsuit
+	name = "Security Hardsuit"
+	desc = "One security hardsuit with an oxygen tank and sechailer mask."
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(
+		/obj/item/clothing/suit/space/hardsuit/security,
+		/obj/item/tank/internals/oxygen,
+		/obj/item/clothing/mask/gas/sechailer
+		)
+	crate_name = "sec hardsuit crate"
 
 /datum/supply_pack/security/ammo
 	name = "Ammo Crate"
@@ -662,6 +690,32 @@
 /datum/supply_pack/engineering
 	group = "Engineering"
 	crate_type = /obj/structure/closet/crate/engineering
+
+/datum/supply_pack/engineering/engi_hardsuit
+	name = "Engineering Hardsuit"
+	desc = "Poly 'Who stole all the hardsuits!' Well now you can get more hardsuits if needed! NOTE ONE HARDSUIT IS IN THIS CRATE, as well as one oxygen tank and mask!"
+	cost = CARGO_CRATE_VALUE * 4
+	access = ACCESS_ENGINE
+	contains = list(
+		/obj/item/tank/internals/oxygen,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/suit/space/hardsuit/engine
+		)
+	crate_name = "engineering hardsuit"
+	crate_type = /obj/structure/closet/crate/secure/engineering
+
+/datum/supply_pack/engineering/atmos_hardsuit
+	name = "Atmospherics Hardsuit"
+	desc = "Too many techs and not enough hardsuits? Time to buy some more! Comes with gas mask and an oxygen tank. Ask the CE to open."
+	cost = CARGO_CRATE_VALUE * 7
+	access = ACCESS_CE //100% Fire and Bio resistance
+	contains = list(
+		/obj/item/tank/internals/oxygen,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/suit/space/hardsuit/engine/atmos
+		)
+	crate_name = "atmospherics hardsuit"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/shieldgen
 	name = "Anti-breach Shield Projector Crate"
@@ -1175,6 +1229,18 @@
 	access_view = ACCESS_MEDICAL
 	crate_type = /obj/structure/closet/crate/medical
 
+/datum/supply_pack/medical/med_hardsuit
+	name = "Medical Hardsuit"
+	desc = "A lightweight medical hardsuit, designed for ease of movement during rescue operations in dangerous envrionments. Comes with a breath mask and an oxygen tank!"
+	cost = CARGO_CRATE_VALUE * 4
+	access = ACCESS_MEDICAL
+	contains = list(
+		/obj/item/tank/internals/oxygen,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/suit/space/hardsuit/medical
+		)
+	crate_name = "medical hardsuit"
+
 /datum/supply_pack/medical/bloodpacks
 	name = "Blood Pack Variety Crate"
 	desc = "Contains eight different blood packs for reintroducing blood to patients."
@@ -1367,6 +1433,19 @@
 	group = "Science"
 	access_view = ACCESS_RESEARCH
 	crate_type = /obj/structure/closet/crate/science
+
+/datum/supply_pack/science/sci_hardsuit
+	name = "Prototype Hardsuit"
+	desc = "A prototyped hardsuit made with composite materials, protecting from biological hazards and keeping the body of the wearer intact after explosive accidents. Comes with a breath mask and an oxygen tank!"
+	cost = CARGO_CRATE_VALUE * 7
+	access = ACCESS_RESEARCH
+	contains = list(
+		/obj/item/tank/internals/oxygen,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/suit/space/hardsuit/rd
+		)
+	crate_name = "prototype hardsuit"
+	crate_type = /obj/structure/closet/crate/secure/science
 
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -245,8 +245,8 @@
 	desc = "Contains one aging suit from Space-Goodwill and a jetpack. Requires EVA access to open."
 	cost = CARGO_CRATE_VALUE * 3
 	access = ACCESS_EVA
-	contains = list(/obj/item/clothing/suit/space,
-					/obj/item/clothing/head/helmet/space,
+	contains = list(/obj/item/clothing/suit/space/eva,
+					/obj/item/clothing/head/helmet/space/eva,
 					/obj/item/clothing/mask/breath,
 					/obj/item/tank/jetpack/carbondioxide)
 	crate_name = "space suit crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I believe at one point they were removed from the TG base
If you want money to matter, you need to have valuable things being able to be purchased with that money
So here are the hardsuits once again

Some amount of strings and values were taken from Citadel codebase because I couldn't find them with version control here

Introduces:
Security Hardsuit pack
Medical Hardsuit pack
Engineering Hardsuit pack
Atmos Hardsuit pack
Prototype Hardsuit pack
Emergency fragile spacesuits (2)

Space suit crate now gives the EVA space suit, instead of the generic space suit (ugly looking)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More things to spend money on, making money more valuable
Filling the very barren cargo catalogues with worthwhile stuff.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Re-adds hardsuits and spacesuits to cargo packs
add: Space suit crate now gives the EVA space suit, instead of the generic space suit (ugly looking)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
