### PR TITLE
Fixes overlay management conflict

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -698,10 +698,12 @@
 		if(LAZYLEN(managed_vis_overlays))
 			SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 
-		var/list/new_overlays = update_overlays(updates)
+		// First clear managed overlays because atoms can be managing the appearance of their own overlays on updates.
 		if(managed_overlays)
 			cut_overlay(managed_overlays)
 			managed_overlays = null
+		// Then get the new overlays and apply them if any.
+		var/list/new_overlays = update_overlays(updates)
 		if(length(new_overlays))
 			if (length(new_overlays) == 1)
 				managed_overlays = new_overlays[1]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was tricky to find.
Basically atoms can modify appearance of already instantiated overlays on `update_overlays` instead of creating a new overlay, and `update_overlays` wouldn't remove the overlays (cause they were modified, so it was a mismatch) before getting new ones.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes overlay management conflict
fix: Booze machines will no longer apply indefinite amount of beaker overlays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
