### PR TITLE
Removes Duplicate APC from the Rockdove

### DIFF
--- a/_maps/shuttles/common_rockdove.dmm
+++ b/_maps/shuttles/common_rockdove.dmm
@@ -308,7 +308,6 @@
 /obj/machinery/computer/shuttle/common_docks{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/pod,
 /area/shuttle/rockdove/helm)
 "GQ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes a duplicate APC from the Rockdove

## Why It's Good For The Game
fixing my bad mapping :(

## Changelog
:cl:
fix: removes a duplicate apc from the Rockdove
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
