### PR TITLE
Adds a flag for objects to allow transparency if they block multiz

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -15,8 +15,9 @@
 #define BLOCK_Z_IN_DOWN (1<<11) // Should this object block z falling from above?
 #define BLOCK_Z_IN_UP (1<<12) // Should this object block z uprise from below?
 #define FULL_BLOCK_Z_BELOW (1<<13)  // Should this object block all z interactions to the below turf? Will block turf transparency, but has to be updated by a signal //DOES NOT BLOCK ATMOS (do your own atmos pass logic)
-#define FULL_BLOCK_Z_ABOVE (1<<14) // Should this object block all z interactions to the above turf? //DOES NOT BLOCK ATMOS (do your own atmos pass logic)
-#define NO_BUILD (1<<15) // Can we build on this object?
+#define BLOCK_ALLOW_TRANSPARENCY (1<<14)  // Whether a FULL_BLOCK_Z_BELOW still allows turf transparency to happen. Special flag for cases where you don't really want to update the transparency often so you just dont block it in the first place.
+#define FULL_BLOCK_Z_ABOVE (1<<15) // Should this object block all z interactions to the above turf? //DOES NOT BLOCK ATMOS (do your own atmos pass logic)
+#define NO_BUILD (1<<16) // Can we build on this object?
 
 // If you add new ones, be sure to add them to /obj/Initialize as well for complete mapping support
 

--- a/code/datums/elements/turf_transparency.dm
+++ b/code/datums/elements/turf_transparency.dm
@@ -42,7 +42,7 @@
 
 	var/apply_transparency = TRUE
 	for(var/obj/object in our_turf)
-		if(object.obj_flags & FULL_BLOCK_Z_BELOW) //Something's blocking our mutltiz view
+		if(object.obj_flags & FULL_BLOCK_Z_BELOW && !(object.obj_flags & BLOCK_ALLOW_TRANSPARENCY)) //Something's blocking our mutltiz view
 			apply_transparency = FALSE
 			break
 	if(apply_transparency)

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -142,7 +142,7 @@
 	smoothing_flags = NONE
 	smoothing_groups = null
 	canSmoothWith = null
-	obj_flags = CAN_BE_HIT | FULL_BLOCK_Z_BELOW
+	obj_flags = CAN_BE_HIT | FULL_BLOCK_Z_BELOW | BLOCK_ALLOW_TRANSPARENCY
 	//kind of a centerpiece of the station, so pretty tough to destroy
 	armor = list(MELEE = 80, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 100, BIO = 80, RAD = 80, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently there's an issue with the tram leaving a hole where it spawns. This can be fixed by updating the turfs transparencies every time the tram is moved, however, this will end up in 35 updates which include networking (vis contents) every time the tram moves on top of already heavy updates it's making. So I'd rather have this flag instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Adds a flag for objects to allow transparency if they block multiz
fix: The tram will no longer leave a black hole where it was first spawned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
