### PR TITLE
Minor Kilo Station fixes

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1921,7 +1921,6 @@
 /area/maintenance/starboard)
 "agg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/closed/wall,
 /area/maintenance/starboard)
 "agh" = (
@@ -15521,7 +15520,7 @@
 "aXN" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -41499,12 +41498,11 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Freight Mining Airlock"
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
@@ -55569,6 +55567,7 @@
 	id = "freight_port";
 	name = "Freight Bay Control"
 	},
+/obj/machinery/light/small/broken/directional/south,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "jsI" = (
@@ -57878,6 +57877,7 @@
 	id = "emmd";
 	name = "Medical Lockdown Toggle"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/surgery)
 "kqL" = (
@@ -64565,6 +64565,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -65662,6 +65663,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "nKW" = (
@@ -74713,7 +74715,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/beer{
 	desc = "A station exclusive. Consumption may result in seizures, blindness, drunkenness, or even death.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko=30);
 	name = "Kilo-Kocktail";
 	pixel_x = 5;
 	pixel_y = 5
@@ -81581,7 +81583,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/server{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/engine/telecomms,
 /area/tcommsat/server)
 "uAo" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -85081,11 +85081,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4;
-	piping_layer = 1
-	},
 /obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "vXv" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a missing cable from Medbay Surgery
Removes a stray cable from the Freight Dock
Changes the layer of a tank connector to the correct one
Changes a freight dock airlock to be consistent with the one next to it
Changes the telecomms air alarm to the correct server prefab

## Why It's Good For The Game
Fixes good.

## Changelog
:cl:
fix: freight dock fixes and upkeep
fix: missing cable from medbay surgery
fix: changes tcomms air alarm to correct prefab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
