### PR TITLE
Hologram Emotes and RUNEchat

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -476,7 +476,13 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		AI.current = src
 	SetLightsAndPower()
 	update_holoray(user, get_turf(loc))
+	RegisterSignal(user, COMSIG_MOB_EMOTE, .proc/handle_hologram_emote)
 	return TRUE
+
+/obj/machinery/holopad/proc/handle_hologram_emote(atom/movable/source, datum/emote/emote, action, type_override, message, intentional)
+	SIGNAL_HANDLER
+	for(var/mob/mob_viewer in viewers(world.view, src))
+		to_chat(mob_viewer, "<span class='emote'><b>[source]</b> [message]</span>")
 
 /obj/machinery/holopad/proc/clear_holo(mob/living/user)
 	qdel(masters[user]) // Get rid of user's hologram
@@ -491,6 +497,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	qdel(holorays[user])
 	LAZYREMOVE(holorays, user)
 	SetLightsAndPower()
+	UnregisterSignal(user, COMSIG_MOB_EMOTE)
 	return TRUE
 
 //Try to transfer hologram to another pad that can project on T

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -484,7 +484,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/holopad/proc/handle_hologram_emote(atom/movable/source, datum/emote/emote, action, type_override, message, intentional)
 	SIGNAL_HANDLER
 	for(var/mob/mob_viewer in viewers(world.view, src))
-		to_chat(mob_viewer, "<span class='emote'><b>[source]</b> [message]</span>")
+		to_chat(mob_viewer, SPAN_EMOTE("<b>[source]</b> [message]"))
 
 /obj/machinery/holopad/proc/clear_holo(mob/living/user)
 	qdel(masters[user]) // Get rid of user's hologram

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -581,7 +581,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	else
 		ray.transform = turn(M.Scale(1,sqrt(distx*distx+disty*disty)),newangle)
 
-// RECORDED MESSAGES%
+// RECORDED MESSAGES
 
 /obj/machinery/holopad/proc/setup_replay_holo(datum/holorecord/record)
 	var/obj/effect/overlay/holo_pad_hologram/Hologram = new(loc)//Spawn a blank effect at the location.

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -439,10 +439,12 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			if(masters[master] && speaker != master)
 				master.relay_speech(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
-	for(var/I in holo_calls)
-		var/datum/holocall/HC = I
-		if(HC.connected_holopad == src && speaker != HC.hologram)
-			HC.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
+	for(var/datum/holocall/holocall_to_update as anything in holo_calls)
+		if(holocall_to_update.connected_holopad == src)//if we answered this call originating from another holopad
+			if(speaker == holocall_to_update.hologram && holocall_to_update.user.client?.prefs.chat_on_map)
+				holocall_to_update.user.create_chat_message(speaker, message_language, raw_message, spans)
+			else
+				holocall_to_update.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
 	if(outgoing_call?.hologram && speaker == outgoing_call.user)
 		outgoing_call.hologram.say(raw_message)
@@ -579,7 +581,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	else
 		ray.transform = turn(M.Scale(1,sqrt(distx*distx+disty*disty)),newangle)
 
-// RECORDED MESSAGES
+// RECORDED MESSAGES%
 
 /obj/machinery/holopad/proc/setup_replay_holo(datum/holorecord/record)
 	var/obj/effect/overlay/holo_pad_hologram/Hologram = new(loc)//Spawn a blank effect at the location.


### PR DESCRIPTION
## About The Pull Request

Brings over some stuff to cover a couple requests people wanted. When doing holocalls you can now use EMOTES as the caller. Makes sense, since you're standing on the pad so it can visually image your body to the person receiving the call.
Also allows runechat functionality for the hologram.

![image](https://user-images.githubusercontent.com/84706993/171532544-849f7485-ad71-4adb-80ca-4ab173d79173.png)
![image](https://user-images.githubusercontent.com/84706993/171532575-777a7d31-ad04-4b39-a731-5605ed081a3a.png)


## Why It's Good For The Game

Just some QoL stuff. That ain't ever gonna hurt nobody!

## Changelog
:cl:
qol: Holograms can now emote. 
qol: Holograms now have runechat support.
/:cl:
