### PR TITLE
Changed mail to also be delivered on Sundays

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -52,8 +52,6 @@ SUBSYSTEM_DEF(economy)
 
 /datum/controller/subsystem/economy/Initialize(timeofday)
 	var/budget_to_hand_out = round(budget_pool / department_accounts.len)
-	if(time2text(world.timeofday, "DDD") == SUNDAY)
-		mail_blocked = TRUE
 	for(var/A in department_accounts)
 		new /datum/bank_account/department(A, budget_to_hand_out)
 	return ..()


### PR DESCRIPTION
## About The Pull Request
• Switches staffing at the mail sorting office to use avian carriers, specifically owls, as their functionality extends to Sunday.

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/53862927/173249247-48706685-06c8-476e-8e9b-d353500a4f41.png)
**Classic example of anti-Avian Carrier misinformation/propaganda. This is a false lie spread by deranged islanders.**

![image](https://user-images.githubusercontent.com/53862927/173249273-24cb60e2-591e-4ff0-9a45-b5e4e07924aa.png)
**Evidence of Avian Carrier operating with full functionality on a Sunday.**

## In all seriousness...
Not receiving mail on Sundays feels like a slap in the face to workers who don't have traditional weekends. It's just an arbitrary day of the week where you aren't allowed to have the fun of engaging with the mail feature.

Also, this stops players being forced to rely on bounties for money on Sundays. No mail? No paycheck delivery, no spending money.

## Changelog
:cl:
balance: Avians have been hired at the sorting office to ensure mail is now delivered every day of the week, including Sunday.
/:cl:
