### PR TITLE
Fixes a rare overlay lighting bug

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -274,8 +274,8 @@
 		if(directional)
 			RegisterSignal(new_holder, COMSIG_ATOM_DIR_CHANGE, .proc/on_holder_dir_change)
 	if(overlay_lighting_flags & LIGHTING_ON)
-		make_luminosity_update()
 		add_dynamic_lumi()
+		make_luminosity_update()
 	if(directional)
 		if(old_dir && isitem(new_holder)) //Small adjustment to make dropping flashlights and the kinds much better
 			new_holder.setDir(old_dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updating the light would remove and re-apply the overlay, and then adding the light would apply the overlay, and what would happen is that you wouldn't have any overlay removed, you'd get a new one during the update, and then another extra one during `add_dynamic_lumi`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes a rare overlay lighting bug, where it would stack the overlays improperly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
