### PR TITLE
Changes Techweb Program Access Requirement

### DIFF
--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -7,7 +7,7 @@
 	size = 16
 	tgui_id = "NtosTechweb"
 	program_icon = "atom"
-	transfer_access = ACCESS_RD
+	transfer_access = ACCESS_RESEARCH
 	/// Reference to global science techweb
 	var/datum/techweb/stored_research
 	/// Determines if the console is locked, and consequently if actions can be performed with it


### PR DESCRIPTION
## About The Pull Request
Changes the access requirement for the techwebs program from RD to Research, as to allow Research staff (scientists/roboticists/geneticists) to download such to modular computers.

## Why It's Good For The Game
Research staff already have access to the RnD console board round start, to allow them to do RnD in the absence of an RD, yet they do not have access to the program itself to download onto modular computers.

In the future, RnD will eventually be replaced with a better system, but it should still receive some balancing tweaks to make it less annoying to interface with.

A concern with doing such is that people might abuse this to hijack RnD's points, by researching random things, but is overall inconsequential with the duration of our rounds. (All of research can usually be completed by the 1hr30m mark, which is 37.5% of the minimum round time of 4hrs.)

## Changelog
:cl:
balance: changed techweb program clearance from RD to Research
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
