### PR TITLE
Proper dir offsets and mapping types for bathroom objects

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -44,6 +44,23 @@
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 	AddElement(/datum/element/connect_loc, src, loc_connections)
+	setDir(dir)
+
+/obj/machinery/shower/setDir(newdir)
+	. = ..()
+	switch(dir)
+		if(NORTH)
+			pixel_x = 0
+			pixel_y = 24
+		if(SOUTH)
+			pixel_x = 0
+			pixel_y = 0
+		if(EAST)
+			pixel_x = 0
+			pixel_y = 0
+		if(WEST)
+			pixel_x = 0
+			pixel_y = 0
 
 /obj/machinery/shower/examine(mob/user)
 	. = ..()
@@ -186,6 +203,18 @@
 		L.adjustFireLoss(5)
 		to_chat(L, SPAN_DANGER("[src] is searing!"))
 
+/obj/machinery/shower/directional/north
+	pixel_y = 24
+	dir = NORTH
+
+/obj/machinery/shower/directional/south
+	dir = SOUTH
+
+/obj/machinery/shower/directional/east
+	dir = EAST
+
+/obj/machinery/shower/directional/west
+	dir = WEST
 
 /obj/structure/showerframe
 	name = "shower frame"

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -17,7 +17,6 @@
 	open = round(rand(0, 1))
 	update_appearance()
 
-
 /obj/structure/toilet/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(.)
@@ -154,6 +153,26 @@
 	var/exposed = 0 // can you currently put an item inside
 	var/obj/item/hiddenitem = null // what's in the urinal
 
+/obj/structure/urinal/Initialize(mapload)
+	. = ..()
+	setDir(dir)
+
+/obj/structure/urinal/setDir(newdir)
+	. = ..()
+	switch(dir)
+		if(NORTH)
+			pixel_x = 0
+			pixel_y = -32
+		if(SOUTH)
+			pixel_x = 0
+			pixel_y = 32
+		if(EAST)
+			pixel_x = 32
+			pixel_y = 0
+		if(WEST)
+			pixel_x = -32
+			pixel_y = 0
+
 /obj/structure/urinal/directional/north
 	dir = SOUTH
 	pixel_y = 32
@@ -282,6 +301,7 @@
 
 /obj/structure/sink/Initialize(mapload, bolt)
 	. = ..()
+	setDir(dir)
 	if(has_water_reclaimer)
 		create_reagents(100, NO_REACT)
 		reagents.add_reagent(dispensedreagent, 100)
@@ -428,6 +448,22 @@
 		drop_materials()
 	..()
 
+/obj/structure/sink/setDir(newdir)
+	. = ..()
+	switch(dir)
+		if(NORTH)
+			pixel_x = 0
+			pixel_y = 20
+		if(SOUTH)
+			pixel_x = 0
+			pixel_y = -5
+		if(EAST)
+			pixel_x = -15
+			pixel_y = 0
+		if(WEST)
+			pixel_x = 15
+			pixel_y = 0
+
 /obj/structure/sink/process(delta_time)
 	if(has_water_reclaimer && reagents.total_volume < reagents.maximum_volume)
 		reagents.add_reagent(dispensedreagent, reclaim_rate * delta_time)
@@ -447,6 +483,26 @@
 	if(!reclaiming)
 		reclaiming = TRUE
 		START_PROCESSING(SSfluids, src)
+
+/obj/structure/sink/directional/north
+	dir = NORTH
+	pixel_x = 0
+	pixel_y = 20
+
+/obj/structure/sink/directional/south
+	dir = SOUTH
+	pixel_x = 0
+	pixel_y = -5
+
+/obj/structure/sink/directional/east
+	dir = EAST
+	pixel_x = -15
+	pixel_y = 0
+
+/obj/structure/sink/directional/west
+	dir = WEST
+	pixel_x = 15
+	pixel_y = 0
 
 /obj/structure/sink/kitchen
 	name = "kitchen sink"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sinks, showers and urinals now set their offset based on their direction instead of being magicked up from the mapping preset / varedit. All of them also have mapping types for directionals now too
Fixes https://github.com/hrzntal/horizon/issues/915

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Proper dir offsets and mapping types for bathroom objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
