### PR TITLE
Refactors Kinetic Accelerator Upgrades

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -16,7 +16,7 @@
 	on_remove_on_mob_delete = TRUE
 	var/obj/item/modkit/bounty/reward_target
 
-/datum/status_effect/syphon_mark/on_creation(mob/living/new_owner, obj/item/borg/upgrade/modkit/bounty/new_reward_target)
+/datum/status_effect/syphon_mark/on_creation(mob/living/new_owner, obj/item/modkit/bounty/new_reward_target)
 	. = ..()
 	if(.)
 		reward_target = new_reward_target

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -14,7 +14,7 @@
 	status_type = STATUS_EFFECT_MULTIPLE
 	alert_type = null
 	on_remove_on_mob_delete = TRUE
-	var/obj/item/borg/upgrade/modkit/bounty/reward_target
+	var/obj/item/modkit/bounty/reward_target
 
 /datum/status_effect/syphon_mark/on_creation(mob/living/new_owner, obj/item/borg/upgrade/modkit/bounty/new_reward_target)
 	. = ..()

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -157,7 +157,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 		if(10)
 			new /obj/item/clothing/neck/necklace/memento_mori(loc)
 		if(11)
-			new /obj/item/borg/upgrade/modkit/lifesteal(loc)
+			new /obj/item/modkit/lifesteal(loc)
 			new /obj/item/bedsheet/cult(loc)
 		if(12)
 			new /obj/item/disk/design_disk/modkit_disc/mob_and_turf_aoe(loc)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -159,7 +159,7 @@
 		if(57 to 58)
 			new /obj/item/toy/balloon/syndicate(src)
 		if(59 to 60)
-			new /obj/item/borg/upgrade/modkit/aoe/mobs(src)
+			new /obj/item/modkit/aoe/mobs(src)
 			new /obj/item/clothing/suit/space(src)
 			new /obj/item/clothing/head/helmet/space(src)
 		if(61 to 62)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -71,7 +71,7 @@
 		if(17)
 			new /obj/item/book_of_babel(src)
 		if(18)
-			new /obj/item/borg/upgrade/modkit/lifesteal(src)
+			new /obj/item/modkit/lifesteal(src)
 			new /obj/item/bedsheet/cult(src)
 		if(19)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
@@ -122,21 +122,21 @@
 	desc = "A device which causes kinetic accelerators to fire AoE blasts that destroy rock and damage creatures."
 	id = "hyperaoemod"
 	materials = list(/datum/material/iron = 7000, /datum/material/glass = 3000, /datum/material/silver = 3000, /datum/material/gold = 3000, /datum/material/diamond = 4000)
-	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs/andmobs
+	build_path = /obj/item/modkit/aoe/turfs/andmobs
 
 /datum/design/unique_modkit/rapid_repeater
 	name = "Kinetic Accelerator Rapid Repeater Mod"
 	desc = "A device which greatly reduces a kinetic accelerator's cooldown on striking a living target or rock, but greatly increases its base cooldown."
 	id = "repeatermod"
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 5000, /datum/material/uranium = 8000, /datum/material/bluespace = 2000)
-	build_path = /obj/item/borg/upgrade/modkit/cooldown/repeater
+	build_path = /obj/item/modkit/cooldown/repeater
 
 /datum/design/unique_modkit/resonator_blast
 	name = "Kinetic Accelerator Resonator Blast Mod"
 	desc = "A device which causes kinetic accelerators to fire shots that leave and detonate resonator blasts."
 	id = "resonatormod"
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 5000, /datum/material/silver = 5000, /datum/material/uranium = 5000)
-	build_path = /obj/item/borg/upgrade/modkit/resonator_blasts
+	build_path = /obj/item/modkit/resonator_blasts
 
 /datum/design/unique_modkit/bounty
 	name = "Kinetic Accelerator Death Syphon Mod"
@@ -144,7 +144,7 @@
 	id = "bountymod"
 	materials = list(/datum/material/iron = 4000, /datum/material/silver = 4000, /datum/material/gold = 4000, /datum/material/bluespace = 4000)
 	reagents_list = list(/datum/reagent/blood = 40)
-	build_path = /obj/item/borg/upgrade/modkit/bounty
+	build_path = /obj/item/modkit/bounty
 
 //Spooky special loot
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -51,17 +51,16 @@
 		new /datum/data/mining_equipment("Nanotrasen Minebot", /mob/living/simple_animal/hostile/mining_drone, 800),
 		new /datum/data/mining_equipment("Minebot Melee Upgrade", /obj/item/mine_bot_upgrade, 400),
 		new /datum/data/mining_equipment("Minebot Armor Upgrade", /obj/item/mine_bot_upgrade/health, 400),
-		new /datum/data/mining_equipment("Minebot Cooldown Upgrade", /obj/item/borg/upgrade/modkit/cooldown/minebot, 600),
 		new /datum/data/mining_equipment("Minebot AI Upgrade", /obj/item/slimepotion/slime/sentience/mining, 1000),
-		new /datum/data/mining_equipment("KA Minebot Passthrough", /obj/item/borg/upgrade/modkit/minebot_passthrough, 100),
-		new /datum/data/mining_equipment("KA White Tracer Rounds", /obj/item/borg/upgrade/modkit/tracer, 100),
-		new /datum/data/mining_equipment("KA Adjustable Tracer Rounds", /obj/item/borg/upgrade/modkit/tracer/adjustable, 150),
-		new /datum/data/mining_equipment("KA Super Chassis", /obj/item/borg/upgrade/modkit/chassis_mod, 250),
-		new /datum/data/mining_equipment("KA Hyper Chassis", /obj/item/borg/upgrade/modkit/chassis_mod/orange, 300),
-		new /datum/data/mining_equipment("KA Range Increase", /obj/item/borg/upgrade/modkit/range, 1000),
-		new /datum/data/mining_equipment("KA Damage Increase", /obj/item/borg/upgrade/modkit/damage, 1000),
-		new /datum/data/mining_equipment("KA Cooldown Decrease", /obj/item/borg/upgrade/modkit/cooldown, 1000),
-		new /datum/data/mining_equipment("KA AoE Damage", /obj/item/borg/upgrade/modkit/aoe/mobs, 2000)
+		new /datum/data/mining_equipment("KA Minebot Passthrough", /obj/item/modkit/minebot_passthrough, 100),
+		new /datum/data/mining_equipment("KA White Tracer Rounds", /obj/item/modkit/tracer, 100),
+		new /datum/data/mining_equipment("KA Adjustable Tracer Rounds", /obj/item/modkit/tracer/adjustable, 150),
+		new /datum/data/mining_equipment("KA Super Chassis", /obj/item/modkit/chassis_mod, 250),
+		new /datum/data/mining_equipment("KA Hyper Chassis", /obj/item/modkit/chassis_mod/orange, 300),
+		new /datum/data/mining_equipment("KA Range Increase", /obj/item/modkit/range, 1000),
+		new /datum/data/mining_equipment("KA Damage Increase", /obj/item/modkit/damage, 1000),
+		new /datum/data/mining_equipment("KA Cooldown Decrease", /obj/item/modkit/cooldown, 1000),
+		new /datum/data/mining_equipment("KA AoE Damage", /obj/item/modkit/aoe/mobs, 2000)
 	)
 
 /datum/data/mining_equipment
@@ -183,7 +182,7 @@
 			new /mob/living/simple_animal/hostile/mining_drone(drop_location)
 			new /obj/item/weldingtool/hugetank(drop_location)
 			new /obj/item/clothing/head/welding(drop_location)
-			new /obj/item/borg/upgrade/modkit/minebot_passthrough(drop_location)
+			new /obj/item/modkit/minebot_passthrough(drop_location)
 		if("Extraction and Rescue Kit")
 			new /obj/item/extraction_pack(drop_location)
 			new /obj/item/fulton_core(drop_location)
@@ -217,7 +216,7 @@
 		new /datum/data/mining_equipment("Toolbelt", /obj/item/storage/belt/utility, 350),
 		new /datum/data/mining_equipment("Royal Cape of the Liberator", /obj/item/bedsheet/rd/royal_cape, 500),
 		new /datum/data/mining_equipment("Grey Slime Extract", /obj/item/slime_extract/grey, 1000),
-		new /datum/data/mining_equipment("Modification Kit", /obj/item/borg/upgrade/modkit/trigger_guard, 1700),
+		new /datum/data/mining_equipment("Modification Kit", /obj/item/modkit/trigger_guard, 1700),
 		new /datum/data/mining_equipment("The Liberator's Legacy", /obj/item/storage/box/rndboards, 2000)
 		)
 	return ..()

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -86,7 +86,7 @@
 	Field repairs can be done with a welder."}
 	if(stored_gun?.max_mod_capacity)
 		. += "<b>[stored_gun.get_remaining_mod_capacity()]%</b> mod capacity remaining."
-		for(var/obj/item/borg/upgrade/modkit/modkit as anything in stored_gun.modkits)
+		for(var/obj/item/modkit/modkit as anything in stored_gun.modkits)
 			. += SPAN_NOTICE("There is \a [modkit] installed, using <b>[modkit.cost]%</b> capacity.")
 
 /mob/living/simple_animal/hostile/mining_drone/welder_act(mob/living/user, obj/item/welder)
@@ -109,7 +109,7 @@
 		to_chat(user, SPAN_INFO("You instruct [src] to drop any collected ore."))
 		DropOre()
 		return
-	if(item_used.tool_behaviour == TOOL_CROWBAR || istype(item_used, /obj/item/borg/upgrade/modkit))
+	if(item_used.tool_behaviour == TOOL_CROWBAR || istype(item_used, /obj/item/modkit))
 		item_used.melee_attack_chain(user, stored_gun, params)
 		return
 	..()
@@ -117,7 +117,7 @@
 /mob/living/simple_animal/hostile/mining_drone/death()
 	DropOre()
 	if(stored_gun)
-		for(var/obj/item/borg/upgrade/modkit/modkit as anything in stored_gun.modkits)
+		for(var/obj/item/modkit/modkit as anything in stored_gun.modkits)
 			modkit.uninstall(stored_gun)
 	deathmessage = "blows apart!"
 	..()
@@ -140,7 +140,7 @@
 	if(istype(object, /obj/projectile/kinetic))
 		var/obj/projectile/kinetic/projectile = object
 		if(projectile.kinetic_gun)
-			if (locate(/obj/item/borg/upgrade/modkit/minebot_passthrough) in projectile.kinetic_gun.modkits)
+			if (locate(/obj/item/modkit/minebot_passthrough) in projectile.kinetic_gun.modkits)
 				return TRUE
 	if(istype(object, /obj/projectile/destabilizer))
 		return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -315,9 +315,9 @@
 			if(prob(20))
 				suit = pickweight(list(/obj/item/clothing/suit/hooded/explorer = 18, /obj/item/clothing/suit/hooded/cloak/goliath = 2))
 			if(prob(30))
-				r_pocket = pickweight(list(/obj/item/stack/marker_beacon = 20, /obj/item/stack/spacecash/c1000 = 7, /obj/item/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/damage = 1 ))
+				r_pocket = pickweight(list(/obj/item/stack/marker_beacon = 20, /obj/item/stack/spacecash/c1000 = 7, /obj/item/reagent_containers/hypospray/medipen/survival = 2, /obj/item/modkit/damage = 1 ))
 			if(prob(10))
-				l_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7, /obj/item/reagent_containers/hypospray/medipen/survival = 2, /obj/item/borg/upgrade/modkit/cooldown = 1 ))
+				l_pocket = pickweight(list(/obj/item/stack/spacecash/c1000 = 7, /obj/item/reagent_containers/hypospray/medipen/survival = 2, /obj/item/modkit/cooldown = 1 ))
 		if("Ashwalker")
 			mob_species = /datum/species/lizard/ashwalker
 			uniform = /obj/item/clothing/under/costume/gladiator/ash_walker

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -313,9 +313,8 @@
 //Cooldown
 /obj/item/modkit/cooldown
 	name = "cooldown decrease"
-	desc = "Decreases the cooldown of a kinetic accelerator. Not rated for minebot use."
+	desc = "Decreases the cooldown of a kinetic accelerator."
 	modifier = 3.2
-	minebot_upgrade = FALSE
 
 /obj/item/modkit/cooldown/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -33,7 +33,7 @@
 		. += "<b>[get_remaining_mod_capacity()]%</b> mod capacity remaining."
 		. += SPAN_INFO("You can use a <b>crowbar</b> to remove modules.")
 		for(var/A in modkits)
-			var/obj/item/borg/upgrade/modkit/M = A
+			var/obj/item/modkit/M = A
 			. += SPAN_NOTICE("There is \a [M] installed, using <b>[M.cost]%</b> capacity.")
 
 /obj/item/gun/energy/kinetic_accelerator/crowbar_act(mob/living/user, obj/item/I)
@@ -42,20 +42,20 @@
 		to_chat(user, SPAN_NOTICE("You pry the modifications out."))
 		I.play_tool_sound(src, 100)
 		for(var/a in modkits)
-			var/obj/item/borg/upgrade/modkit/M = a
+			var/obj/item/modkit/M = a
 			M.forceMove(drop_location()) //uninstallation handled in Exited(), or /mob/living/silicon/robot/remove_from_upgrades() for borgs
 	else
 		to_chat(user, SPAN_NOTICE("There are no modifications currently installed."))
 
 /obj/item/gun/energy/kinetic_accelerator/Exited(atom/movable/gone, direction)
 	if(gone in modkits)
-		var/obj/item/borg/upgrade/modkit/MK = gone
+		var/obj/item/modkit/MK = gone
 		MK.uninstall(src)
 	return ..()
 
 /obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/borg/upgrade/modkit))
-		var/obj/item/borg/upgrade/modkit/MK = I
+	if(istype(I, /obj/item/modkit))
+		var/obj/item/modkit/MK = I
 		MK.install(src, user)
 	else
 		..()
@@ -63,14 +63,14 @@
 /obj/item/gun/energy/kinetic_accelerator/proc/get_remaining_mod_capacity()
 	var/current_capacity_used = 0
 	for(var/A in modkits)
-		var/obj/item/borg/upgrade/modkit/M = A
+		var/obj/item/modkit/M = A
 		current_capacity_used += M.cost
 	return max_mod_capacity - current_capacity_used
 
 /obj/item/gun/energy/kinetic_accelerator/proc/modify_projectile(obj/projectile/kinetic/K)
 	K.kinetic_gun = src //do something special on-hit, easy!
 	for(var/A in modkits)
-		var/obj/item/borg/upgrade/modkit/M = A
+		var/obj/item/modkit/M = A
 		M.modify_projectile(K)
 
 /obj/item/gun/energy/kinetic_accelerator/cyborg
@@ -192,7 +192,7 @@
 		return
 	if(kinetic_gun)
 		var/list/mods = kinetic_gun.modkits
-		for(var/obj/item/borg/upgrade/modkit/modkit in mods)
+		for(var/obj/item/modkit/modkit in mods)
 			modkit.projectile_prehit(src, target, kinetic_gun)
 	if(!pressure_decrease_active && !lavaland_equipment_pressure_check(get_turf(target)))
 		name = "weakened [name]"
@@ -213,9 +213,9 @@
 		target_turf = get_turf(src)
 	if(kinetic_gun) //hopefully whoever shot this was not very, very unfortunate.
 		var/list/mods = kinetic_gun.modkits
-		for(var/obj/item/borg/upgrade/modkit/M in mods)
+		for(var/obj/item/modkit/M in mods)
 			M.projectile_strike_predamage(src, target_turf, target, kinetic_gun)
-		for(var/obj/item/borg/upgrade/modkit/M in mods)
+		for(var/obj/item/modkit/M in mods)
 			M.projectile_strike(src, target_turf, target, kinetic_gun)
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/M = target_turf
@@ -232,51 +232,33 @@
 
 
 //Modkits
-/obj/item/borg/upgrade/modkit
+/obj/item/modkit
 	name = "kinetic accelerator modification kit"
 	desc = "An upgrade for kinetic accelerators."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "modkit"
 	w_class = WEIGHT_CLASS_SMALL
-	require_model = TRUE
-	model_type = list(/obj/item/robot_model/miner)
-	model_flags = BORG_MODEL_MINER
 	var/denied_type = null
 	var/maximum_of_type = 1
 	var/cost = 30
 	var/modifier = 1 //For use in any mod kit that has numerical modifiers
-	var/minebot_upgrade = TRUE
-	var/minebot_exclusive = FALSE
 
-/obj/item/borg/upgrade/modkit/examine(mob/user)
+/obj/item/modkit/examine(mob/user)
 	. = ..()
 	. += SPAN_NOTICE("Occupies <b>[cost]%</b> of mod capacity.")
 
-/obj/item/borg/upgrade/modkit/attackby(obj/item/A, mob/user)
-	if(istype(A, /obj/item/gun/energy/kinetic_accelerator) && !issilicon(user))
+/obj/item/modkit/attackby(obj/item/A, mob/user)
+	if(istype(A, /obj/item/gun/energy/kinetic_accelerator))
 		install(A, user)
 	else
 		..()
 
-/obj/item/borg/upgrade/modkit/action(mob/living/silicon/robot/R)
-	. = ..()
-	if (.)
-		for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/H in R.model.modules)
-			return install(H, usr, FALSE)
-
-/obj/item/borg/upgrade/modkit/proc/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user, transfer_to_loc = TRUE)
+/obj/item/modkit/proc/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user, transfer_to_loc = TRUE)
 	. = TRUE
-	if(minebot_upgrade)
-		if(minebot_exclusive && !istype(KA.loc, /mob/living/simple_animal/hostile/mining_drone))
-			to_chat(user, SPAN_NOTICE("The modkit you're trying to install is only rated for minebot use."))
-			return FALSE
-	else if(istype(KA.loc, /mob/living/simple_animal/hostile/mining_drone))
-		to_chat(user, SPAN_NOTICE("The modkit you're trying to install is not rated for minebot use."))
-		return FALSE
 	if(denied_type)
 		var/number_of_denied = 0
 		for(var/A in KA.modkits)
-			var/obj/item/borg/upgrade/modkit/M = A
+			var/obj/item/modkit/M = A
 			if(istype(M, denied_type))
 				number_of_denied++
 			if(number_of_denied >= maximum_of_type)
@@ -295,83 +277,66 @@
 		to_chat(user, SPAN_NOTICE("You don't have room(<b>[KA.get_remaining_mod_capacity()]%</b> remaining, [cost]% needed) to install this modkit. Use a crowbar to remove existing modkits."))
 		. = FALSE
 
-/obj/item/borg/upgrade/modkit/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if (.)
-		for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/KA in R.model.modules)
-			uninstall(KA)
-
-/obj/item/borg/upgrade/modkit/proc/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/proc/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
 	KA.modkits -= src
 
-/obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/projectile/kinetic/K)
+/obj/item/modkit/proc/modify_projectile(obj/projectile/kinetic/K)
 
 //use this one for effects you want to trigger before any damage is done at all and before damage is decreased by pressure
-/obj/item/borg/upgrade/modkit/proc/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/proc/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //use this one for effects you want to trigger before mods that do damage
-/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/proc/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //and this one for things that don't need to trigger before other damage-dealing mods
-/obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/proc/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 
 //Range
-/obj/item/borg/upgrade/modkit/range
+/obj/item/modkit/range
 	name = "range increase"
 	desc = "Increases the range of a kinetic accelerator when installed."
 	modifier = 1
 	cost = 25
 
-/obj/item/borg/upgrade/modkit/range/modify_projectile(obj/projectile/kinetic/K)
+/obj/item/modkit/range/modify_projectile(obj/projectile/kinetic/K)
 	K.range += modifier
 
 
 //Damage
-/obj/item/borg/upgrade/modkit/damage
+/obj/item/modkit/damage
 	name = "damage increase"
 	desc = "Increases the damage of kinetic accelerator when installed."
 	modifier = 10
 
-/obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/projectile/kinetic/K)
+/obj/item/modkit/damage/modify_projectile(obj/projectile/kinetic/K)
 	K.damage += modifier
 
 
 //Cooldown
-/obj/item/borg/upgrade/modkit/cooldown
+/obj/item/modkit/cooldown
 	name = "cooldown decrease"
 	desc = "Decreases the cooldown of a kinetic accelerator. Not rated for minebot use."
 	modifier = 3.2
 	minebot_upgrade = FALSE
 
-/obj/item/borg/upgrade/modkit/cooldown/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
+/obj/item/modkit/cooldown/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	. = ..()
 	if(.)
 		KA.overheat_time -= modifier
 
-/obj/item/borg/upgrade/modkit/cooldown/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/cooldown/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
 	KA.overheat_time += modifier
 	..()
 
-/obj/item/borg/upgrade/modkit/cooldown/minebot
-	name = "minebot cooldown decrease"
-	desc = "Decreases the cooldown of a kinetic accelerator. Only rated for minebot use."
-	icon_state = "door_electronics"
-	icon = 'icons/obj/module.dmi'
-	denied_type = /obj/item/borg/upgrade/modkit/cooldown/minebot
-	modifier = 10
-	cost = 0
-	minebot_upgrade = TRUE
-	minebot_exclusive = TRUE
-
 
 //AoE blasts
-/obj/item/borg/upgrade/modkit/aoe
+/obj/item/modkit/aoe
 	modifier = 0
 	var/turf_aoe = FALSE
 	var/stats_stolen = FALSE
 
-/obj/item/borg/upgrade/modkit/aoe/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
+/obj/item/modkit/aoe/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	. = ..()
 	if(.)
-		for(var/obj/item/borg/upgrade/modkit/aoe/AOE in KA.modkits) //make sure only one of the aoe modules has values if somebody has multiple
+		for(var/obj/item/modkit/aoe/AOE in KA.modkits) //make sure only one of the aoe modules has values if somebody has multiple
 			if(AOE.stats_stolen || AOE == src)
 				continue
 			modifier += AOE.modifier //take its modifiers
@@ -380,16 +345,16 @@
 			AOE.turf_aoe = FALSE
 			AOE.stats_stolen = TRUE
 
-/obj/item/borg/upgrade/modkit/aoe/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/aoe/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
 	..()
 	modifier = initial(modifier) //get our modifiers back
 	turf_aoe = initial(turf_aoe)
 	stats_stolen = FALSE
 
-/obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/projectile/kinetic/K)
+/obj/item/modkit/aoe/modify_projectile(obj/projectile/kinetic/K)
 	K.name = "kinetic explosion"
 
-/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/aoe/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(stats_stolen)
 		return
 	new /obj/effect/temp_visual/explosion/fast(target_turf)
@@ -404,38 +369,38 @@
 			L.apply_damage(K.damage*modifier, K.damage_type, K.def_zone, armor)
 			to_chat(L, SPAN_USERDANGER("You're struck by a [K.name]!"))
 
-/obj/item/borg/upgrade/modkit/aoe/turfs
+/obj/item/modkit/aoe/turfs
 	name = "mining explosion"
 	desc = "Causes the kinetic accelerator to destroy rock in an AoE."
-	denied_type = /obj/item/borg/upgrade/modkit/aoe/turfs
+	denied_type = /obj/item/modkit/aoe/turfs
 	turf_aoe = TRUE
 
-/obj/item/borg/upgrade/modkit/aoe/turfs/andmobs
+/obj/item/modkit/aoe/turfs/andmobs
 	name = "offensive mining explosion"
 	desc = "Causes the kinetic accelerator to destroy rock and damage mobs in an AoE."
 	maximum_of_type = 3
 	modifier = 0.25
 
-/obj/item/borg/upgrade/modkit/aoe/mobs
+/obj/item/modkit/aoe/mobs
 	name = "offensive explosion"
 	desc = "Causes the kinetic accelerator to damage mobs in an AoE."
 	modifier = 0.2
 
 //Minebot passthrough
-/obj/item/borg/upgrade/modkit/minebot_passthrough
+/obj/item/modkit/minebot_passthrough
 	name = "minebot passthrough"
 	desc = "Causes kinetic accelerator shots to pass through minebots."
 	cost = 0
 
 //Tendril-unique modules
-/obj/item/borg/upgrade/modkit/cooldown/repeater
+/obj/item/modkit/cooldown/repeater
 	name = "rapid repeater"
 	desc = "Quarters the kinetic accelerator's cooldown on striking a living target, but greatly increases the base cooldown."
-	denied_type = /obj/item/borg/upgrade/modkit/cooldown/repeater
+	denied_type = /obj/item/modkit/cooldown/repeater
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
-/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/cooldown/repeater/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	var/valid_repeat = FALSE
 	if(isliving(target))
 		var/mob/living/L = target
@@ -447,7 +412,7 @@
 		KA.overheat = FALSE
 		KA.attempt_reload(KA.overheat_time * 0.25) //If you hit, the cooldown drops to 0.75 seconds.
 
-/obj/item/borg/upgrade/modkit/lifesteal
+/obj/item/modkit/lifesteal
 	name = "lifesteal crystal"
 	desc = "Causes kinetic accelerator shots to slightly heal the firer on striking a living target."
 	icon_state = "modkit_crystal"
@@ -455,7 +420,7 @@
 	cost = 20
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
 
-/obj/item/borg/upgrade/modkit/lifesteal/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/lifesteal/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target) && isliving(K.firer))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
@@ -463,14 +428,14 @@
 		L = K.firer
 		L.heal_ordered_damage(modifier, damage_heal_order)
 
-/obj/item/borg/upgrade/modkit/resonator_blasts
+/obj/item/modkit/resonator_blasts
 	name = "resonator blast"
 	desc = "Causes kinetic accelerator shots to leave and detonate resonator blasts."
-	denied_type = /obj/item/borg/upgrade/modkit/resonator_blasts
+	denied_type = /obj/item/modkit/resonator_blasts
 	cost = 30
 	modifier = 0.25 //A bonus 15 damage if you burst the field on a target, 60 if you lure them into it.
 
-/obj/item/borg/upgrade/modkit/resonator_blasts/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/resonator_blasts/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(target_turf && !ismineralturf(target_turf)) //Don't make fields on mineral turfs.
 		var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in target_turf
 		if(R)
@@ -479,16 +444,16 @@
 			return
 		new /obj/effect/temp_visual/resonance(target_turf, K.firer, null, 30)
 
-/obj/item/borg/upgrade/modkit/bounty
+/obj/item/modkit/bounty
 	name = "death syphon"
 	desc = "Killing or assisting in killing a creature permanently increases your damage against that type of creature."
-	denied_type = /obj/item/borg/upgrade/modkit/bounty
+	denied_type = /obj/item/modkit/bounty
 	modifier = 1.25
 	cost = 30
 	var/maximum_bounty = 25
 	var/list/bounties_reaped = list()
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/bounty/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		var/list/existing_marks = L.has_status_effect_list(STATUS_EFFECT_SYPHONMARK)
@@ -499,7 +464,7 @@
 				qdel(SM)
 		L.apply_status_effect(STATUS_EFFECT_SYPHONMARK, src)
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/bounty/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(bounties_reaped[L.type])
@@ -509,7 +474,7 @@
 			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
 			L.apply_damage(bounties_reaped[L.type]*kill_modifier, K.damage_type, K.def_zone, armor)
 
-/obj/item/borg/upgrade/modkit/bounty/proc/get_kill(mob/living/L)
+/obj/item/modkit/bounty/proc/get_kill(mob/living/L)
 	var/bonus_mod = 1
 	if(ismegafauna(L)) //megafauna reward
 		bonus_mod = 4
@@ -519,76 +484,76 @@
 		bounties_reaped[L.type] = min(bounties_reaped[L.type] + (modifier * bonus_mod), maximum_bounty)
 
 //Indoors
-/obj/item/borg/upgrade/modkit/indoors
+/obj/item/modkit/indoors
 	name = "decrease pressure penalty"
 	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure environments."
 	modifier = 2
-	denied_type = /obj/item/borg/upgrade/modkit/indoors
+	denied_type = /obj/item/modkit/indoors
 	maximum_of_type = 2
 	cost = 35
 
-/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/projectile/kinetic/K)
+/obj/item/modkit/indoors/modify_projectile(obj/projectile/kinetic/K)
 	K.pressure_decrease *= modifier
 
 
 //Trigger Guard
-/obj/item/borg/upgrade/modkit/trigger_guard
+/obj/item/modkit/trigger_guard
 	name = "modified trigger guard"
 	desc = "Allows creatures normally incapable of firing guns to operate the weapon when installed."
 	cost = 20
-	denied_type = /obj/item/borg/upgrade/modkit/trigger_guard
+	denied_type = /obj/item/modkit/trigger_guard
 
-/obj/item/borg/upgrade/modkit/trigger_guard/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
+/obj/item/modkit/trigger_guard/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	. = ..()
 	if(.)
 		KA.trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
-/obj/item/borg/upgrade/modkit/trigger_guard/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/trigger_guard/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
 	KA.trigger_guard = TRIGGER_GUARD_NORMAL
 	..()
 
 
 //Cosmetic
 
-/obj/item/borg/upgrade/modkit/chassis_mod
+/obj/item/modkit/chassis_mod
 	name = "super chassis"
 	desc = "Makes your KA yellow. All the fun of having a more powerful KA without actually having a more powerful KA."
 	cost = 0
-	denied_type = /obj/item/borg/upgrade/modkit/chassis_mod
+	denied_type = /obj/item/modkit/chassis_mod
 	var/chassis_icon = "kineticgun_u"
 	var/chassis_name = "super-kinetic accelerator"
 
-/obj/item/borg/upgrade/modkit/chassis_mod/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
+/obj/item/modkit/chassis_mod/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	. = ..()
 	if(.)
 		KA.icon_state = chassis_icon
 		KA.name = chassis_name
 
-/obj/item/borg/upgrade/modkit/chassis_mod/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/modkit/chassis_mod/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
 	KA.icon_state = initial(KA.icon_state)
 	KA.name = initial(KA.name)
 	..()
 
-/obj/item/borg/upgrade/modkit/chassis_mod/orange
+/obj/item/modkit/chassis_mod/orange
 	name = "hyper chassis"
 	desc = "Makes your KA orange. All the fun of having explosive blasts without actually having explosive blasts."
 	chassis_icon = "kineticgun_h"
 	chassis_name = "hyper-kinetic accelerator"
 
-/obj/item/borg/upgrade/modkit/tracer
+/obj/item/modkit/tracer
 	name = "white tracer bolts"
 	desc = "Causes kinetic accelerator bolts to have a white tracer trail and explosion."
 	cost = 0
-	denied_type = /obj/item/borg/upgrade/modkit/tracer
+	denied_type = /obj/item/modkit/tracer
 	var/bolt_color = "#FFFFFF"
 
-/obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/projectile/kinetic/K)
+/obj/item/modkit/tracer/modify_projectile(obj/projectile/kinetic/K)
 	K.icon_state = "ka_tracer"
 	K.color = bolt_color
 
-/obj/item/borg/upgrade/modkit/tracer/adjustable
+/obj/item/modkit/tracer/adjustable
 	name = "adjustable tracer bolts"
 	desc = "Causes kinetic accelerator bolts to have an adjustable-colored tracer trail and explosion. Use in-hand to change color."
 
-/obj/item/borg/upgrade/modkit/tracer/adjustable/attack_self(mob/user)
+/obj/item/modkit/tracer/adjustable/attack_self(mob/user)
 	bolt_color = input(user,"","Choose Color",bolt_color) as color|null

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -88,7 +88,7 @@
 	id = "triggermod"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1500, /datum/material/gold = 1500, /datum/material/uranium = 1000)
-	build_path = /obj/item/borg/upgrade/modkit/trigger_guard
+	build_path = /obj/item/modkit/trigger_guard
 	category = list("Mining Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
@@ -96,9 +96,9 @@
 	name = "Kinetic Accelerator Damage Mod"
 	desc = "A device which allows kinetic accelerators to deal more damage."
 	id = "damagemod"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1500, /datum/material/gold = 1500, /datum/material/uranium = 1000)
-	build_path = /obj/item/borg/upgrade/modkit/damage
+	build_path = /obj/item/modkit/damage
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
@@ -106,9 +106,9 @@
 	name = "Kinetic Accelerator Cooldown Mod"
 	desc = "A device which decreases the cooldown of a Kinetic Accelerator."
 	id = "cooldownmod"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1500, /datum/material/gold = 1500, /datum/material/uranium = 1000)
-	build_path = /obj/item/borg/upgrade/modkit/cooldown
+	build_path = /obj/item/modkit/cooldown
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
@@ -116,9 +116,9 @@
 	name = "Kinetic Accelerator Range Mod"
 	desc = "A device which allows kinetic accelerators to fire at a further range."
 	id = "rangemod"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1500, /datum/material/gold = 1500, /datum/material/uranium = 1000)
-	build_path = /obj/item/borg/upgrade/modkit/range
+	build_path = /obj/item/modkit/range
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
@@ -126,9 +126,9 @@
 	name = "Kinetic Accelerator Mining AoE Mod"
 	desc = "A modification kit for Kinetic Accelerators which causes it to fire AoE blasts that destroy rock."
 	id = "hypermod"
-	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 8000, /datum/material/glass = 1500, /datum/material/silver = 2000, /datum/material/gold = 2000, /datum/material/diamond = 2000)
-	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs
+	build_path = /obj/item/modkit/aoe/turfs
 	category = list("Mining Designs", "Cyborg Upgrade Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1860,7 +1860,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Kinetic Accelerator Pressure Mod"
 	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
 			Occupies 35% mod capacity."
-	item = /obj/item/borg/upgrade/modkit/indoors
+	item = /obj/item/modkit/indoors
 	cost = 5 //you need two for full damage, so total of 10 for maximum damage
 	limited_stock = 2 //you can't use more than two!
 	restricted_roles = list("Shaft Miner")


### PR DESCRIPTION
## About The Pull Request

Renames the upgrades for the Kinetic Accelerator from /obj/item/borg/upgrade/modkit
to
/obj/item/modkit

Removes snowflake borg code that prevents borgs upgrading there Kinetic Accelerator

Removes the upgrades from the MECHFAB (They were the same thing as the vendor spit out. zero diffrances aside from a type setting)


## Why It's Good For The Game

Cleans up more snowflakey borg code from the game.
While also giving a little more freedom to borgs.


## Changelog
:cl:
refactor: Kinetic Accelerator Upgrades
add: Borgs can now upgrade there KA like any other mob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
