### PR TITLE
Logarithmic Audio Volume

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -14,6 +14,14 @@
 //KEEP IT UPDATED
 #define CHANNEL_HIGHEST_AVAILABLE 985
 
+// TODO: This is currently set to 2 because of legacy audio volumes. Re-balance all audio with a target of NUM_E or 3
+/// Logarithmic exponent for volume levels - Good values are 2, NUM_E, 3 and 4, depending on loudness.
+#define LOGARITHMIC_AUDIO_VOLUME_EXPONENT 2
+// I hate the following but my smooth brain can't come up with a better way to multiply this correctly.
+// (x²) * 0.01 would work, but the multiplier is dependent on the exponent.
+/// Helper macro for converting linear volume to logarithmic.
+#define LOG_AUDIOVOLUME(X) (((X * 0.01) ** LOGARITHMIC_AUDIO_VOLUME_EXPONENT) * 100)
+
 ///Default range of a sound.
 #define SOUND_RANGE 17
 #define MEDIUM_RANGE_SOUND_EXTRARANGE -5

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -193,7 +193,7 @@
 	for(var/client/C in GLOB.clients)
 		if(!C?.credits)
 			C?.RollCredits()
-		C?.playtitlemusic(40)
+		C?.playtitlemusic()
 
 	CHECK_TICK
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,3 +1,4 @@
+#define LOBBYMUSIC_VOLUME 30
 
 ///Default override for echo
 /sound
@@ -197,12 +198,12 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	S.status = SOUND_UPDATE
 	SEND_SOUND(src, S)
 
-/client/proc/playtitlemusic(vol = 30)
+/client/proc/playtitlemusic(vol = LOBBYMUSIC_VOLUME)
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
-		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
+		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = LOG_AUDIOVOLUME(vol), channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.
@@ -269,3 +270,5 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 			if("hypertorusmelting")
 				soundin = pick('sound/machines/sm/accent/delam/1.ogg', 'sound/machines/sm/accent/normal/2.ogg', 'sound/machines/sm/accent/normal/3.ogg', 'sound/machines/sm/accent/normal/4.ogg', 'sound/machines/sm/accent/normal/5.ogg', 'sound/machines/sm/accent/normal/6.ogg', 'sound/machines/sm/accent/normal/7.ogg', 'sound/machines/sm/accent/normal/8.ogg', 'sound/machines/sm/accent/normal/9.ogg', 'sound/machines/sm/accent/normal/10.ogg', 'sound/machines/sm/accent/normal/11.ogg', 'sound/machines/sm/accent/normal/12.ogg', 'sound/machines/sm/accent/normal/13.ogg', 'sound/machines/sm/accent/normal/14.ogg', 'sound/machines/sm/accent/normal/15.ogg', 'sound/machines/sm/accent/normal/16.ogg', 'sound/machines/sm/accent/normal/17.ogg', 'sound/machines/sm/accent/normal/18.ogg', 'sound/machines/sm/accent/normal/19.ogg', 'sound/machines/sm/accent/normal/20.ogg', 'sound/machines/sm/accent/normal/21.ogg', 'sound/machines/sm/accent/normal/22.ogg', 'sound/machines/sm/accent/normal/23.ogg', 'sound/machines/sm/accent/normal/24.ogg', 'sound/machines/sm/accent/normal/25.ogg', 'sound/machines/sm/accent/normal/26.ogg', 'sound/machines/sm/accent/normal/27.ogg', 'sound/machines/sm/accent/normal/28.ogg', 'sound/machines/sm/accent/normal/29.ogg', 'sound/machines/sm/accent/normal/30.ogg', 'sound/machines/sm/accent/normal/31.ogg', 'sound/machines/sm/accent/normal/32.ogg', 'sound/machines/sm/accent/normal/33.ogg')
 	return soundin
+
+#undef LOBBYMUSIC_VOLUME


### PR DESCRIPTION
## About The Pull Request
*Ever feel.. like your ears explode when you play Space Station 13?
Ever feel.. like the sounds all have the same volume?
Ever feel.. like a plastic bag-* wait.. no.
Anyways-
*Look no further!*

This adds defines and macro for logarithmic audio volumes.
Currently only the lobbymusic has been adjusted to make use of it, but soon more will follow.

Right now this uses an exponent of ², as most other sounds do not use this system, and I'm going to assume that EVERYONE plays with their game on the audio mixer at ~30% or less.

In the future, a target of the mathematical constant e (`NUM_E`) / Euler's number, or `3` would be preferable.
This largely depends on how loud the average of all sound files are, or could even be changed based on what kind of sound category is being controlled.

A good read:
https://www.dr-lex.be/info-stuff/volumecontrols.html

## Why It's Good For The Game
Better audio volume experience for users and audio volume control for developers.

## Changelog
:cl:
soundadd: Added logarithmic audio volume
qol: Lobbymusic now uses logarithmic audio volume at 30% - tune in!
qol: Roundend music now uses the same volume as the lobby music (30% instead of 40%)
/:cl:
