### PR TITLE
Limits Radstorms to Outside the Surface of Stations

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -21,6 +21,8 @@
 
 	immunity_type = RAD
 	multiply_blend_on_main_stage = TRUE
+	affects_underground = FALSE
+	protect_indoors = TRUE
 
 /datum/weather/rad_storm/telegraph()
 	..()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -4,7 +4,7 @@
 	max_occurrences = 1
 
 	track = EVENT_TRACK_MODERATE
-	tags = list(TAG_COMMUNAL, TAG_SPACE)
+	tags = list(TAG_COMMUNAL)
 
 /datum/round_event/radiation_storm
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -4,7 +4,7 @@
 	max_occurrences = 1
 
 	track = EVENT_TRACK_MODERATE
-	tags = list(TAG_COMMUNAL)
+	tags = list(TAG_COMMUNAL, TAG_SPACE)
 
 /datum/round_event/radiation_storm
 


### PR DESCRIPTION
## About The Pull Request
Limits the effects of radstorms to surface-level EVA outside of stations, at Avunia'a request, by restricting the event to only effect outdoors and ground level areas. 

## Why It's Good For The Game
This overall limits the effect of rad storms on station, as the event is in a weird place of being both ineffectual and annoying. It has problems of penetrating multiple z-levels, and needs some overall touchups to how it effects the crew. 

For now, it will be limited as an EVA hazard. 

## Changelog
:cl:
balance: restricts radiation storms to outside of stations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
