### PR TITLE
Adds LRHPs to techwebs and circuit imprinters

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -441,6 +441,12 @@
 	build_path = /obj/item/circuitboard/machine/holopad
 	category = list ("Misc. Machinery")
 
+/datum/design/board/holopad/holopad_long_range
+	name = "Machine Design (Long Range Holopad)"
+	desc = "The circuit board for a long range holopad."
+	id = "long_range"
+	build_path = /obj/item/circuitboard/machine/holopad_long_range
+	category = list ("Misc. Machinery")
 
 /datum/design/board/autolathe
 	name = "Machine Design (Autolathe Board)"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -832,6 +832,7 @@
 		"tray_goggles",
 		"holopad",
 		"vendatray",
+		"long_range"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -832,7 +832,7 @@
 		"tray_goggles",
 		"holopad",
 		"vendatray",
-		"long_range"
+		"long_range",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds LRHPs to techwebs, under the same node requirement as normal holopads (Electromagnetic Theory), and makes them printable from the circuit imprinter.

![image](https://user-images.githubusercontent.com/29272475/171337696-9caa3ab1-4591-4203-b4ea-de23643a6c70.png)


## Why It's Good For The Game
More availability of long distance communication good, especially for those building on platform shuttles.

## Changelog
:cl:
add: adds long range holopads to the circuit imprinter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
