### PR TITLE
Megafauna will no longer devour (gib) dead targets

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -110,10 +110,8 @@
 			if(!client && ranged && ranged_cooldown <= world.time)
 				OpenFire()
 
-			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH)) //Nope, it still gibs yall
-				devour(L)
-		else
-			devour(L)
+			else
+				LoseTarget(L)
 
 /// Devours a target and restores health to the megafauna
 /mob/living/simple_animal/hostile/megafauna/proc/devour(mob/living/L)


### PR DESCRIPTION
## About The Pull Request
• Megafauna no longer call the proc to gib and restore health of a target if they are dead, and instead, call the `LoseTarget()` proc that makes simplemobs (incl. megas) disengage.

Please note, the `devour()` proc has not been touched as it is still used by player-controlled megafauna.

## Why It's Good For The Game
Please look at this from the perspective of "why should megafauna gib you?" instead of "why should we remove megafauna gibbing you?".
I think there is more value in giving your fellow miners the prospect of trying to recover your body when it's so close to a megafauna and giving medical a player to revive than there is just removing the player from the round and forcing them to sign up again as a new job.

## Changelog
:cl:
balance: computer-controlled Megafaunas no longer gib their active targets.
/:cl:
