### PR TITLE
Synthetic Anthromorphs and more sanity

### DIFF
--- a/code/__HELPERS/customization/mobs.dm
+++ b/code/__HELPERS/customization/mobs.dm
@@ -13,7 +13,12 @@
 
 /proc/random_accessory_of_key_for_species(key, datum/species/S, mismatched=FALSE, ckey)
 	var/list/accessory_list = accessory_list_of_key_for_species(key, S, mismatched, ckey)
-	var/datum/sprite_accessory/SP = GLOB.sprite_accessories[key][pick(accessory_list)]
+	var/datum/sprite_accessory/SP
+	if(length(accessory_list))
+		SP = GLOB.sprite_accessories[key][pick(accessory_list)]
+	// Try and default the choice to "None" if nothing was found
+	if(!SP)
+		SP = GLOB.sprite_accessories[key]["None"]
 	if(!SP)
 		CRASH("Cant find random accessory of [key] key, for species [S.id]")
 	return SP

--- a/code/modules/mob/living/carbon/human/species_types/robotic.dm
+++ b/code/modules/mob/living/carbon/human/species_types/robotic.dm
@@ -146,3 +146,71 @@
 	if(BMS)
 		markings = assemble_body_markings_from_set(BMS, passed_features, src)
 	return markings
+
+/datum/species/robotic/synth_anthro
+	name = "Synthetic Anthromorph"
+	id = "synthanthro"
+	flavor_text = "A robotic lifeform. This model is designed to appear similar to anthromorphs. Surface level damage is easy to repair, but they're sensitive to electronic disruptions."
+	species_traits = list(
+		ROBOTIC_DNA_ORGANS,
+		MUTCOLORS,
+		EYECOLOR,
+		LIPS,
+		HAIR,
+		ROBOTIC_LIMBS,
+		NOTRANSSTING,
+		REVIVES_BY_HEALING
+		)
+	default_mutant_bodyparts = list(
+		"tail" = ACC_RANDOM,
+		"snout" = ACC_RANDOM,
+		"horns" = "None",
+		"ears" = ACC_RANDOM,
+		"legs" = ACC_RANDOM,
+		"taur" = "None",
+		"wings" = "None",
+		"neck" = "None"
+		)
+	limbs_icon = 'icons/mob/species/mammal_parts_greyscale.dmi'
+	limbs_id = "mammal"
+
+// Somewhat of a paste from the mammal's random features, because they're supposed to mimick them in appearance.
+/datum/species/robotic/synth_anthro/get_random_features()
+	var/list/returned = MANDATORY_FEATURE_LIST
+	var/main_color
+	var/second_color
+	var/third_color
+	var/random = rand(1,7)
+	switch(random)
+		if(1)
+			main_color = "FFFFFF"
+			second_color = "333333"
+			third_color = "333333"
+		if(2)
+			main_color = "FFFFDD"
+			second_color = "DD6611"
+			third_color = "AA5522"
+		if(3)
+			main_color = "DD6611"
+			second_color = "FFFFFF"
+			third_color = "DD6611"
+		if(4)
+			main_color = "CCCCCC"
+			second_color = "FFFFFF"
+			third_color = "FFFFFF"
+		if(5)
+			main_color = "AA5522"
+			second_color = "CC8833"
+			third_color = "FFFFFF"
+		if(6)
+			main_color = "FFFFDD"
+			second_color = "FFEECC"
+			third_color = "FFDDBB"
+		if(7) //Oh no you've rolled the sparkle dog
+			main_color = random_color()
+			second_color = random_color()
+			third_color = random_color()
+	returned["mcolor"] = main_color
+	returned["mcolor2"] = second_color
+	returned["mcolor3"] = third_color
+	return returned

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -393,6 +393,7 @@ ROUNDSTART_RACES vox
 ROUNDSTART_RACES aquatic
 ROUNDSTART_RACES insect
 ROUNDSTART_RACES teshari
+ROUNDSTART_RACES synthanthro
 
 ##-------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds synthetic anthromorphs, they currently need to enable mismatched parts to customize properly.
Adds more sanity to randomizing an accessory sprite.
Closes https://github.com/hrzntal/horizon/issues/922

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Synthetic Anthromorphs
fix: More sanity in randomizing sprite accessories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
