### PR TITLE
Unifies abstract types

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -5695,16 +5695,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
-"SJ" = (
-/obj/structure/statue{
-	desc = "A lifelike statue of a horrifying monster.";
-	dir = 8;
-	icon = 'icons/mob/lavaland/lavaland_monsters.dmi';
-	icon_state = "goliath";
-	name = "goliath"
-	},
-/turf/open/floor/iron,
-/area/mine/living_quarters)
 "SR" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -17394,7 +17384,7 @@ dZ
 fy
 fy
 dZ
-SJ
+dZ
 cR
 mO
 mO

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4632,16 +4632,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
-"SJ" = (
-/obj/structure/statue{
-	desc = "A lifelike statue of a horrifying monster.";
-	dir = 8;
-	icon = 'icons/mob/lavaland/lavaland_monsters.dmi';
-	icon_state = "goliath";
-	name = "goliath"
-	},
-/turf/open/floor/iron,
-/area/mine/living_quarters)
 "Tb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/north{
@@ -12716,7 +12706,7 @@ dZ
 fy
 fy
 dZ
-SJ
+dZ
 cR
 aj
 aj

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -6,6 +6,7 @@
 #define KEY_MODE_TYPE 1
 
 /datum/config_entry
+	abstract_type = /datum/config_entry //do not instantiate if type matches this
 	var/name //read-only, this is determined by the last portion of the derived entry type
 	var/config_entry_value
 	var/default //read-only, just set value directly
@@ -16,14 +17,13 @@
 	var/deprecated_by //the /datum/config_entry type that supercedes this one
 
 	var/protection = NONE
-	var/abstract_type = /datum/config_entry //do not instantiate if type matches this
 
 	var/vv_VAS = TRUE //Force validate and set on VV. VAS proccall guard will run regardless.
 
 	var/dupes_allowed = FALSE
 
 /datum/config_entry/New()
-	if(type == abstract_type)
+	if(is_abstract(type))
 		CRASH("Abstract config entry [type] instatiated!")
 	name = lowertext(type2top(type))
 	if(islist(config_entry_value))

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -83,9 +83,9 @@
 	entries_by_type = _entries_by_type
 
 	for(var/I in typesof(/datum/config_entry)) //typesof is faster in this case
-		var/datum/config_entry/E = I
-		if(initial(E.abstract_type) == I)
+		if(is_abstract(I))
 			continue
+		var/datum/config_entry/E = I
 		E = new I
 		var/esname = E.name
 		var/datum/config_entry/test = _entries[esname]
@@ -196,7 +196,7 @@
 
 /datum/controller/configuration/proc/Get(entry_type)
 	var/datum/config_entry/E = entry_type
-	var/entry_is_abstract = initial(E.abstract_type) == entry_type
+	var/entry_is_abstract = is_abstract(E)
 	if(entry_is_abstract)
 		CRASH("Tried to retrieve an abstract config_entry: [entry_type]")
 	E = entries_by_type[entry_type]
@@ -209,7 +209,7 @@
 
 /datum/controller/configuration/proc/Set(entry_type, new_val)
 	var/datum/config_entry/E = entry_type
-	var/entry_is_abstract = initial(E.abstract_type) == entry_type
+	var/entry_is_abstract = is_abstract(E)
 	if(entry_is_abstract)
 		CRASH("Tried to set an abstract config_entry: [entry_type]")
 	E = entries_by_type[entry_type]

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -24,9 +24,9 @@ SUBSYSTEM_DEF(assets)
 
 /datum/controller/subsystem/assets/Initialize(timeofday)
 	for(var/type in typesof(/datum/asset))
-		var/datum/asset/A = type
-		if (type != initial(A._abstract))
-			get_asset_datum(type)
+		if(is_abstract(type))
+			continue
+		get_asset_datum(type)
 
 	transport.Initialize(cache)
 

--- a/code/controllers/subsystem/processing/instruments.dm
+++ b/code/controllers/subsystem/processing/instruments.dm
@@ -34,9 +34,9 @@ PROCESSING_SUBSYSTEM_DEF(instruments)
 
 /datum/controller/subsystem/processing/instruments/proc/initialize_instrument_data()
 	for(var/path in subtypesof(/datum/instrument))
-		var/datum/instrument/I = path
-		if(initial(I.abstract_type) == path)
+		if(is_abstract(path))
 			continue
+		var/datum/instrument/I = path
 		I = new path
 		I.Initialize()
 		if(!I.id)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -51,6 +51,9 @@
 	*/
 	var/list/cooldowns
 
+	/// Meta property of a type. If this equals to .type it means the type is abstract, and should not be instantiated.
+	var/abstract_type
+
 #ifdef REFERENCE_TRACKING
 	var/running_find_references
 	var/last_find_references = 0
@@ -263,3 +266,7 @@
 		return
 	SEND_SIGNAL(source, COMSIG_CD_RESET(index), S_TIMER_COOLDOWN_TIMELEFT(source, index))
 	TIMER_COOLDOWN_END(source, index)
+
+/// Returns whether a type is an abstract type.
+/proc/is_abstract(datum/datum_type)
+	return (initial(datum_type.abstract_type) == datum_type)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -208,6 +208,12 @@
 /atom/proc/Initialize(mapload, ...)
 	SHOULD_NOT_SLEEP(TRUE)
 	SHOULD_CALL_PARENT(TRUE)
+
+	// This isn't on /datum level because datums don't have Initialize() and their New() doesn't enforce calling parent.
+	if(is_abstract(type))
+		stack_trace("Warning: [src]([type]) initialized as an abstract type!")
+		// Return an INITIALIZE_HINT_QDEL here? I think it's fine with just a warning.
+
 	if(flags_1 & INITIALIZED_1)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	flags_1 |= INITIALIZED_1

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -1,4 +1,5 @@
 /obj/structure/statue
+	abstract_type = /obj/structure/statue
 	name = "statue"
 	desc = "Placeholder. Yell at Firecage if you SOMEHOW see this."
 	icon = 'icons/obj/statue.dmi'
@@ -14,8 +15,6 @@
 	var/impressiveness = 15
 	/// Art component subtype added to this statue
 	var/art_type = /datum/element/art
-	/// Abstract root type
-	var/abstract_type = /obj/structure/statue
 
 /obj/structure/statue/Initialize()
 	. = ..()
@@ -533,8 +532,10 @@ Moving interrupts
 /obj/structure/carving_block/proc/build_statue_cost_table()
 	. = list()
 	for(var/statue_type in subtypesof(/obj/structure/statue) - /obj/structure/statue/custom)
+		if(is_abstract(statue_type))
+			continue
 		var/obj/structure/statue/S = new statue_type()
-		if(!S.icon_state || S.abstract_type == S.type || !S.custom_materials)
+		if(!S.icon_state || !S.custom_materials)
 			continue
 		.[S.type] = S.custom_materials
 		qdel(S)

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	return GLOB.asset_datums[type] || new type()
 
 /datum/asset
-	var/_abstract = /datum/asset
+	abstract_type = /datum/asset
 
 /datum/asset/New()
 	GLOB.asset_datums[type] = src
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 /// If you don't need anything complicated.
 /datum/asset/simple
-	_abstract = /datum/asset/simple
+	abstract_type = /datum/asset/simple
 	/// list of assets for this datum in the form of:
 	/// asset_filename = asset_file. At runtime the asset_file will be
 	/// converted into a asset_cache datum.
@@ -62,7 +62,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 // For registering or sending multiple others at once
 /datum/asset/group
-	_abstract = /datum/asset/group
+	abstract_type = /datum/asset/group
 	var/list/children
 
 /datum/asset/group/register()
@@ -90,7 +90,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 #define SPRSZ_STRIPPED 3
 
 /datum/asset/spritesheet
-	_abstract = /datum/asset/spritesheet
+	abstract_type = /datum/asset/spritesheet
 	var/name
 	var/list/sizes = list()    // "32x32" -> list(10, icon/normal, icon/stripped)
 	var/list/sprites = list()  // "foo_bar" -> list("32x32", 5)
@@ -249,7 +249,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 
 /datum/asset/changelog_item
-	_abstract = /datum/asset/changelog_item
+	abstract_type = /datum/asset/changelog_item
 	var/item_filename
 
 /datum/asset/changelog_item/New(date)
@@ -267,7 +267,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	. = list("[item_filename]" = SSassets.transport.get_asset_url(item_filename))
 
 /datum/asset/spritesheet/simple
-	_abstract = /datum/asset/spritesheet/simple
+	abstract_type = /datum/asset/spritesheet/simple
 	var/list/assets
 
 /datum/asset/spritesheet/simple/register()
@@ -277,7 +277,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 //Generates assets based on iconstates of a single icon
 /datum/asset/simple/icon_states
-	_abstract = /datum/asset/simple/icon_states
+	abstract_type = /datum/asset/simple/icon_states
 	var/icon
 	var/list/directions = list(SOUTH)
 	var/frame = 1
@@ -301,7 +301,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 			SSassets.transport.register_asset(asset_name, asset)
 
 /datum/asset/simple/icon_states/multiple_icons
-	_abstract = /datum/asset/simple/icon_states/multiple_icons
+	abstract_type = /datum/asset/simple/icon_states/multiple_icons
 	var/list/icons
 
 /datum/asset/simple/icon_states/multiple_icons/register()
@@ -314,7 +314,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 /// For example `blah.css` with asset `blah.png` will get loaded as `namespaces/a3d..14f/f12..d3c.css` and `namespaces/a3d..14f/blah.png`. allowing the css file to load `blah.png` by a relative url rather then compute the generated url with get_url_mappings().
 /// The namespace folder's name will change if any of the assets change. (excluding parent assets)
 /datum/asset/simple/namespaced
-	_abstract = /datum/asset/simple/namespaced
+	abstract_type = /datum/asset/simple/namespaced
 	/// parents - list of the parent asset or assets (in name = file assoicated format) for this namespace.
 	/// parent assets must be referenced by their generated url, but if an update changes a parent asset, it won't change the namespace's identity.
 	var/list/parents = list()

--- a/code/modules/explorer_drone/exploration_events/_exploration_event.dm
+++ b/code/modules/explorer_drone/exploration_events/_exploration_event.dm
@@ -1,7 +1,6 @@
 /// Exploration event
 /datum/exploration_event
-	/// These types will be ignored in event creation
-	var/root_abstract_type = /datum/exploration_event
+	abstract_type = /datum/exploration_event
 	///This name will show up in exploration list if it's repeatable
 	var/name = "Something interesting"
 	/// encountered at least once
@@ -40,7 +39,7 @@
 
 /// Simple events, not a full fledged adventure, consist only of single encounter screen
 /datum/exploration_event/simple
-	root_abstract_type = /datum/exploration_event/simple
+	abstract_type = /datum/exploration_event/simple
 	var/ui_image = "default"
 	/// Show ignore button.
 	var/skippable = TRUE

--- a/code/modules/explorer_drone/exploration_events/adventure.dm
+++ b/code/modules/explorer_drone/exploration_events/adventure.dm
@@ -2,7 +2,7 @@
 /datum/exploration_event/adventure
 	discovery_log = "Encountered something unexpected"
 	var/datum/adventure/adventure
-	root_abstract_type = /datum/exploration_event/adventure
+	abstract_type = /datum/exploration_event/adventure
 
 /datum/exploration_event/adventure/encounter(obj/item/exodrone/drone)
 	. = ..()

--- a/code/modules/explorer_drone/exploration_events/danger.dm
+++ b/code/modules/explorer_drone/exploration_events/danger.dm
@@ -1,6 +1,6 @@
 /// Danger event - unskippable, if you have appriopriate tool you can mitigate damage.
 /datum/exploration_event/simple/danger
