### PR TITLE
Cargo Pack QoL & Additions (Boombox Goodie, RCD, meat/pizza re-jiggery)

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -187,7 +187,7 @@
 /datum/supply_pack/goody/boombox
 	name = "Boombox"
 	desc = "A classic-style boombox! A large set of speakers, your own portable jukebox!"
-	cost = PAYCHECK_HARD * 25
+	cost = PAYCHECK_HARD * 21
 	contains = list(
 		/obj/item/boombox
 	)

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -184,6 +184,14 @@
 		/obj/item/clothing/mask/breath,
 	)
 
+/datum/supply_pack/goody/boombox
+	name = "Boombox"
+	desc = "A classic-style boombox! A large set of speakers, your own portable jukebox!"
+	cost = PAYCHECK_HARD * 25
+	contains = list(
+		/obj/item/boombox
+	)
+
 // Misc Stuff
 /datum/supply_pack/goody/crayons
 	name = "Box of Crayons"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -691,6 +691,17 @@
 	group = "Engineering"
 	crate_type = /obj/structure/closet/crate/engineering
 
+/datum/supply_pack/engineering/rcd_crate
+	name = "Rapid Construction Device"
+	desc = "One fully-loaded RCD! Capable of patching breaches and constructing simple rooms."
+	cost = CARGO_CRATE_VALUE * 12.5
+	access = ACCESS_ENGINE
+	contains = list(
+		/obj/item/construction/rcd/loaded
+		)
+	crate_name = "RCD crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
+
 /datum/supply_pack/engineering/engi_hardsuit
 	name = "Engineering Hardsuit"
 	desc = "Poly 'Who stole all the hardsuits!' Well now you can get more hardsuits if needed! NOTE ONE HARDSUIT IS IN THIS CRATE, as well as one oxygen tank and mask!"
@@ -939,12 +950,6 @@
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"
 
-/datum/supply_pack/engineering/rcd_crate
-	name = "Rapid Construction Device (RCD) Crate"
-	desc = "Need to patch out large-scale breaches, or build on easy-mode? RCDs are the tools for you! Contains one RCD, with enough matter units to fully load it."
-	cost = CARGO_CRATE_VALUE * 12.5
-	access = ACCESS_ENGINE
-	crate_type = /obj/structure/closet/crate/rcd
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////// Engine Construction /////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -939,6 +939,12 @@
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"
 
+/datum/supply_pack/engineering/rcd_crate
+	name = "Rapid Construction Device (RCD) Crate"
+	desc = "Need to patch out large-scale breaches, or build on easy-mode? RCDs are the tools for you! Contains one RCD, with enough matter units to fully load it."
+	cost = CARGO_CRATE_VALUE * 12.5
+	access = ACCESS_ENGINE
+	crate_type = /obj/structure/closet/crate/rcd
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////// Engine Construction /////////////////////////////////
@@ -1922,17 +1928,12 @@
 /datum/supply_pack/organic/randomized/chef
 	name = "Excellent Meat Crate"
 	desc = "The best cuts in the whole galaxy."
-	cost = CARGO_CRATE_VALUE * 4
-	contains = list(/obj/item/food/meat/slab/human/mutant/slime,
+	cost = CARGO_CRATE_VALUE * 3.75
+	contains = list(/obj/item/food/meat/slab,
 					/obj/item/food/meat/slab/killertomato,
 					/obj/item/food/meat/slab/bear,
-					/obj/item/food/meat/slab/xeno,
-					/obj/item/food/meat/slab/spider,
 					/obj/item/food/meat/rawbacon,
-					/obj/item/food/meat/slab/penguin,
-					/obj/item/food/spiderleg,
-					/obj/item/food/fishmeat/carp,
-					/obj/item/food/meat/slab/human)
+					/obj/item/food/fishmeat/)
 	crate_name = "food crate"
 
 /datum/supply_pack/organic/randomized/chef/fill(obj/structure/closet/crate/C)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2049,7 +2049,7 @@
 	///The percentage chance (per pizza) of this supply pack to spawn an anomalous pizza box.
 	var/anna_molly_box_chance = 1
 	///Total tickets in our figurative lottery (per pizza) to decide if we create a bomb box, and if so what type. 1 to 3 create a bomb. The rest do nothing.
-	var/boombox_tickets = 100
+	var/boombox_tickets = 200
 	///Whether we've provided a bomb pizza box already this shift or not.
 	var/boombox_provided = FALSE
 


### PR DESCRIPTION
## About The Pull Request
• Adds the boombox as a cargo goodie pack. It costs 2100cr, slightly higher than going to a vendor (2000cr)
• Adds the RCD crate. Contains one fully-loaded RCD for the price of 2500cr. It costs an absurd 1000cr to buy it at a vendor.
• Changes the changes of pizza crates spawning bombs to 3 in 100 to 3 in 200.
• Removes meme meats from the "excellent meat crate" so it's actually excellent. The crate picks from the list and gives some extras at random. Here's me testing it locally. Fishy, huh?
![image](https://user-images.githubusercontent.com/53862927/171841273-26172569-f121-4558-928b-2f91ebee6293.png)

## Why It's Good For The Game
RCDs are currently the only way to remove ground on icebox. It's a pain to try and actually get the darned thing. The price might be a little cheap, it's up to everyone else to decide.

The meat crate gave you about two useable meats, the rest were xeno, spider legs, human meat and meat-that-kills-you-if-you-eat it. Now it's actually worth buying the crate, because you'll get what the crate promises. Excellent meat.

Pizza bombs... I'm personally responsible for a few because of how frequently I make the order. We get far too many. It happens so often that I now pre-check pizza out of fear that me delivering a pizza to someone is going to remove them from the round for 15m whilst medical re-attaches their limbs. It's no longer funny and unique when we get a pizza bomb.

Boomboxes are very desirable, them being orderable by cargo goodies gives people a reason actually get money. Not many people know you can get them at the games vendor, so this should up the visibility. The reasoning for it being more expensive is:
![image](https://user-images.githubusercontent.com/53862927/171842078-321c32a4-561b-4f59-ad02-bb1e50e44257.png)
I think the vendor remains attractive at the same price regardless because it allows you to get the boombox instantly, instead of waiting on cargo, but I'll leave that point up for discussion in the comments.

## Changelog
:cl:
balance: Pizza bombs are now much less frequent (3 in 200 chance, down from 3 in 100).
qol: Boomboxes can now be ordered as a cargo goodie!
balance: Meat crates from cargo now contain only useable quality meat that won't kill you.
qol: RCDs can now be ordered from cargo!
/:cl:
