### PR TITLE
Icemoon Hermit Upkeep

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
@@ -16,6 +16,7 @@
 /area/icemoon/underground/explored)
 "ec" = (
 /obj/item/clothing/suit/hooded/wintercoat,
+/obj/structure/sink/directional/east,
 /turf/open/floor/wood,
 /area/ruin/powered/hermit)
 "ei" = (
@@ -24,10 +25,6 @@
 /area/ruin/powered/hermit)
 "gr" = (
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/hermit)
-"ha" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
 /area/ruin/powered/hermit)
 "hv" = (
 /obj/machinery/space_heater,
@@ -38,6 +35,7 @@
 /area/ruin/powered/hermit)
 "ii" = (
 /obj/effect/mob_spawn/human/hermit,
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/ruin/powered/hermit)
 "lH" = (
@@ -47,12 +45,9 @@
 "mN" = (
 /turf/closed/wall/mineral/wood,
 /area/ruin/powered/hermit)
-"oJ" = (
-/obj/structure/sink,
-/turf/open/floor/plating,
-/area/ruin/powered/hermit)
 "pI" = (
 /obj/item/chair/wood/wings,
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/ruin/powered/hermit)
 "sC" = (
@@ -65,8 +60,6 @@
 /area/ruin/powered/hermit)
 "sM" = (
 /obj/structure/chair/comfy/beige,
-/obj/machinery/light/directional/west,
-/obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/ruin/powered/hermit)
 "wH" = (
@@ -271,7 +264,7 @@ mN
 sM
 ec
 ii
-ha
+hN
 mN
 OU
 OU
@@ -303,7 +296,7 @@ ON
 gr
 Xh
 Si
-oJ
+cI
 hN
 hN
 pI

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
@@ -2,14 +2,14 @@
 "bz" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "bW" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "cI" = (
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "de" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -17,44 +17,44 @@
 "ec" = (
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "ei" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "gr" = (
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "ha" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "hv" = (
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "hN" = (
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "ii" = (
 /obj/effect/mob_spawn/human/hermit,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "lH" = (
 /obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "mN" = (
 /turf/closed/wall/mineral/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "oJ" = (
 /obj/structure/sink,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "pI" = (
 /obj/item/chair/wood/wings,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "sC" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -62,39 +62,39 @@
 /obj/item/ammo_box/a762,
 /obj/item/ammo_box/a762,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "sM" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/light/directional/west,
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "wH" = (
 /obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "EV" = (
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/firstaid/medical,
 /obj/item/storage/bag/ore,
 /obj/structure/table/wood,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "GU" = (
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "II" = (
 /obj/item/paper/guides/jobs/hydroponics,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "JI" = (
 /obj/structure/mineral_door/wood{
 	name = "Frozen Shack"
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "Oe" = (
 /obj/item/seeds/plump,
 /obj/item/seeds/plump,
@@ -103,12 +103,12 @@
 /obj/structure/table/wood,
 /obj/item/food/grown/mushroom/glowshroom,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "ON" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "OU" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
@@ -118,13 +118,13 @@
 "Si" = (
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "UL" = (
 /obj/item/pickaxe/improvised,
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/combat,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "Wb" = (
 /obj/structure/barricade/wooden/snowed,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -136,19 +136,19 @@
 "WK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "Xh" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "XI" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "Yi" = (
 /obj/item/shovel,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
 "YN" = (
 /turf/closed/mineral/snowmountain/icemoon,
 /area/icemoon/underground/explored)

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -20,4 +20,4 @@
 
 /area/ruin/powered/hermit
 	name = "Hermit Hovel"
-	icon_station = "dk_yellow"
+	icon_state = "dk_yellow"

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -17,3 +17,7 @@
 	base_icon_state = "block"
 	smoothing_flags = NONE
 	canSmoothWith = null
+
+/area/ruin/powered/hermit
+	name = "Hermit Hovel"
+	icon_station = "dk_yellow"


### PR DESCRIPTION
## About The Pull Request
Gives the hermit ruin its own unique area, instead of it running on the template area.
Reconfigures the amount of lights that are within the ruin.
Moves the sink and changes it to a directional prefab.

<details>

![image](https://user-images.githubusercontent.com/29272475/174651986-2f97d06f-0871-4fb8-9ce4-79b401b126a9.png)

</details>

## Why It's Good For The Game
Having in-use ruins on a template could cause issues further down the line, especially if someone changes the template.
Upkeep also good.

## Changelog
:cl:
add: adds a Hermit Ruin area
qol: moves elements to more sane positions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