-	root_abstract_type = /datum/exploration_event/simple/danger
+	abstract_type = /datum/exploration_event/simple/danger
 	description = "You encounter a giant error."
 	var/required_tool = EXODRONE_TOOL_LASER
 	var/has_tool_action_text = "Fight"

--- a/code/modules/explorer_drone/exploration_events/resource.dm
+++ b/code/modules/explorer_drone/exploration_events/resource.dm
@@ -1,7 +1,7 @@
 /// Simple event type that checks if you have a tool and after a retrieval delay adds loot to drone.
 /datum/exploration_event/simple/resource
 	name = "Retrievable resource"
-	root_abstract_type = /datum/exploration_event/simple/resource
+	abstract_type = /datum/exploration_event/simple/resource
 	discovery_log = "Encountered recoverable resource"
 	action_text = "Extract"
 	/// Tool type required to recover this resource

--- a/code/modules/explorer_drone/exploration_events/trader.dm
+++ b/code/modules/explorer_drone/exploration_events/trader.dm
@@ -1,6 +1,6 @@
 /// Trader events - If drone is loaded with X exchanges it for Y, might require translator tool.
 /datum/exploration_event/simple/trader
-	root_abstract_type = /datum/exploration_event/simple/trader
+	abstract_type = /datum/exploration_event/simple/trader
 	action_text = "Trade"
 	/// Obj path we'll take or list of paths ,one path will be picked from it at init
 	var/required_path

--- a/code/modules/explorer_drone/exploration_site.dm
+++ b/code/modules/explorer_drone/exploration_site.dm
@@ -119,9 +119,9 @@ GLOBAL_LIST_EMPTY(exploration_sites)
 /datum/exploration_site/proc/build_exploration_event_requirements_cache()
 	. = list()
 	for(var/event_type in subtypesof(/datum/exploration_event))
-		var/datum/exploration_event/event = event_type
-		if(initial(event.root_abstract_type) == event_type)
+		if(is_abstract(event_type))
 			continue
+		var/datum/exploration_event/event = event_type
 		event = new event_type
 		.[event_type] = list("required" = event.required_site_traits,"blacklisted" = event.blacklisted_site_traits)
 		//Should be no event refs,GC'd naturally

--- a/code/modules/instruments/instrument_data/_instrument_data.dm
+++ b/code/modules/instruments/instrument_data/_instrument_data.dm
@@ -17,14 +17,13 @@
  * Since songs cache them while playing, there isn't realistic issues regarding performance from accessing.
  */
 /datum/instrument
+	abstract_type = /datum/instrument
 	/// Name of the instrument
 	var/name = "Generic instrument"
 	/// Uniquely identifies this instrument so runtime changes are possible as opposed to paths. If this is unset, things will use path instead.
 	var/id
 	/// Category
 	var/category = "Unsorted"
-	/// Used for categorization subtypes
-	var/abstract_type = /datum/instrument
 	/// Write here however many samples, follow this syntax: "%note num%"='%sample file%' eg. "27"='synthesizer/e2.ogg'. Key must never be lower than 0 and higher than 127
 	var/list/real_samples
 	/// assoc list key = /datum/instrument_key. do not fill this yourself!

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -120,6 +120,8 @@
 	var/baseturf_count = length(spawn_at.baseturfs)
 
 	for(var/type_path in typesof(/atom/movable, /turf) - ignore) //No areas please
+		if(is_abstract(type_path))
+			continue
 		if(ispath(type_path, /turf))
 			spawn_at.ChangeTurf(type_path, /turf/baseturf_skipover)
 			//We change it back to prevent pain, please don't ask


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Instead of every single thing requiring an abstract type property it now is on /datum, and don't have to be re-implemented for everything.

Adds a simple proc `is_abstract(path)` which returns whether a datum path is abstract or not.

Converts current implementations to use this unified method.

Future implementations of checking abstractiveness can just use that property and the proc instead of re-implementing it over and over again.

Removes the goliath statues because they were a hack, even using an abstract type.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: It seems someone stole the lifelike Goliath statues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
