### PR TITLE
Fixes Storyteller pop scalling bug

### DIFF
--- a/code/controllers/subsystem/gamemode.dm
+++ b/code/controllers/subsystem/gamemode.dm
@@ -89,11 +89,11 @@ SUBSYSTEM_DEF(gamemode)
 
 	/// Associative list of active multipliers from pop scale penalty.
 	var/list/current_pop_scale_multipliers = list(
-		EVENT_TRACK_MUNDANE = 0,
-		EVENT_TRACK_MODERATE = 0,
-		EVENT_TRACK_MAJOR = 0,
-		EVENT_TRACK_ROLESET = 0,
-		EVENT_TRACK_OBJECTIVES = 0
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_MAJOR = 1,
+		EVENT_TRACK_ROLESET = 1,
+		EVENT_TRACK_OBJECTIVES = 1
 		)
 
 	/// Associative list of control events by their track category. Compiled in Init
@@ -179,6 +179,8 @@ SUBSYSTEM_DEF(gamemode)
 			message_admins("Scheduled Event: [sch_event.event] will run in [(sch_event.start_time - world.time) / 10] seconds. (<a href='?src=[REF(sch_event)];action=cancel'>CANCEL</a>) (<a href='?src=[REF(sch_event)];action=refund'>REFUND</a>)")
 
 	if(!halted_storyteller && next_storyteller_process <= world.time && storyteller)
+		// We update crew information here to adjust population scalling and event thresholds for the storyteller.
+		update_crew_infos()
 		next_storyteller_process = world.time + STORYTELLER_WAIT_TIME
 		storyteller.process(STORYTELLER_WAIT_TIME * 0.1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Storytellers didn't update the people counters and population scalling by default which lead to bugs, one most notable was that points were not generated over time unless an admin opened a storyteller panel, which updates its to display correct information on screen.

Also by default the population scalling multipliers are set to 1 instead of 0 so we dont run into those issues again just in case.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes Storytellers often not running any events.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
