### PR TITLE
Bluespace anomaly will now only teleport to the same level

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -233,11 +233,13 @@
 /obj/effect/anomaly/bluespace/detonate()
 	var/turf/T = pick(get_area_turfs(impact_area))
 	if(T)
-			// Calculate new position (searches through beacons in world)
+		// Find a teleport beacon in the same z-level to teleport the entities to.
 		var/obj/item/beacon/chosen
 		var/list/possible = list()
+		var/datum/virtual_level/my_vlevel = get_virtual_level()
 		for(var/obj/item/beacon/W in GLOB.teleportbeacons)
-			possible += W
+			if(W.get_virtual_level == my_vlevel)
+				possible += W
 
 		if(possible.len > 0)
 			chosen = pick(possible)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
9 out of 10 cases this teleports into some safe spots, some cases it just kills people and makes their body unrecoverably, and it isn't very fun. So now its restricted to the same level

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Bluespace anomaly will now only teleport to the same level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
