### PR TITLE
Adds Long Range Holopads to Petrel and Vulture

### DIFF
--- a/_maps/shuttles/common_petrel.dmm
+++ b/_maps/shuttles/common_petrel.dmm
@@ -89,6 +89,7 @@
 /area/shuttle/petrel)
 "C" = (
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/holopad/long_range,
 /turf/open/floor/pod,
 /area/shuttle/petrel)
 "E" = (

--- a/_maps/shuttles/common_vulture.dmm
+++ b/_maps/shuttles/common_vulture.dmm
@@ -662,6 +662,16 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/shuttle/vulture)
+"VY" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/holopad/long_range,
+/turf/open/floor/iron,
+/area/shuttle/vulture)
 "Wx" = (
 /obj/machinery/door/airlock,
 /obj/effect/decal/cleanable/dirt,
@@ -806,7 +816,7 @@ eN
 Vg
 fG
 rI
-MG
+VY
 MG
 MG
 oz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds long range holopads to Petrel and Vulture, at Cypress' request.

## Why It's Good For The Game
More forms of long distance communication good.

## Changelog
:cl:
add: adds long range holopads to two shuttles
/:cl:
