### PR TITLE
Fixes NTOS Chat client Bluescreen when in admin mode

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNetChat.js
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.js
@@ -222,10 +222,10 @@ export const NtosNetChat = (props, context) => {
                               <>
                                 <Stack.Item>
                                   <Button
-                                    disabled={this_client.muted}
+                                    disabled={this_client?.muted}
                                     compact
                                     icon="bullhorn"
-                                    tooltip={!this_client.muted
+                                    tooltip={!this_client?.muted
                                       && "Ping" || "You are muted!"}
                                     tooltipPosition="left"
                                     onClick={() => act('PRG_ping_user', {


### PR DESCRIPTION
## About The Pull Request
Fixes a bluescreen caused by a nullkey when in admin mode.

NTOS bluescreens in the chat client because it attempts to render a mute button on a client after the admin mode has "removed" them from the room.

Added a null check to prevent this from happening, so it will check the type exists rather than just exploding.

Thanks to TG Station old prs for helping find this issue.

Fixes #798


## Changelog
:cl:
fix: NTOS Bluescreen on chat client when in admin mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
