### PR TITLE
Update BYOND hub status string generation 🚀

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -27,6 +27,9 @@
 
 /datum/config_entry/string/servername // server name (the name of the game window)
 
+/// Server short description
+/datum/config_entry/string/serverdesc
+
 /datum/config_entry/string/serversqlname // short form server name used for the DB
 
 /datum/config_entry/string/stationname // station name (the name of the station in-game)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -221,17 +221,15 @@
 
 /datum/config_entry/string/banappeals
 
+/datum/config_entry/string/websiteurl
+
 /datum/config_entry/string/wikiurl
-	config_entry_value = "http://www.tgstation13.org/wiki"
 
 /datum/config_entry/string/forumurl
-	config_entry_value = "http://tgstation13.org/phpBB/index.php"
 
 /datum/config_entry/string/rulesurl
-	config_entry_value = "http://www.tgstation13.org/wiki/Rules"
 
-/datum/config_entry/string/githuburl
-	config_entry_value = "https://www.github.com/tgstation/tgstation"
+/datum/config_entry/string/sourcerepourl
 
 /datum/config_entry/string/discordbotcommandprefix
 	config_entry_value = "?"

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -47,7 +47,7 @@
 		var/datum/tgs_revision_information/test_merge/tm = line
 		var/cm = tm.head_commit
 		var/details = ": '" + html_encode(tm.title) + "' by " + html_encode(tm.author) + " at commit " + html_encode(copytext_char(cm, 1, 11))
-		. += "<a href=\"[CONFIG_GET(string/githuburl)]/pull/[tm.number]\">#[tm.number][details]</a><br>"
+		. += "<a href=\"[CONFIG_GET(string/sourcerepourl)]/pull/[tm.number]\">#[tm.number][details]</a><br>"
 
 /client/verb/showrevinfo()
 	set category = "OOC"
@@ -68,7 +68,7 @@
 	msg += "<b>Server revision compiled on:</b> [revdata.date]"
 	var/pc = revdata.originmastercommit
 	if(pc)
-		msg += "Master commit: <a href=\"[CONFIG_GET(string/githuburl)]/commit/[pc]\">[pc]</a>"
+		msg += "Master commit: <a href=\"[CONFIG_GET(string/sourcerepourl)]/commit/[pc]\">[pc]</a>"
 	if(revdata.testmerge.len)
 		msg += revdata.GetTestMergeInfo()
 	if(revdata.commit && revdata.commit != revdata.originmastercommit)

--- a/code/datums/hubstatus.dm
+++ b/code/datums/hubstatus.dm
@@ -1,0 +1,48 @@
+/datum/hubstatus
+	var/hostedby
+	var/popcap
+	var/server_name
+	var/server_desc
+	var/website_url
+	var/clients
+	var/players
+	var/list/navlinks_list
+
+/datum/hubstatus/proc/get_status()
+	clients = GLOB.clients.len
+	players = GLOB.player_list.len
+
+	if(config)
+		website_url = CONFIG_GET(string/websiteurl)
+		var/forum_url = CONFIG_GET(string/forumurl)
+
+		// TODO: make this more configurable, don't hardcode Forum == Discord. Sorry downstreams, please edit or overwrite this for the meantime.
+		navlinks_list = list()
+		if(website_url)
+			navlinks_list.Add("<a href=\"[website_url]\">Website</a>")
+		if(forum_url)
+			navlinks_list.Add("<a href=\"[forum_url]\">Discord</a>")
+
+		hostedby = CONFIG_GET(string/hostedby)
+		popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
+		server_name = CONFIG_GET(string/servername)
+		server_desc = CONFIG_GET(string/serverdesc)
+
+	server_name = server_name ? server_name : station_name()
+
+	// Intermediates, that get constructed partly with config values.
+	// Make sure these can return valid values even if no config is loaded!
+	var/navlinks = navlinks_list.len ? " &#x2014; [jointext(navlinks_list, " | ")]" : ""
+	var/population_text = "[clients][popcap ? "/[popcap]" : ""] connected, [players] playing"
+	var/map_text = "Current Map: [SSmapping.config.map_name]"
+	var/hostedby_text = hostedby && !host ? " | Hosted by [hostedby]" : ""
+
+	// Our custom status construct
+	var/hubstatus = {"
+	<b>[website_url ? "<a href=\"[website_url]\">[server_name]</a>" : server_name]</b>[navlinks]&#x005D;
+	[server_desc ? "<i>[server_desc]</i>" : ""]
+
+	[map_text]
+	&#x005B;[population_text][hostedby_text]"}
+
+	return hubstatus

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -273,51 +273,18 @@ GLOBAL_VAR(restart_counter)
 	..()
 
 /world/proc/update_status()
+	var/datum/hubstatus/hubstatus = new /datum/hubstatus()
+	var/players = GLOB.player_list.len
 
-	var/list/features = list()
+	var/hubstatus_text = hubstatus.get_status()
 
-	if (!GLOB.enter_allowed)
-		features += "closed"
+	log_game(hubstatus_text)
 
-	var/s = ""
-	var/hostedby
-	if(config)
-		var/server_name = CONFIG_GET(string/servername)
-		if (server_name)
-			s += "<b>[server_name]</b> &#8212; "
-		features += "[CONFIG_GET(flag/norespawn) ? "no " : ""]respawn"
-		if(CONFIG_GET(flag/allow_ai))
-			features += "AI allowed"
-		hostedby = CONFIG_GET(string/hostedby)
+	/// tells the hub if we are full
+	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap))
 
