### PR TITLE
Adds the CTS Pigeon and EMS Rockdove

### DIFF
--- a/_maps/shuttles/common_pigeon.dmm
+++ b/_maps/shuttles/common_pigeon.dmm
@@ -2,7 +2,9 @@
 "be" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/lattice/catwalk/plated,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/north{
+	locked = 0
+	},
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plating,
 /area/shuttle/pigeon)
@@ -179,7 +181,9 @@
 /area/shuttle/pigeon/helm)
 "se" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/airalarm/directional/east{
+	locked = 0
+	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/pod,
 /area/shuttle/pigeon/helm)
@@ -371,10 +375,12 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/pigeon)
 "Pp" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad/long_range,
+/obj/machinery/power/apc/auto_name/west{
+	locked = 0
+	},
 /turf/open/floor/pod,
 /area/shuttle/pigeon/helm)
 "QV" = (
@@ -476,7 +482,9 @@
 /area/shuttle/pigeon/helm)
 "Yz" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	locked = 0
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,

--- a/_maps/shuttles/common_pigeon.dmm
+++ b/_maps/shuttles/common_pigeon.dmm
@@ -154,9 +154,7 @@
 /turf/open/floor/plating,
 /area/shuttle/pigeon)
 "nS" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
+/obj/machinery/recharge_station,
 /turf/open/floor/pod,
 /area/shuttle/pigeon/helm)
 "qy" = (

--- a/_maps/shuttles/common_pigeon.dmm
+++ b/_maps/shuttles/common_pigeon.dmm
@@ -1,0 +1,628 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"be" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"cm" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters{
+	id = "pigeon cargo shutter"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"cV" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/space/syndiecosmetic,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"de" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/structure/rack,
+/obj/item/clothing/suit/space/fragile,
+/obj/item/clothing/head/helmet/space/fragile,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"eT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"fJ" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"gF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/lights/tubes,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "fuel pump";
+	color = "#FF7B00";
+	pipe_color = "#FF7B00"
+	},
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"gO" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"iU" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"jG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin{
+	pixel_x = -4
+	},
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = 4
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"ki" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/pigeon)
+"kk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"kA" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/pigeon/helm)
+"li" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pigeon_shutter"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/pigeon/helm)
+"lQ" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"ml" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"nj" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "air supply pump";
+	color = "#0000FF";
+	pipe_color = "#0000FF"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/power/apc/auto_name/west{
+	locked = 0
+	},
+/obj/structure/cable,
+/obj/structure/lattice/catwalk/plated,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"nS" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"qy" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	pipe_color = "#0000FF"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/directional/north,
+/obj/structure/lattice/catwalk/plated,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"qA" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Pigeon Helm"
+	},
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"se" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"sw" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "pigeon_shutter";
+	name = "safety shutters button"
+	},
+/obj/item/radio/intercom/wideband/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"tf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"vu" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"wU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"xC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"zl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"zE" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"zX" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/pigeon)
+"Dd" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"EW" = (
+/obj/machinery/computer/shuttle/common_docks{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"GQ" = (
+/turf/template_noop,
+/area/template_noop)
+"GX" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"HU" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "pigeon cargo shutter"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/button/door/directional/west{
+	name = "cargo bay shutters";
+	id = "pigeon cargo shutter"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"In" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/ore_scarce,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"Je" = (
+/obj/machinery/door/window/eastleft{
+	dir = 2
+	},
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"Ji" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters{
+	id = "pigeon cargo shutter"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/door/firedoor,
+/obj/structure/sign/warning/movingparts/small{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"LG" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/lattice/catwalk/plated,
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"LJ" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"LX" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"Nd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"NV" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pigeon_shutter"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"Oa" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/pigeon)
+"Pp" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad/long_range,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"QV" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/large/air_can,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"QW" = (
+/obj/docking_port/mobile{
+	dir = 2;
+	dwidth = 6;
+	height = 9;
+	id = "pigeon";
+	launch_status = 0;
+	name = "CTS Pigeon";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 11
+	},
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/lattice/catwalk/plated,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"UO" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"Vb" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/plush/borbplushie{
+	name = "Garuda";
+	desc = "Garuda is portrayed as a protector with the power to swiftly travel anywhere, ever vigilant and an enemy of every serpent."
+	},
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"Vt" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/visible,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"VH" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	pipe_color = "#FF7B00"
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/lattice/catwalk/plated,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+"VQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"Wc" = (
+/obj/machinery/atmospherics/components/unary/engine{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/pigeon)
+"Yb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/pod,
+/area/shuttle/pigeon/helm)
+"Yz" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron,
+/area/shuttle/pigeon)
+"ZS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/lattice/catwalk/plated,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/pigeon)
+
+(1,1,1) = {"
+zX
+Wc
+zX
+GQ
+GQ
+GQ
+zX
+Wc
+zX
+"}
+(2,1,1) = {"
+zX
+Vt
+Oa
+NV
+ki
+NV
+Oa
+Vt
+zX
+"}
+(3,1,1) = {"
+zX
+qy
+nj
+LG
+Yz
+QV
+zE
+LJ
+zX
+"}
+(4,1,1) = {"
+zX
+VH
+gF
+Je
+fJ
+xC
+ml
+wU
+HU
+"}
+(5,1,1) = {"
+zX
+zX
+zX
+zX
+UO
+In
+cV
+wU
+cm
+"}
+(6,1,1) = {"
+QW
+ZS
+iU
+lQ
+vu
+zl
+VQ
+tf
+Ji
+"}
+(7,1,1) = {"
+zX
+be
+de
+kA
+qA
+kA
+li
+li
+kA
+"}
+(8,1,1) = {"
+kA
+kA
+li
+kA
+LX
+Pp
+Nd
+nS
+li
+"}
+(9,1,1) = {"
+li
+GX
+Nd
+Yb
+Dd
+Vb
+kk
+eT
+li
+"}
+(10,1,1) = {"
+kA
+kA
+gO
+se
+jG
+EW
+sw
+kA
+kA
+"}
+(11,1,1) = {"
+GQ
+kA
+kA
+kA
+li
+li
+li
+kA
+GQ
+"}

--- a/_maps/shuttles/common_rockdove.dmm
+++ b/_maps/shuttles/common_rockdove.dmm
@@ -2,7 +2,9 @@
 "be" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/lattice/catwalk/plated,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/airalarm/directional/north{
+	locked = 0
+	},
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plating,
 /area/shuttle/rockdove)
@@ -155,11 +157,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/cable,
+/obj/structure/lattice/catwalk/plated,
 /obj/machinery/power/apc/auto_name/west{
 	locked = 0
 	},
-/obj/structure/cable,
-/obj/structure/lattice/catwalk/plated,
 /turf/open/floor/plating,
 /area/shuttle/rockdove)
 "nl" = (
@@ -306,6 +308,7 @@
 /obj/machinery/computer/shuttle/common_docks{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/pod,
 /area/shuttle/rockdove/helm)
 "GQ" = (
@@ -314,7 +317,9 @@
 "GX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	locked = 0
+	},
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/under/misc/pj/red,
 /turf/open/floor/pod,
@@ -407,10 +412,12 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/rockdove)
 "Pp" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad/long_range,
+/obj/machinery/power/apc/auto_name/west{
+	locked = 0
+	},
 /turf/open/floor/pod,
 /area/shuttle/rockdove/helm)
 "QV" = (
@@ -531,7 +538,9 @@
 /area/shuttle/rockdove/helm)
 "Yz" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	locked = 0
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,

--- a/_maps/shuttles/common_rockdove.dmm
+++ b/_maps/shuttles/common_rockdove.dmm
@@ -162,6 +162,17 @@
 /obj/structure/lattice/catwalk/plated,
 /turf/open/floor/plating,
 /area/shuttle/rockdove)
+"nl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rockdove_shutter"
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/shuttle/rockdove/helm)
 "nS" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/pod,
@@ -635,10 +646,10 @@ LX
 Pp
 Nd
 nS
-li
+nl
 "}
 (9,1,1) = {"
-li
+nl
 GX
 zX
 Yb

--- a/_maps/shuttles/common_rockdove.dmm
+++ b/_maps/shuttles/common_rockdove.dmm
@@ -163,9 +163,7 @@
 /turf/open/floor/plating,
 /area/shuttle/rockdove)
 "nS" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
+/obj/machinery/recharge_station,
 /turf/open/floor/pod,
 /area/shuttle/rockdove/helm)
 "qy" = (

--- a/_maps/shuttles/common_rockdove.dmm
+++ b/_maps/shuttles/common_rockdove.dmm
@@ -1,0 +1,674 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"be" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"cm" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "rockdove_cargo_shutter"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/sign/warning/movingparts/small{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"cV" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"de" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/structure/rack,
+/obj/item/clothing/suit/space/fragile,
+/obj/item/clothing/head/helmet/space/fragile,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"eT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"fJ" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/machinery/meter,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"gF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/lights/tubes,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "fuel pump";
+	color = "#FF7B00";
+	pipe_color = "#FF7B00"
+	},
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"gO" = (
+/obj/machinery/light/directional/north,
+/obj/structure/bed,
+/obj/structure/curtain,
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"iU" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"jG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin{
+	pixel_x = -4
+	},
+/obj/structure/table,
+/obj/item/pen{
+	pixel_x = 4
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"jO" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rockdove_shutter"
+	},
+/turf/open/floor/plating,
+/area/shuttle/rockdove/helm)
+"ki" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/rockdove)
+"kk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"kA" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/rockdove/helm)
+"li" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rockdove_shutter"
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/rockdove/helm)
+"lQ" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/lattice/catwalk/plated,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"ml" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"nj" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	name = "air supply pump";
+	color = "#0000FF";
+	pipe_color = "#0000FF"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/power/apc/auto_name/west{
+	locked = 0
+	},
+/obj/structure/cable,
+/obj/structure/lattice/catwalk/plated,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"nS" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"qy" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/directional/north,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	pipe_color = "#0000FF"
+	},
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"qA" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Rockdove Helm"
+	},
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"se" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed,
+/obj/structure/curtain,
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"sw" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "rockdove_shutter";
+	name = "safety shutters button"
+	},
+/obj/item/radio/intercom/wideband/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"tf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/stasis,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"vu" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"wU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"xC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"zl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/stasis,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mob_spawn/human/skeleton,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"zE" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/brute{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"zX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/plush/snakeplushie{
+	name = "Aesculapian snake plushie";
+	desc = "A tag reads: 'I swear by Apollo the Healer and by Asclepius and by Hygieia and Panacea and by all the gods...'"
+	},
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"Dd" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"EW" = (
+/obj/machinery/computer/shuttle/common_docks{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"GQ" = (
+/turf/template_noop,
+/area/template_noop)
+"GX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf,
+/obj/machinery/airalarm/directional/west,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/clothing/under/misc/pj/red,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"HU" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "rockdove_cargo_shutter"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/button/door/directional/west{
+	name = "cargo bay shutters";
+	id = "rockdove_cargo_shutter"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"In" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"Je" = (
+/obj/machinery/door/window/eastleft{
+	dir = 2
+	},
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"Ji" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/rockdove)
+"LG" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/lattice/catwalk/plated,
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"LJ" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"LX" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"Nd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"NV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rockdove_shutter"
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"Oa" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/rockdove)
+"Pp" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad/long_range,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"QV" = (
+/obj/structure/rack/shelf,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/belt/medical,
+/obj/item/healthanalyzer,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"QW" = (
+/obj/docking_port/mobile{
+	dir = 2;
+	dwidth = 6;
+	height = 9;
+	id = "rockdove";
+	launch_status = 0;
+	name = "EMS Rockdove";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 11
+	},
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/lattice/catwalk/plated,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"UO" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"Vb" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/soft/paramedic{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/toggle/labcoat/paramedic,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"Vt" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/visible,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"VH" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/lattice/catwalk/plated,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	pipe_color = "#FF7B00"
+	},
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+"VQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/chem_pack{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/stack/medical/gauze{
+	pixel_x = 8
+	},
+/obj/item/stack/medical/mesh{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"Wc" = (
+/obj/machinery/atmospherics/components/unary/engine{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/rockdove)
+"Yb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/pod,
+/area/shuttle/rockdove/helm)
+"Yz" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/rockdove)
+"ZS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/lattice/catwalk/plated,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/rockdove)
+
+(1,1,1) = {"
+Ji
+Wc
+Ji
+GQ
+GQ
+GQ
+Ji
+Wc
+Ji
+"}
+(2,1,1) = {"
+Ji
+Vt
+Oa
+NV
+ki
+NV
+Oa
+Vt
+Ji
+"}
+(3,1,1) = {"
+Ji
+qy
+nj
+LG
+Yz
+QV
+zE
+LJ
+Ji
+"}
+(4,1,1) = {"
+Ji
+VH
+gF
+Je
+fJ
+xC
+ml
+In
+HU
+"}
+(5,1,1) = {"
+Ji
+Ji
+Ji
+Ji
+UO
+cV
+cV
+wU
+cm
+"}
+(6,1,1) = {"
+QW
+ZS
+iU
+lQ
+vu
+zl
+VQ
+tf
+Ji
+"}
+(7,1,1) = {"
+Ji
+be
+de
+kA
+qA
+kA
+li
+li
+kA
+"}
+(8,1,1) = {"
+kA
+kA
+li
+kA
+LX
+Pp
+Nd
+nS
+li
+"}
+(9,1,1) = {"
+li
+GX
+zX
+Yb
+Dd
+Vb
+kk
+eT
+li
+"}
+(10,1,1) = {"
+kA
+kA
+gO
+se
+jG
+EW
+sw
+kA
+kA
+"}
+(11,1,1) = {"
+GQ
+kA
+kA
+kA
+jO
+jO
+li
+kA
+GQ
+"}

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -317,6 +317,22 @@
 	requires_power = TRUE
 	area_limited_icon_smoothing = /area/shuttle/petrel
 
+/area/shuttle/pigeon
+	name = "CTS Pigeon"
+	requires_power = TRUE
+	area_limited_icon_smoothing = /area/shuttle/pigeon
+
+/area/shuttle/pigeon/helm
+	name = "CTS Pigeon Helm"
+
+/area/shuttle/rockdove
+	name = "EMS Rockdove"
+	requires_power = TRUE
+	area_limited_icon_smoothing = /area/shuttle/rockdove
+
+/area/shuttle/rockdove/helm
+	name = "EMS Rockdove Helm"
+
 /area/shuttle/barrow
 	name = "The Barrows"
 	requires_power = FALSE

--- a/code/modules/shuttle/common_docks.dm
+++ b/code/modules/shuttle/common_docks.dm
@@ -50,6 +50,14 @@
 	suffix = "petrel"
 	name = "MS Petrel"
 
+/datum/map_template/shuttle/common/pigeon
+	suffix = "pigeon"
+	name = "CTS Pigeon"
+
+/datum/map_template/shuttle/common/rockdove
+	suffix = "rockdove"
+	name = "EMS Rockdove"
+
 /datum/map_template/shuttle/common/platform_small
 	suffix = "platform_small"
 	name = "Platform Shuttle"

--- a/code/modules/shuttle/sold_shuttles.dm
+++ b/code/modules/shuttle/sold_shuttles.dm
@@ -25,6 +25,24 @@
 	allowed_docks = list(DOCKS_MEDIUM_UPWARDS)
 	shuttle_type = SHUTTLE_MINING
 
+/datum/sold_shuttle/pigeon
+	name = "CTS Pigeon"
+	desc = "A small sized civilian transport shuttle."
+	detailed_desc = "It's a small sized transport shuttle that is normally utilized by colonies, this model featuring a small cargo bay. This shuttle is normally considered the workhorse of the frontier."
+	shuttle_id = "common_pigeon"
+	cost = 3000
+	allowed_docks = list(DOCKS_MEDIUM_UPWARDS)
+	shuttle_type = SHUTTLE_CIV
+
+/datum/sold_shuttle/rockdove
+	name = "EMS Rockdove"
+	desc = "A small sized emergency medical shuttle."
+	detailed_desc = "A medical shuttle conversion of the CTS Pigeon by Frontier Practical Solutions, in which the cargo bay has been converted into a triage zone. While sometimes utilized by colony hospitals, it is often a rare sight on the frontier."
+	shuttle_id = "common_rockdove"
+	cost = 4500 //upcharge on the conversion, debatable if actually worth it
+	allowed_docks = list(DOCKS_MEDIUM_UPWARDS)
+	shuttle_type = SHUTTLE_CIV
+
 /datum/sold_shuttle/vulture
 	name = "MS Vulture"
 	desc = "A medium sized mining shuttle, equipped with a living quarter."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the CTS (Civilian Transport Shuttle) Pigeon and the EMS (Emergency Medical Shuttle) Rockdove, and allows them to be purchased on the Sold Shuttles console. These are packaged together due to both going into the cheap shuttle niche, with each fulfilling a different role. I've tested both thoroughly to make sure they function and both have minimal runtimes. 

Descriptions and screenshots collapsed into details.

<details>

The Pigeon is a stock-standard shuttle that has no lasers or transporter pad, as its main role is for the transportation of people and supplies. The concept behind this shuttle is to provide overmap travelers with a 'sprinter van'-esq alternative to the larger ESS Crow. This shuttle costs the same as the Petrel, as to fill out the cheap and small shuttle niche.

![image](https://user-images.githubusercontent.com/29272475/172253500-9fb08f31-7f0e-42b7-87cd-b0319f1c48a1.png)

</details>

<details>

The Rockdove is an aftermarket remodel of the Pigeon by the newly coined "Frontier Practical Solutions" corporation, with its purpose being defined as an ambulance. The cargo area is replaced with a triage zone, with it facilitating only the most basic of medical treatment. This is intentional to provide people the bedrock to upgrade and customize in an emergent fashion, or to work around the limitations provided to roleplay. There is a 1500cr upcharge on this conversion, as to keep it from being the better choice between it and the Pigeon

![image](https://user-images.githubusercontent.com/29272475/172253666-7ba4295f-fba7-46f0-835b-cc021efb09d9.png)

</details>

## Why It's Good For The Game
These two shuttles round out the cheap shuttle niche, allowing for a nice variety on this end of the Sold Shuttles.

The Pigeon is also a nice shuttle for colony mapping, giving them an option for overmap travel.

Let me know if anything needs to be changed or reworked.


## Changelog
:cl:
add: CTS Pigeon
add: EMS Rockdove
/:cl:
