### PR TITLE
Deconstructing showers

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -48,6 +48,8 @@
 /obj/machinery/shower/examine(mob/user)
 	. = ..()
 	. += SPAN_NOTICE("[reagents.total_volume]/[reagents.maximum_volume] liquids remaining.")
+	. += SPAN_NOTICE("You could adjust its temperature <b>wrenching</b> it.")
+	. += SPAN_NOTICE("You could disassemble it by <b>unwrenching</b> it with right-click.")
 
 /obj/machinery/shower/Destroy()
 	QDEL_NULL(soundloop)
@@ -73,6 +75,13 @@
 			tile.MakeSlippery(TURF_WET_WATER, min_wet_time = 5 SECONDS, wet_time_to_add = 1 SECONDS)
 
 /obj/machinery/shower/attackby(obj/item/I, mob/user, params)
+	var/list/modifiers = params2list(params)
+	if(I.tool_behaviour == TOOL_WRENCH && LAZYACCESS(modifiers, RIGHT_CLICK))
+		to_chat(user, SPAN_NOTICE("You start deconstructing [src]..."))
+		if(I.use_tool(src, user, 5 SECONDS, volume=50))
+			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+			deconstruct(TRUE)
+		return TRUE
 	if(I.tool_behaviour == TOOL_ANALYZER)
 		to_chat(user, SPAN_NOTICE("The water temperature seems to be [current_temperature]."))
 	else
@@ -170,7 +179,9 @@
 		return PROCESS_KILL
 
 /obj/machinery/shower/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/iron(drop_location(), 3)
+	new /obj/item/stack/sheet/iron(drop_location(), 2)
+	if(disassembled)
+		new /obj/item/stock_parts/water_recycler(drop_location())
 	qdel(src)
 
 /obj/machinery/shower/proc/check_heat(mob/living/L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now deconstruct showers, and you'll get back their full parts too
Added interaction hints to examine of showers
Closes https://github.com/hrzntal/horizon/issues/916

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added interaction hints to examine of showers
add: You can now deconstruct showers, and you'll get back their full parts too
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