-	s += "<b>[station_name()]</b>";
-	s += " ("
-	s += "<a href=\"http://\">" //Change this to wherever you want the hub to link to.
-	s += "Default"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
-	s += "</a>"
-	s += ")"
-
-	var/players = GLOB.clients.len
-
-	var/popcaptext = ""
-	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
-	if (popcap)
-		popcaptext = "/[popcap]"
-
-	if (players > 1)
-		features += "[players][popcaptext] players"
-	else if (players > 0)
-		features += "[players][popcaptext] player"
-
-	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
-
-	if (!host && hostedby)
-		features += "hosted by <b>[hostedby]</b>"
-
-	if (features)
-		s += ": [jointext(features, ", ")]"
-
-	status = s
+	// Sets BYOND status to our string
+	status = hubstatus_text
 
 /world/proc/update_hub_visibility(new_visibility)
 	if(new_visibility == GLOB.hub_visibility)

--- a/config/config.txt
+++ b/config/config.txt
@@ -8,20 +8,20 @@ $include interviews.txt
 
 # You can use the @ character at the beginning of a config option to lock it from being edited in-game
 # Example usage:
-# @SERVERNAME tgstation
+# @SERVERNAME Unnamed Server
 # Which sets the SERVERNAME, and disallows admins from being able to change it using View Variables.
 # @LOG_TWITTER 0
 # Which explicitly disables LOG_TWITTER, as well as locking it.
 # There are various options which are hard-locked for security reasons.
 
-## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'tgstation' with the name of your choice.
-# SERVERNAME tgstation
+## Server name: This appears at the top of the screen in-game and in the BYOND hub.
+# SERVERNAME Unnamed Server
 
 ## Short description of the server, appears below the server name in the BYOND hub
 # SERVERDESC This server's description has not been set up yet.
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
-# SERVERSQLNAME tgstation
+# SERVERSQLNAME server1
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13
@@ -242,17 +242,20 @@ CHECK_RANDOMIZER
 ## Don't set this to the same server, BYOND will automatically restart players to the server when it has restarted.
 # SERVER ss13.example.com:2506
 
+## website address
+# WEBSITEURL https://example.com
+
 ## forum address
-# FORUMURL http://tgstation13.org/phpBB/index.php
+# FORUMURL https://example.com/forum
 
 ## Wiki address
-# WIKIURL http://www.tgstation13.org/wiki
+# WIKIURL https://example.com/wiki
 
 ## Rules address
-# RULESURL http://www.tgstation13.org/wiki/Rules
+# RULESURL https://example.com/rules
 
-## Github address
-# GITHUBURL https://www.github.com/tgstation/tgstation
+## GitHub address
+# SOURCEREPOURL https://github.com/octocat/Hello-World
 
 ## Discord bot command prefix, if the discord bot is used
 # DISCORDBOTCOMMANDPREFIX ?

--- a/config/config.txt
+++ b/config/config.txt
@@ -17,6 +17,9 @@ $include interviews.txt
 ## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'tgstation' with the name of your choice.
 # SERVERNAME tgstation
 
+## Short description of the server, appears below the server name in the BYOND hub
+# SERVERDESC This server's description has not been set up yet.
+
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 # SERVERSQLNAME tgstation
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -40,26 +40,26 @@
 		to_chat(src, SPAN_DANGER("The rules URL is not set in the server configuration."))
 	return
 
-/client/verb/github()
-	set name = "github"
-	set desc = "Visit Github"
+/client/verb/source()
+	set name = "sourcecode"
+	set desc = "Visit the source code."
 	set hidden = TRUE
-	var/githuburl = CONFIG_GET(string/githuburl)
-	if(githuburl)
-		if(tgui_alert(src, "This will open the Github repository in your browser. Are you sure?",, list("Yes","No"))!="Yes")
+	var/sourcerepourl = CONFIG_GET(string/sourcerepourl)
+	if(sourcerepourl)
+		if(tgui_alert(src, "This will open the sourecode repository in your browser. Are you sure?",, list("Yes","No"))!="Yes")
 			return
-		src << link(githuburl)
+		src << link(sourcerepourl)
 	else
-		to_chat(src, SPAN_DANGER("The Github URL is not set in the server configuration."))
+		to_chat(src, SPAN_DANGER("The Sourcecode repo URL is not set in the server configuration."))
 	return
 
 /client/verb/reportissue()
 	set name = "report-issue"
 	set desc = "Report an issue"
 	set hidden = TRUE
-	var/githuburl = CONFIG_GET(string/githuburl)
-	if(githuburl)
-		var/message = "This will open the Github issue reporter in your browser. Are you sure?"
+	var/sourcerepourl = CONFIG_GET(string/sourcerepourl)
+	if(sourcerepourl)
+		var/message = "This will open the issue reporter in your browser. Are you sure?"
 		if(GLOB.revdata.testmerge.len)
 			message += "<br>The following experimental changes are active and are probably the cause of any new or sudden issues you may experience. If possible, please try to find a specific thread for your issue instead of posting to the general issue tracker:<br>"
 			message += GLOB.revdata.GetTestMergeInfo(FALSE)
@@ -88,14 +88,14 @@
 			var/list/all_tms = list()
 			for(var/entry in GLOB.revdata.testmerge)
 				var/datum/tgs_revision_information/test_merge/tm = entry
-				all_tms += "- \[[tm.title]\]([githuburl]/pull/[tm.number])"
+				all_tms += "- \[[tm.title]\]([sourcerepourl]/pull/[tm.number])"
 			var/all_tms_joined = all_tms.Join("\n") // for some reason this can't go in the []
 			local_template = replacetext(local_template, "## Testmerges:\n", "## Testmerges:\n[all_tms_joined]")
 
 		var/url_params = "Reporting client version: [byond_version].[byond_build]\n\n[local_template]"
-		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[url_encode(url_params)]"))
+		DIRECT_OUTPUT(src, link("[sourcerepourl]/issues/new?body=[url_encode(url_params)]"))
 	else
-		to_chat(src, SPAN_DANGER("The Github URL is not set in the server configuration."))
+		to_chat(src, SPAN_DANGER("The sourecode repo URL is not set in the server configuration."))
 	return
 
 /client/verb/changelog()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -444,6 +444,7 @@
 #include "code\datums\hailer_phrase.dm"
 #include "code\datums\holocall.dm"
 #include "code\datums\http.dm"
+#include "code\datums\hubstatus.dm"
 #include "code\datums\hud.dm"
 #include "code\datums\jukebox_datums.dm"
 #include "code\datums\map_config.dm"


### PR DESCRIPTION
## About The Pull Request
Updates the hub status generator to be confined in its own file.
Adds and removes some metadata from it.
Will now use the same text string if config is missing, just with omitted entries.

Also edits some of the default config entries to be more general (and https for good habits), along with a refactor of `githuburl` to `sourcerepourl`
Added a new `website_url` config entry