### PR TITLE
Clearing turfs in the map parser

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1526,3 +1526,10 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	new /obj/effect/pod_landingzone(landing_location, pod)
 	return pod
 
+/proc/clear_turf(turf/turf_to_clear)
+	for(var/obj/structure/spawner/nest in turf_to_clear)
+		qdel(nest)
+	for(var/mob/living/simple_animal/monster in turf_to_clear)
+		qdel(monster)
+	for(var/obj/structure/flora/plant in turf_to_clear)
+		qdel(plant)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1526,6 +1526,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	new /obj/effect/pod_landingzone(landing_location, pod)
 	return pod
 
+/// Clears a turf out of flora, monsters and monster nets. Used by map parsing and a mapping helper.
 /proc/clear_turf(turf/turf_to_clear)
 	for(var/obj/structure/spawner/nest in turf_to_clear)
 		qdel(nest)

--- a/code/game/objects/effects/spawners/clear.dm
+++ b/code/game/objects/effects/spawners/clear.dm
@@ -1,12 +1,11 @@
-///This spawner clears the terrain of flora, and ScrapeAway's mineral turfs
+///This spawner clears the terrain of flora and other stuff, and ScrapeAway's mineral turfs
 /obj/effect/spawner/clear
 	name = "clear terrain"
 
 /obj/effect/spawner/clear/Initialize()
 	..()
 	var/turf/my_turf = get_turf(src)
-	for(var/obj/structure/flora/flora in my_turf)
-		qdel(flora)
 	if(ismineralturf(my_turf))
 		my_turf.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
+	clear_turf(my_turf)
 	return INITIALIZE_HINT_QDEL

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -136,7 +136,7 @@
 
 	return mapzone
 
-/datum/map_template/proc/load(turf/T, centered = FALSE)
+/datum/map_template/proc/load(turf/T, centered = FALSE, clear_existing_turfs = FALSE)
 	if(centered)
 		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)
 	if(!T)

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -25,16 +25,7 @@
 
 		testing("Ruin \"[name]\" placed at ([central_turf.x], [central_turf.y], [central_turf.z])")
 
-		for(var/i in get_affected_turfs(central_turf, 1))
-			var/turf/T = i
-			for(var/obj/structure/spawner/nest in T)
-				qdel(nest)
-			for(var/mob/living/simple_animal/monster in T)
-				qdel(monster)
-			for(var/obj/structure/flora/plant in T)
-				qdel(plant)
-
-		load(central_turf,centered = TRUE)
+		load(central_turf,centered = TRUE, clear_existing_turfs = TRUE)
 		loaded++
 
 		for(var/turf/T in get_affected_turfs(central_turf, 1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The turf passthrough will no longer clear the turf of its content during spawning ruins.
The map parser now has the functionality of clearing turfs in the loaded maps, instead of that being on the ruin level (needs to be because the parser is the one checking for passthroughs)
You can retain previous behaviours by placing down the `/obj/effect/spawner/clear` map helper wherever you please
Closes https://github.com/hrzntal/horizon/issues/935

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ruins will no longer cut every flora and monster in their viscinity when spawned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
