### PR TITLE
ERT Medic loadout changes

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -110,15 +110,18 @@
 	suit_store = /obj/item/gun/energy/e_gun
 	back = /obj/item/storage/backpack/ert/medical
 	backpack_contents = list(
-		/obj/item/gun/medbeam = 1,
+		/obj/item/storage/box/survival/engineer = 1,
+		/obj/item/storage/box/hug/plushes = 1,
+		/obj/item/storage/firstaid/advanced = 1,
 		/obj/item/melee/baton/loaded = 1,
 		/obj/item/reagent_containers/hypospray/combat = 1,
-		/obj/item/storage/box/hug/plushes = 1,
-		/obj/item/storage/box/survival/engineer = 1,
+		/obj/item/pinpointer/crew = 1,
+		/obj/item/healthanalyzer/advanced = 1,
 )
-	belt = /obj/item/storage/belt/medical
+	belt = /obj/item/defibrillator/compact/loaded
 	glasses = /obj/item/clothing/glasses/hud/health
-	l_hand = /obj/item/storage/firstaid/regular
+	l_hand = /obj/item/storage/belt/medical/paramedic
+	r_hand = /obj/item/storage/duffelbag/med/surgery
 
 /datum/outfit/centcom/ert/medic/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -134,14 +137,19 @@
 	name = "ERT Medic - High Alert"
 
 	backpack_contents = list(
+		/obj/item/storage/box/survival/engineer = 1,
+		/obj/item/storage/box/hug/plushes = 1,
+		/obj/item/storage/firstaid/advanced = 1,
 		/obj/item/gun/energy/pulse/pistol/loyalpin = 1,
 		/obj/item/gun/medbeam = 1,
 		/obj/item/melee/baton/loaded = 1,
 		/obj/item/reagent_containers/hypospray/combat/nanites = 1,
-		/obj/item/storage/box/hug/plushes = 1,
-		/obj/item/storage/box/survival/engineer = 1,
+		/obj/item/pinpointer/crew = 1,
+		/obj/item/healthanalyzer/advanced = 1,
 )
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
+	glasses = /obj/item/clothing/glasses/hud/health/night
+	belt = /obj/item/defibrillator/compact/combat/loaded/nanotrasen
 
 /datum/outfit/centcom/ert/engineer
 	name = "ERT Engineer"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -121,7 +121,7 @@
 	belt = /obj/item/defibrillator/compact/loaded
 	glasses = /obj/item/clothing/glasses/hud/health
 	l_hand = /obj/item/storage/belt/medical/paramedic
-	r_hand = /obj/item/storage/duffelbag/med/surgery
+	r_hand = /obj/item/storage/backpack/duffelbag/med/surgery
 
 /datum/outfit/centcom/ert/medic/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()


### PR DESCRIPTION
## About The Pull Request
• Makes ERT medics both fit for purpose, giving them the tools they need to actually do _stuff_. They now both have defibrillators.
• Regular ERT medic loses their medigun.
• Both ERT medics get a crew pinpointer, advanced medkit (synthflesh), surgery duffelbag, advanced health analyzer and paramedic belt.
• High Alert ERT get night vision medihuds.

## Why It's Good For The Game
ERT medics that spawn currently do not have the appropriate tools to do their job, and have little difference between alert levels.
This PR fully equips both medics, and takes the medigun away from the regular alert ERT. They do have synthflesh to reduce the damage to defib levels, though. Now there's a meaningful difference between the two alerts.

_Okay, this is a bit of a non-issue, but it'd be nice if these outfits weren't scuffed._

## Changelog
:cl:
balance: ERT medics are now equipped for purpose upon spawning. Normal ones lose their medigun, but gain other supplies. Both gain defibs and some other goodies.
/:cl: