### PR TITLE
Adds Wideband Intercom Relay to Autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -701,6 +701,14 @@
 	build_path = /obj/item/wallframe/intercom
 	category = list("initial", "T-Comm")
 
+/datum/design/wideband_intercom_frame
+	name = "Wideband Intercom Frame"
+	id = "wideband relay"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 75, /datum/material/glass = 25)
+	build_path = /obj/item/wallframe/intercom/wideband
+	category = list("initial", "T-Comm")
+
 /datum/design/infrared_emitter
 	name = "Infrared Emitter"
 	id = "infrared_emitter"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the Wideband Intercom Relay to the Autolathe, as it is the low tech solution to long distance communication. Doing it in this fashion allows for ghost roles to have access to it.

## Why It's Good For The Game
Easier access to forms of long distance communication is good, especially those wishing to build one on a shuttle platform without access to a circuit imprinter.

## Changelog
:cl:
add: adds the wideband intercom to the autolathe
/:cl:
