### PR TITLE
Deposit Credits in PDA/Tablet

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -431,14 +431,8 @@
 	if(istype(W, /obj/item/rupee))
 		to_chat(user, SPAN_WARNING("Your ID smartly rejects the strange shard of glass. Who knew, apparently it's not ACTUALLY valuable!"))
 		return
-	else if(istype(W, /obj/item/holochip))
+	else if(iscash(W))
 		insert_money(W, user)
-		return
-	else if(istype(W, /obj/item/stack/spacecash))
-		insert_money(W, user, TRUE)
-		return
-	else if(istype(W, /obj/item/coin))
-		insert_money(W, user, TRUE)
 		return
 	else if(istype(W, /obj/item/storage/bag/money))
 		var/obj/item/storage/bag/money/money_bag = W
@@ -458,7 +452,11 @@
  * user - The user inserting the item.
  * physical_currency - Boolean, whether this is a physical currency such as a coin and not a holochip.
  */
-/obj/item/card/id/proc/insert_money(obj/item/money, mob/user, physical_currency)
+/obj/item/card/id/proc/insert_money(obj/item/money, mob/user)
+	var/physical_currency
+	if(istype(money, /obj/item/stack/spacecash) || istype(money, /obj/item/coin))
+		physical_currency = TRUE
+
 	if(!registered_account)
 		to_chat(user, SPAN_WARNING("[src] doesn't have a linked account to deposit [money] into!"))
 		return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1035,6 +1035,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 		var/obj/item/photo/P = C
 		picture = P.picture
 		to_chat(user, SPAN_NOTICE("You scan \the [C]."))
+	// Check to see if we have an ID inside, and a valid input for money
+	else if(id && iscash(C))
+		id.attackby(C, user) // If we do, try and put that attacking object in
 	else
 		return ..()
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -555,6 +555,13 @@
 			to_chat(user, SPAN_NOTICE("You repair \the [src]."))
 		return
 
+	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
+	// Check to see if we have an ID inside, and a valid input for money
+	if(card_slot?.GetID() && iscash(W))
+		var/obj/item/card/id/id = card_slot.GetID()
+		id.attackby(W, user) // If we do, try and put that attacking object in
+		return
+
 	..()
 
 // Used by processor to relay qdel() to machinery type.


### PR DESCRIPTION
## About The Pull Request

Just a QoL upgrade that got added awhile back on TG. Let's you push credits right onto your PDA or Tablet, and assuming they have an ID inside with a linked account, adds the money.

## Why It's Good For The Game

We get a _**lot**_ of money in the mail. Sucks having to keep pulling out my ID to stick the newly gotten credits in my account. This simplifies things.

## Changelog
:cl:
qol: Put credits straight into your PDA/Tablet
/:cl: