### PR TITLE
Pubby Service QoL/Balance & Fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -393,14 +393,18 @@
 /area/security/prison/toilet)
 "aaX" = (
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/structure/sign/departments/botany{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aaY" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aaZ" = (
 /obj/machinery/door/poddoor/preopen{
@@ -6629,6 +6633,12 @@
 "aro" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "arp" = (
@@ -6656,6 +6666,7 @@
 /area/security/brig)
 "ars" = (
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "art" = (
@@ -15764,14 +15775,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"aPy" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/crew_quarters/bar)
 "aPz" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating{
@@ -16551,16 +16554,11 @@
 /turf/closed/wall,
 /area/service/kitchen)
 "aRO" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/service/kitchen)
 "aRP" = (
-/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -16754,7 +16752,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/machinery/hydroponics/constructable,
+/obj/structure/closet/wardrobe/botanist,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aSB" = (
@@ -16763,13 +16761,14 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aSC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/watertank,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aSD" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/item/watertank,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aSE" = (
@@ -16780,22 +16779,25 @@
 	c_tag = "Hydroponics Storage"
 	},
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/item/watertank,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aSF" = (
 /obj/machinery/chem_master/condimaster,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aSG" = (
 /obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 2;
+	pixel_y = -6
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aSH" = (
@@ -16809,20 +16811,28 @@
 /turf/open/floor/plating,
 /area/service/kitchen)
 "aSI" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -4
-	},
+/obj/structure/rack/shelf,
+/obj/item/reagent_containers/food/condiment/bbqsauce,
+/obj/item/food/spaghetti,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aSJ" = (
-/obj/machinery/gibber,
+/obj/machinery/light/small/directional/north,
+/obj/structure/rack/shelf,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/raw_patty,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aSK" = (
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aSL" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/icecream_vat,
+/turf/open/floor/iron/showroomfloor,
+/area/service/kitchen)
+"aSM" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
 	freq = 1400;
@@ -16845,19 +16855,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
-"aSM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/crew_quarters/bar)
 "aSN" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood{
@@ -17224,24 +17221,13 @@
 /area/service/hydroponics)
 "aTW" = (
 /obj/structure/table,
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/watertank,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aTX" = (
 /obj/structure/kitchenspike,
 /obj/item/assembly/mousetrap,
 /obj/item/food/deadmouse,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aTY" = (
@@ -17255,24 +17241,16 @@
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room"
 	},
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	pixel_y = 30
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aUa" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/item/crowbar,
-/obj/item/wrench,
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "aUb" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/tile/neutral{
@@ -17575,6 +17553,7 @@
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aUU" = (
@@ -17586,18 +17565,28 @@
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/closet/crate/hydroponics,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aUW" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aUX" = (
-/obj/machinery/icecream_vat,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
+/obj/structure/kitchenspike,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aUY" = (
@@ -17605,6 +17594,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aUZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
@@ -17612,17 +17604,17 @@
 /area/service/kitchen)
 "aVa" = (
 /obj/machinery/holopad,
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aVb" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 23
 	},
-/obj/structure/reagent_dispensers/cooking_oil,
+/obj/machinery/gibber,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aVc" = (
@@ -17639,12 +17631,13 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "aVd" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
 	req_access_txt = "25"
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aVf" = (
@@ -17662,9 +17655,6 @@
 /area/service/bar)
 "aVh" = (
 /obj/structure/table/glass,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/reagent_containers/food/drinks/bottle/patron{
 	pixel_x = -5;
 	pixel_y = 16
@@ -17684,6 +17674,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 22
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aVi" = (
@@ -17732,9 +17723,7 @@
 	pixel_x = 28;
 	req_access_txt = "25"
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aVk" = (
@@ -17749,9 +17738,6 @@
 /area/service/theater)
 "aVl" = (
 /obj/structure/dresser,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = 32
 	},
@@ -18036,7 +18022,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aVW" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aVX" = (
@@ -18045,6 +18031,7 @@
 	pixel_y = -23
 	},
 /obj/structure/cable,
+/obj/machinery/food_cart,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aVY" = (
@@ -18056,9 +18043,12 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "aVZ" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Walk-in Freezer";
+	req_access_txt = "28"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aWa" = (
@@ -18069,14 +18059,12 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "aWb" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aWd" = (
 /obj/structure/sink/kitchen{
-	pixel_y = 28
+	pixel_y = 20
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -18137,10 +18125,20 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aWm" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/iron/dark,
-/area/service/bar)
+/obj/effect/turf_decal/siding/white,
+/obj/structure/window,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/structure/rack/shelf,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/service/kitchen)
 "aWn" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -18196,12 +18194,6 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "aWq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -18216,6 +18208,8 @@
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/service/theater)
 "aWr" = (
@@ -18421,44 +18415,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
-"aWP" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"aWQ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "aWR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aWS" = (
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 21
 	},
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aWT" = (
 /obj/machinery/light_switch{
@@ -18466,25 +18435,42 @@
 	pixel_y = 38
 	},
 /obj/structure/sink/kitchen{
-	name = "utility sink";
-	pixel_y = 28
+	pixel_y = 20
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aWU" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/structure/rack/shelf,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/item/storage/bag/tray,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/kitchen/rollingpin,
+/obj/machinery/requests_console/directional/north,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
 /area/service/kitchen)
 "aWV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/mapping_helpers/smart_pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
 /area/service/kitchen)
 "aWW" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
 /area/service/kitchen)
 "aWX" = (
 /obj/structure/disposalpipe/segment{
@@ -18499,10 +18485,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aXb" = (
@@ -18515,10 +18501,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aXd" = (
@@ -18578,6 +18564,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/service/theater)
 "aXm" = (
@@ -18876,24 +18863,18 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aXR" = (
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -18901,10 +18882,10 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aXT" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/iron{
@@ -18919,92 +18900,59 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aXV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"aXX" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aXY" = (
 /obj/machinery/hydroponics/constructable,
-/obj/structure/sign/departments/botany{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"aXZ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aYa" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner,
+/turf/open/floor/iron/white/textured,
 /area/service/kitchen)
 "aYb" = (
-/obj/machinery/door/airlock{
-	name = "Bar Access";
-	req_access_txt = "28"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Service Access";
+	req_access_txt = "28"
+	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
 "aYd" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Service Access";
 	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aYe" = (
 /obj/structure/table/reinforced,
-/obj/item/kirbyplants{
-	icon_state = "plant-18";
-	pixel_y = 10
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 7
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -19058,10 +19006,6 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aYj" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Storage";
-	req_access_txt = "46"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19072,6 +19016,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Theatre Storage";
+	req_access_txt = "46"
 	},
 /turf/open/floor/iron/dark,
 /area/service/theater)
@@ -19124,6 +19073,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/theater)
 "aYp" = (
@@ -19284,28 +19234,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
-"aYN" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "aYO" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/green/corner,
+/obj/effect/turf_decal/siding/green/corner,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/green/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aYQ" = (
@@ -19313,31 +19255,33 @@
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aYR" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
 	},
+/obj/machinery/computer/chef_order,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aYS" = (
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aYT" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aYU" = (
-/obj/machinery/processor,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/directional/north,
+/obj/structure/sink/kitchen{
+	pixel_y = 20
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -19376,6 +19320,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aYZ" = (
@@ -19391,9 +19336,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19407,15 +19349,17 @@
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/mob/living/carbon/human/species/monkey/punpun,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 4
 	},
 /obj/structure/window/reinforced,
-/mob/living/carbon/human/species/monkey/punpun,
+/obj/machinery/light/directional/north{
+	light_color = "#c9d3e8"
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aZb" = (
@@ -19488,9 +19432,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19501,16 +19442,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/directional/north{
+	light_color = "#c9d3e8"
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aZg" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aZh" = (
@@ -19824,19 +19765,13 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aZS" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron{
@@ -19844,35 +19779,37 @@
 	},
 /area/service/hydroponics)
 "aZT" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aZU" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/iron,
 /area/service/hydroponics)
 "aZV" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/mapping_helpers/smart_pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold/supply/hidden/layer4{
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -19881,6 +19818,7 @@
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aZX" = (
@@ -19926,7 +19864,6 @@
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bae" = (
-/obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19937,6 +19874,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "bag" = (
@@ -20292,34 +20230,37 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "bba" = (
-/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bbb" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/seed_extractor,
+/turf/open/floor/iron,
 /area/service/hydroponics)
 "bbc" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/green{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bbd" = (
@@ -20327,35 +20268,43 @@
 	icon_state = "plant-10"
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"bbe" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"bbe" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "bbg" = (
-/obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bbh" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/white{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bbi" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bbl" = (
 /obj/structure/table/reinforced,
@@ -20372,11 +20321,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
-"bbm" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "bbo" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet,
@@ -20427,17 +20371,17 @@
 /turf/open/floor/plating,
 /area/service/bar)
 "bbv" = (
-/obj/structure/chair/stool,
 /obj/item/trash/can,
+/obj/structure/chair/stool/directional/south,
 /turf/open/floor/carpet,
 /area/service/bar)
 "bbw" = (
+/obj/structure/chair/stool/directional/south,
 /obj/effect/landmark/start/assistant,
-/obj/structure/chair/stool,
 /turf/open/floor/carpet,
 /area/service/bar)
 "bbx" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool/directional/south,
 /turf/open/floor/carpet,
 /area/service/bar)
 "bby" = (
@@ -20606,87 +20550,113 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "bbZ" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/turf/open/floor/iron,
 /area/service/hydroponics)
 "bca" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11;
+	pixel_y = -6
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bcb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/door/window/northleft{
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
 	},
-/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bcc" = (
 /obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
-"bcd" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright{
-	dir = 1;
+/obj/machinery/door/window/northright{
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
 	},
 /obj/item/food/monkeycube,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/service/hydroponics)
+"bcd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/biogenerator,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "HydroBiogenCoverShutters";
+	name = "Shutter"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	id = "jangarage";
+	name = "Biogenerator Shutter";
+	pixel_x = 22;
+	req_access_txt = "35"
+	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bce" = (
 /obj/structure/table,
 /obj/machinery/microwave{
-	pixel_x = -3;
+	pixel_x = 4;
 	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bcg" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bch" = (
 /obj/structure/table,
-/obj/item/storage/box/ingredients/wildcard,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bck" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "bcm" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "bco" = (
@@ -20975,21 +20945,32 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "bdj" = (
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/green/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bdk" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/green{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bdl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/green/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bdm" = (
@@ -21009,21 +20990,26 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bdp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bdq" = (
-/obj/structure/table,
-/obj/item/food/grown/tomato,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/machinery/griddle,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bdr" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 6
+/obj/effect/turf_decal/siding/white/end,
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bdv" = (
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
@@ -21211,11 +21197,11 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "bef" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -21224,14 +21210,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "beh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -21246,6 +21236,11 @@
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/landmark/start/botanist,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bej" = (
@@ -21257,6 +21252,13 @@
 	},
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -21394,7 +21396,7 @@
 	c_tag = "Bar Port";
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/directional/south{
 	light_color = "#c9d3e8"
 	},
 /turf/open/floor/iron/dark,
@@ -21424,14 +21426,14 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/light{
-	light_color = "#c9d3e8"
-	},
 /obj/machinery/button/door{
 	id = "barshutters";
 	name = "Bar Lockdown";
 	pixel_y = -28;
 	req_access_txt = "25"
+	},
+/obj/machinery/light/directional/south{
+	light_color = "#c9d3e8"
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -21443,14 +21445,14 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/light{
-	light_color = "#c9d3e8"
-	},
 /obj/machinery/button/door{
 	id = "barshutters";
 	name = "Bar Lockdown";
 	pixel_y = -28;
 	req_access_txt = "25"
+	},
+/obj/machinery/light/directional/south{
+	light_color = "#c9d3e8"
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -21500,7 +21502,7 @@
 	c_tag = "Bar Starboard";
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/directional/south{
 	light_color = "#c9d3e8"
 	},
 /turf/open/floor/iron/dark,
@@ -21685,38 +21687,14 @@
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/janitor)
-"bfj" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"bfk" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
-"bfl" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "bfm" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/iron,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bfn" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bfo" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold/supply/hidden/layer4{
@@ -21728,17 +21706,27 @@
 /turf/open/floor/carpet,
 /area/service/library/artgallery)
 "bfp" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/machinery/button/door{
+	dir = 4;
 	id = "kitchenwindowshutters";
 	name = "Kitchen Window Shutters Control";
 	pixel_x = -26;
-	pixel_y = 5;
+	pixel_y = 10;
 	req_access_txt = "28"
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = -8
+	},
+/obj/item/storage/box/ingredients/italian{
+	pixel_x = 8
+	},
+/obj/item/storage/box/ingredients/wildcard,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "bfr" = (
 /obj/structure/sign/barsign,
@@ -22106,15 +22094,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bgx" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
-	},
 /obj/structure/chair,
 /obj/item/clothing/mask/cigarette,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bgy" = (
@@ -31152,10 +31137,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bGJ" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/biogenerator,
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/turf_decal/siding/green,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bGK" = (
@@ -41227,9 +41210,6 @@
 /area/service/bar)
 "cpb" = (
 /obj/structure/table/glass,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/reagent_containers/food/drinks/bottle/goldschlager{
 	pixel_x = -8;
 	pixel_y = 15
@@ -41250,6 +41230,7 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "cpc" = (
@@ -41261,6 +41242,7 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "cpe" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Bar Access";
 	req_access_txt = "25"
@@ -41333,24 +41315,35 @@
 "cpm" = (
 /obj/structure/table,
 /obj/item/food/pie/cream,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpn" = (
 /obj/structure/table,
-/obj/item/food/spaghetti,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpo" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "cpq" = (
-/obj/machinery/deepfryer,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpr" = (
 /obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
@@ -41376,8 +41369,14 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "cpu" = (
-/obj/machinery/griddle,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/obj/item/sharpener,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -41422,27 +41421,45 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpy" = (
-/obj/machinery/food_cart,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpz" = (
-/obj/structure/rack,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpA" = (
-/obj/structure/rack,
-/obj/item/food/mint,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpB" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/service/kitchen)
 "cpC" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -46861,6 +46878,8 @@
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
 	},
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gcn" = (
@@ -48097,6 +48116,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"hAh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "hBd" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -48769,6 +48803,15 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"ilV" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "imB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
@@ -52520,6 +52563,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"ngR" = (
+/obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "nhH" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron,
@@ -54674,6 +54723,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"pwE" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "pwS" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -54746,6 +54804,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"pEu" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "pEv" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -54873,6 +54942,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pLT" = (
+/obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/landmark/start/cook,
+/obj/machinery/holopad,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "pMg" = (
 /obj/machinery/rnd/bepis,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -54994,16 +55069,10 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "pVr" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/displaycase/forsale/kitchen,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/requests_console/directional/north,
 /turf/open/floor/iron/dark,
-/area/service/bar)
+/area/service/hydroponics)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -55025,15 +55094,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"pWT" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "pXg" = (
 /obj/machinery/firealarm{
 	pixel_y = 27
@@ -55133,14 +55193,16 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "qaQ" = (
-/obj/item/pen{
-	layer = 4
+/obj/effect/turf_decal/siding/white,
+/obj/structure/window,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
 	},
-/obj/item/paper_bin{
-	layer = 2.9
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/service/bar)
+/area/service/kitchen)
 "qbp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -55847,6 +55909,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"rad" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "rax" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -56261,12 +56329,11 @@
 "rxV" = (
 /obj/structure/table,
 /obj/machinery/microwave{
-	pixel_x = -3;
+	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 23
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -57566,6 +57633,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"tjO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/machinery/processor,
+/turf/open/floor/iron/dark,
+/area/service/kitchen)
 "tkl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57804,6 +57878,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
+"tyx" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/service/kitchen)
 "tzM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57849,6 +57927,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"tBl" = (
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "tBP" = (
 /obj/effect/loot_site_spawner,
 /obj/structure/disposalpipe/segment{
@@ -57900,6 +57988,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"tFG" = (
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "tGy" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -59074,6 +59166,15 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"uXJ" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/botanist,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "uYF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -60435,6 +60536,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"wGB" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "wGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -61718,16 +61826,8 @@
 /area/medical/medbay/lobby)
 "ydZ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "yfd" = (
 /obj/effect/turf_decal/sand,
@@ -87087,7 +87187,7 @@ aOv
 aKJ
 kVO
 kVO
-aRL
+aLL
 aRL
 aUQ
 aVU
@@ -87605,15 +87705,15 @@ aSA
 aTQ
 aUS
 aRL
-aWP
+bfm
 aXQ
 ydZ
 aZR
-aYN
-aYN
+bfm
+bfm
 ydZ
 aXQ
-bfj
+bfm
 bdm
 bhd
 aDZ
@@ -87862,15 +87962,15 @@ aSB
 aTR
 aUT
 aRL
-aWQ
+bfm
 aXR
-aXS
+bba
 aZS
 bba
 aZS
-aXS
+bba
 bef
-bfk
+bfm
 bdm
 bhd
 aDZ
@@ -88112,22 +88212,22 @@ aKO
 aLC
 aNa
 aKP
-aPy
+aRP
 aQI
 aRL
 aSC
 aTS
 aUU
 aRL
-aWQ
-aXS
+pVr
+pwE
 aYO
 aZT
 aZT
 aZT
 bdj
 beg
-bfl
+bfm
 bdm
 bhd
 aDZ
@@ -88384,7 +88484,7 @@ bbb
 bbZ
 bdk
 beh
-bfl
+bfm
 bdm
 bhd
 aDZ
@@ -88892,11 +88992,11 @@ aXS
 aRL
 aWT
 aXV
-aXS
+rad
 aZW
-aXS
+tFG
 bca
-aXS
+wGB
 bej
 bfn
 bdm
@@ -89149,7 +89249,7 @@ aUW
 aRL
 aaX
 aaY
-aXS
+ilV
 aZX
 bbd
 aRL
@@ -89405,10 +89505,10 @@ aRN
 aRN
 aRN
 aRN
-aXX
+bfm
+pwE
 aXS
-aXS
-pWT
+uXJ
 bcb
 bdn
 bel
@@ -89656,16 +89756,16 @@ aKQ
 aKQ
 aLL
 aQN
-aRN
+tyx
 aRN
 aTX
 aUX
 aVW
 aRN
 aXY
+pwE
 aXS
-aXS
-pWT
+uXJ
 bcc
 aDZ
 bem
@@ -89919,9 +90019,9 @@ aTY
 aUY
 aVX
 aRN
-aXZ
+bfm
 aYQ
-aXS
+wGB
 bbe
 bcd
 bdo
@@ -90174,7 +90274,7 @@ aRN
 aRN
 aTZ
 aSK
-aSK
+aRN
 aRN
 aRN
 bgk
@@ -90431,12 +90531,12 @@ aRN
 aSI
 aSK
 aUZ
-aSK
-aWU
 aRN
+aWU
+aWm
 aYR
 aYS
-aYS
+tjO
 cpq
 cpu
 cpw
@@ -90688,13 +90788,13 @@ aRN
 aSJ
 aSK
 aVa
-aSK
+aVZ
 aWV
 aYa
-ars
+tBl
 ars
 bbg
-cpr
+ngR
 cpr
 beq
 cpy
@@ -90942,12 +91042,12 @@ aKT
 aPD
 aQQ
 aRN
+aSL
 aSK
-aUa
 aVb
-aVZ
-aWW
 aRN
+aWW
+qaQ
 bce
 aYS
 cpm
@@ -91199,8 +91299,8 @@ aOx
 aNj
 aQR
 aRN
-aSL
 aRN
+aSM
 aRN
 aRN
 aRN
@@ -91456,7 +91556,7 @@ aOy
 aLL
 aLL
 aRP
-aSM
+aLL
 aUb
 aVc
 aWb
@@ -91465,7 +91565,7 @@ aYb
 aYV
 cpl
 cps
-cps
+pLT
 cps
 bep
 cpB
@@ -91972,7 +92072,7 @@ aQS
 aRQ
 aSN
 aPE
-qaQ
+aPE
 aWd
 aXb
 aRN
@@ -92492,8 +92592,8 @@ aXb
 aPE
 aYY
 bae
-bbm
-bae
+bcm
+hAh
 bcm
 bae
 cpC
@@ -94288,7 +94388,7 @@ aPE
 aVi
 bah
 aXh
-aYg
+pEu
 aZd
 beB
 bbq
@@ -94545,7 +94645,7 @@ aPE
 cpb
 bah
 bah
-pVr
+aYg
 cpi
 bag
 bbr
@@ -95057,7 +95157,7 @@ aKY
 aQN
 aPE
 aVj
-aWm
+aUa
 bck
 aYi
 cpk

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16578,7 +16578,6 @@
 	dir = 8
 	},
 /obj/item/clothing/under/rank/civilian/janitor/maid,
-/obj/structure/cable,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -16856,17 +16855,19 @@
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
 "aSN" = (
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
 /area/service/bar)
 "aSO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
 "aSP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
 "aSQ" = (
@@ -16877,6 +16878,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/rack/shelf,
 /turf/open/floor/wood,
 /area/service/bar)
 "aSR" = (
@@ -17247,9 +17249,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aUa" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
 /area/service/bar)
 "aUb" = (
 /obj/structure/plasticflaps/opaque,
@@ -17266,8 +17268,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aUd" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/service/bar)
 "aUe" = (
@@ -18069,25 +18070,21 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "aWe" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/camera{
+	c_tag = "Bar Access"
 	},
-/turf/open/floor/iron/dark,
-/area/service/bar)
-"aWf" = (
 /obj/machinery/requests_console{
 	department = "Bar";
 	departmentType = 2;
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Bar Access"
-	},
+/turf/open/floor/iron/dark,
+/area/service/bar)
+"aWf" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -45917,6 +45914,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/science/circuits)
+"eXJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "eYr" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -47941,6 +47947,21 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd/dorm)
+"hnq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "hnu" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -48116,21 +48137,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"hAh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "hBd" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -48803,15 +48809,6 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"ilV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "imB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
@@ -54697,6 +54694,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"pvc" = (
+/obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
+/obj/effect/landmark/start/cook,
+/obj/machinery/holopad,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "pvK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -54723,15 +54726,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"pwE" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "pwS" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -54892,6 +54886,15 @@
 "pIh" = (
 /turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
+"pIn" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "pIv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/table,
@@ -54942,12 +54945,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pLT" = (
-/obj/effect/mapping_helpers/smart_pipe/simple/supply/hidden/layer4,
-/obj/effect/landmark/start/cook,
-/obj/machinery/holopad,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "pMg" = (
 /obj/machinery/rnd/bepis,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -55069,10 +55066,10 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "pVr" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/requests_console/directional/north,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/service/hydroponics)
+/area/service/bar)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -55909,12 +55906,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"rad" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "rax" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -56011,6 +56002,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"riB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "riF" = (
 /obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral{
@@ -56584,6 +56581,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"rNy" = (
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "rNB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -57988,10 +57989,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
-"tFG" = (
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "tGy" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -58125,12 +58122,24 @@
 	},
 /turf/closed/wall,
 /area/engineering/main)
+"tPx" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "tQj" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"tQt" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/requests_console/directional/north,
+/turf/open/floor/iron/dark,
+/area/service/hydroponics)
 "tQu" = (
 /obj/machinery/atmospherics/components/binary/heat_pump/heater/on{
 	dir = 8;
@@ -60536,13 +60545,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"wGB" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "wGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -88219,8 +88221,8 @@ aSC
 aTS
 aUU
 aRL
-pVr
-pwE
+tQt
+pIn
 aYO
 aZT
 aZT
@@ -88992,11 +88994,11 @@ aXS
 aRL
 aWT
 aXV
-rad
+riB
 aZW
-tFG
+rNy
 bca
-wGB
+tPx
 bej
 bfn
 bdm
@@ -89249,7 +89251,7 @@ aUW
 aRL
 aaX
 aaY
-ilV
+eXJ
 aZX
 bbd
 aRL
@@ -89506,7 +89508,7 @@ aRN
 aRN
 aRN
 bfm
-pwE
+pIn
 aXS
 uXJ
 bcb
@@ -89763,7 +89765,7 @@ aUX
 aVW
 aRN
 aXY
-pwE
+pIn
 aXS
 uXJ
 bcc
@@ -90021,7 +90023,7 @@ aVX
 aRN
 bfm
 aYQ
-wGB
+tPx
 bbe
 bcd
 bdo
@@ -91565,7 +91567,7 @@ aYb
 aYV
 cpl
 cps
-pLT
+pvc
 cps
 bep
 cpB
@@ -92329,7 +92331,7 @@ aQT
 aRR
 aSO
 aUd
-aVd
+aPE
 aWe
 aXb
 aRN
@@ -92585,15 +92587,15 @@ aPE
 aQU
 aRS
 aSP
-aSP
-aPE
+aUa
+aVd
 aWf
 aXb
 aPE
 aYY
 bae
 bcm
-hAh
+hnq
 bcm
 bae
 cpC
@@ -95157,7 +95159,7 @@ aKY
 aQN
 aPE
 aVj
-aUa
+pVr
 bck
 aYi
 cpk

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20278,6 +20278,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/botanist,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bbg" = (
@@ -20590,25 +20592,7 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bcc" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northright{
-	name = "Hydroponics Desk";
-	req_access_txt = "35"
-	},
-/obj/item/food/monkeycube,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
-"bcd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/biogenerator,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "HydroBiogenCoverShutters";
-	name = "Shutter"
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/button/door{
 	dir = 8;
 	id = "jangarage";
@@ -20616,6 +20600,16 @@
 	pixel_x = 22;
 	req_access_txt = "35"
 	},
+/turf/open/floor/iron/dark,
+/area/service/hydroponics)
+"bcd" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northright{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
+/obj/item/food/monkeycube,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bce" = (
@@ -46880,12 +46874,16 @@
 	name = "kitchen shutters"
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/machinery/door/window/westleft{
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
 	},
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
+/obj/machinery/door/window/eastright{
+	name = "Kitchen Desk";
+	req_access_txt = "28"
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gcn" = (
@@ -55523,6 +55521,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space)
+"qvl" = (
+/obj/machinery/biogenerator,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "HydroBiogenCoverShutters";
+	name = "Shutter"
+	},
+/turf/open/floor/plating,
+/area/service/kitchen)
 "qvx" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -58734,6 +58740,13 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"uvd" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/service/hydroponics)
 "uvo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -89767,8 +89780,8 @@ aRN
 aXY
 pIn
 aXS
-uXJ
-bcc
+uvd
+bdm
 aDZ
 bem
 bih
@@ -90021,7 +90034,7 @@ aTY
 aUY
 aVX
 aRN
-bfm
+bcc
 aYQ
 tPx
 bbe
@@ -90279,7 +90292,7 @@ aSK
 aRN
 aRN
 aRN
-bgk
+qvl
 gam
 aZZ
 aRN


### PR DESCRIPTION
## About The Pull Request
• Adjusted wallmounts in the service area only, there were things like missing firelocks, missing fire alarms and poor intercom coverage.
• Missing produce console added to kitchen.
• Refridgerators in kitchen coldroom moved into the kitchen itself. It's like having a freezer within a freezer.
• As Pubby is a lowpop map, a few more food items have been placed in the kitchen, mostly as decoration.
• Kitchen now has a mini-stockroom, most of the table-clutter has been moved there to give chefs a clean space to work roundstart without having to find a place to chuck everything.
• Kitchen re-organised heavily to have high-use machinery more front and centre. A notable example is the Condimaster, which is out of the coldroom and in the kitchen itself.
• Condimaster given to the bar.
• Botany has an extra sink to combat the evils of walking.
• Botany has their biogenerator moved so kitchen staff can access it.
• Third botanist spawn and locker added.

## Why It's Good For The Game
These changes should make botany and kitchen a little prettier, and more fun to work in.

## Media
![image](https://user-images.githubusercontent.com/53862927/175031966-c887876f-31b4-484e-9b51-60d8b9d29290.png)

## Changelog
:cl:
qol: Pubby kitchen re-organised to be less frustrating to work in.
qol: Pubby botany has their biogenerator moved between the kitchen and botany.
balance: Pubby kitchen has a few more roundstart food items.
balance: Pubby bartender has their own condimaster for drink mixing.
fix: Missing wallmounts and firelocks for Pubby service.
/:cl:

Closes #1170 