### PR TITLE
Decrease standard organ decay time

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -167,8 +167,8 @@
 //organ defines
 #define STANDARD_ORGAN_THRESHOLD 100
 #define STANDARD_ORGAN_HEALING 50 / 100000
-/// designed to fail organs when left to decay for ~15 minutes
-#define STANDARD_ORGAN_DECAY 111 / 100000
+/// designed to fail organs when left to decay for ~30 minutes CALC: y = 100 − 0.0000555 * x
+#define STANDARD_ORGAN_DECAY 55.5 / 100000
 
 //used for the can_chromosome var on mutations
 #define CHROMOSOME_NEVER 0


### PR DESCRIPTION
## About The Pull Request
organs decay a bit too fast, this PR should address this.

Currently, it raises the time it takes for organs to decay by standard by 100% (200% total / double)

While writing this I actually realized i wouldn't be happy with this, because it would also count organs outside bodies for this.

I'm going to draft this and instead change it to only apply to in-body organs (sensewise it would be due to less contaminants being inside the body for them to rot, than outside)
Reason for that is, organ transport boxes and such should still be viable and part of active gameplay.
We just don't want people that died to rot way too quickly.

## Changelog
:cl:
balance: Organs decay slower
/:cl:
