### PR TITLE
Fixes wall scanning experiments

### DIFF
--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -46,6 +46,13 @@
 	/// Typecache of all objects that we seek out to apply a neighbor stripe overlay
 	var/static/list/neighbor_typecache
 
+/turf/closed/wall/has_material_type(datum/material/mat_type, exact=FALSE, mat_amount=0)
+	if(plating_material == mat_type)
+		return TRUE
+	if(reinf_material == mat_type)
+		return TRUE
+	return FALSE
+
 /turf/closed/wall/update_name()
 	. = ..()
 	name = ""

--- a/code/modules/experisci/experiment/types/scanning_material.dm
+++ b/code/modules/experisci/experiment/types/scanning_material.dm
@@ -16,7 +16,7 @@
 		required_materials[req_atom] = chosen_material
 
 /datum/experiment/scanning/random/material/final_contributing_index_checks(atom/target, typepath)
-	return ..() && target.custom_materials && target.has_material_type(required_materials[typepath])
+	return ..() && target.has_material_type(required_materials[typepath])
 
 /datum/experiment/scanning/random/material/serialize_progress_stage(atom/target, list/seen_instances)
 	var/datum/material/required_material = GET_MATERIAL_REF(required_materials[target])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/hrzntal/horizon/issues/696
Checking truthiness of `target.custom_materials` has been removed as that is the responsibility of `has_material_type`. Turfs don't use the `custom_materials` list as an optimization.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes experiments that required you to scan a mineral wall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
