### PR TITLE
Fix: Can't cryo while buckled

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -307,8 +307,11 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		to_chat(user, SPAN_DANGER("You can't put [target] into [src]. They might wake up soon. Try again in [remaining_minutes] minutes."))
 		return
 
-	if(target == user && LAZYLEN(target.buckled_mobs) > 0)
-		to_chat(user, SPAN_DANGER("You can't fit into the cryopod while someone is buckled to you."))
+	if(LAZYLEN(target.buckled_mobs) > 0)
+		if(target == user)
+			to_chat(user, SPAN_DANGER("You can't fit into the cryopod while someone is buckled to you."))
+		else
+			to_chat(user, SPAN_DANGER("You can't fit [target] into the cryopod while someone is buckled to them."))
 		return
 
 	if(target == user)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -307,6 +307,10 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		to_chat(user, SPAN_DANGER("You can't put [target] into [src]. They might wake up soon. Try again in [remaining_minutes] minutes."))
 		return
 
+	if(target == user && LAZYLEN(target.buckled_mobs) > 0)
+		to_chat(user, SPAN_DANGER("You can't fit into the cryopod while someone is buckled to you."))
+		return
+
 	if(target == user)
 		if(target.mind.assigned_role.req_admin_notify)
 			tgui_alert(target, "You're an important role! [AHELP_FIRST_MESSAGE]")


### PR DESCRIPTION
## About The Pull Request

Stops an attempt at cryo'ing while someone's buckled to you. Thereby stopping the cryopod from permanently breaking and creating situations like 'cryogenic freezer (Deek-Za) (Deek-Za) (Deek-Za) (Deek-Za)' upon repeated attempts to enter the cryopod. 
Resolves #1129 

## Why It's Good For The Game

People can't accidently (or maliciously) break cryopods.
![image](https://user-images.githubusercontent.com/84706993/174223553-208dd909-dfd3-49a2-b2c4-7be00f04f4c0.png)


## Changelog
:cl:
fix: Can no longer attempt to cryo while someone is buckled to you.
/:cl:
