### PR TITLE
Kilo Station Research Update

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -187,6 +187,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "aaM" = (
@@ -996,6 +997,7 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "ads" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "adt" = (
@@ -1789,6 +1791,7 @@
 	pixel_x = -24;
 	req_access_txt = "55"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afG" = (
@@ -2358,19 +2361,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ahm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
 	},
-/area/maintenance/starboard)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "ahn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -2693,6 +2695,7 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "aik" = (
@@ -3009,18 +3012,19 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ajk" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/loading_area/red,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "ajl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno3";
@@ -3567,6 +3571,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "akC" = (
@@ -4489,6 +4494,7 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/orange,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "amK" = (
@@ -4586,6 +4592,7 @@
 	pixel_x = 24;
 	req_access_txt = "55"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "anc" = (
@@ -4634,6 +4641,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -5461,6 +5469,12 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"apw" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/cytology)
 "apx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5605,16 +5619,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "apS" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "apT" = (
@@ -7104,9 +7115,6 @@
 "auk" = (
 /obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -7935,8 +7943,19 @@
 	},
 /area/maintenance/starboard)
 "awB" = (
-/turf/closed/wall,
-/area/science/cytology)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "awG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -8249,19 +8268,9 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "axR" = (
-/obj/effect/turf_decal/loading_area/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "aya" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -8375,11 +8384,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ayp" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
-/obj/structure/railing,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/science/research)
 "ayq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -8414,15 +8427,16 @@
 "ayw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
+	dir = 4
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard)
 "ayy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8681,28 +8695,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "azt" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = 9
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Lab";
+	req_access_txt = "29"
 	},
 /turf/open/floor/iron/dark,
-/area/science/circuits)
+/area/science/robotics/lab)
 "azv" = (
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -8759,6 +8757,7 @@
 	name = "rd sorting disposal pipe";
 	sortType = 13
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
@@ -9736,6 +9735,20 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
+"aDK" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "aDM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -10342,20 +10355,14 @@
 /turf/open/floor/engine/telecomms,
 /area/tcommsat/server)
 "aFY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/obj/machinery/duct,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "aGb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -12318,6 +12325,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "aOt" = (
@@ -12334,6 +12342,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "aOv" = (
@@ -12365,6 +12374,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "aOx" = (
@@ -12978,12 +12988,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"aPQ" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/cytology)
 "aPR" = (
 /obj/item/storage/firstaid/regular{
 	pixel_x = 3;
@@ -13814,6 +13818,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "aRE" = (
@@ -15912,6 +15917,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aXJ" = (
@@ -16571,6 +16577,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "aZn" = (
@@ -16735,6 +16742,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aZH" = (
@@ -16978,6 +16986,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "bae" = (
@@ -17036,6 +17045,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "baj" = (
@@ -17047,6 +17057,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bal" = (
@@ -17150,6 +17161,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "bay" = (
@@ -17170,6 +17182,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "baA" = (
@@ -17192,6 +17205,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "baD" = (
@@ -17366,6 +17380,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "bbb" = (
@@ -17659,6 +17674,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "bbP" = (
@@ -17674,8 +17690,9 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "bbQ" = (
-/turf/closed/wall/r_wall/rust,
-/area/science/cytology)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "bbR" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -17781,6 +17798,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "bca" = (
@@ -17938,7 +17956,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -18135,6 +18152,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bde" = (
@@ -18305,6 +18323,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "bdG" = (
@@ -18553,6 +18572,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "bef" = (
@@ -18563,6 +18583,7 @@
 /obj/effect/turf_decal/siding/purple/end{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "beg" = (
@@ -18577,6 +18598,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "bei" = (
@@ -18631,6 +18653,7 @@
 /obj/structure/sign/warning/explosives/alt{
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "bem" = (
@@ -18652,6 +18675,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "beo" = (
@@ -18847,6 +18871,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "beK" = (
@@ -18937,6 +18962,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "beT" = (
@@ -18951,6 +18977,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "beV" = (
@@ -19062,6 +19089,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/science/cytology)
 "bft" = (
@@ -19382,16 +19410,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "bgo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno2";
+	name = "Creature Cell 2"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/cytology)
 "bgq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19497,9 +19523,16 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "bgA" = (
-/obj/machinery/duct,
-/turf/closed/wall,
-/area/commons/toilet/restrooms)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "bgB" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -19925,6 +19958,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bhC" = (
@@ -19935,6 +19969,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bhE" = (
@@ -20452,6 +20487,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "blb" = (
@@ -21033,16 +21069,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/central)
-"boV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/science/research)
 "boX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -22229,6 +22255,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/scientist,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "bwe" = (
@@ -30979,6 +31006,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "cbn" = (
@@ -36903,6 +36931,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cuH" = (
@@ -38870,10 +38899,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"cCx" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "cCB" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -39998,6 +40023,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "cHH" = (
@@ -41598,6 +41624,16 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/port/fore)
+"cWB" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "cWK" = (
 /turf/closed/wall,
 /area/commons/storage/primary)
@@ -42839,6 +42875,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "dyi" = (
@@ -43316,13 +43353,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"dJA" = (
-/obj/effect/turf_decal/box/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "dJB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -43414,13 +43444,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
-"dLT" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Robotics Lab";
-	req_access_txt = "29"
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "dMh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -43562,6 +43585,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "dPy" = (
@@ -44289,6 +44313,15 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"eht" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "ehz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery,
@@ -45203,6 +45236,7 @@
 /obj/effect/turf_decal/siding/purple/end{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "ezG" = (
@@ -45467,6 +45501,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"eEx" = (
+/obj/effect/turf_decal/box/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "eEU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46134,6 +46178,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
+"ePz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "ePG" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -46434,6 +46484,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "eUX" = (
@@ -46514,6 +46565,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "eWc" = (
@@ -46561,6 +46613,19 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
+"eWQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "eWZ" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/grassybush,
@@ -46733,10 +46798,10 @@
 /area/science/storage)
 "faC" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/circuits)
@@ -46883,6 +46948,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
+"ffK" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
+/obj/structure/railing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ffM" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -46936,19 +47007,8 @@
 	},
 /area/engineering/supermatter/room)
 "fga" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/turf/closed/wall,
+/area/science/cytology)
 "fgq" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -47595,6 +47655,7 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "fvI" = (
@@ -47670,15 +47731,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"fwE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/circuits)
 "fxf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47970,6 +48022,21 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/cargo/qm)
+"fCq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "fCx" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -48271,13 +48338,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"fHC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "fHP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -48916,6 +48976,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/warden)
+"fVj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "fVk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -49397,6 +49467,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "ggR" = (
@@ -50230,6 +50301,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"gAo" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/research)
 "gAE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -51307,6 +51389,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "haI" = (
@@ -52206,6 +52289,7 @@
 	},
 /obj/effect/landmark/start/scientist,
 /obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "hvG" = (
@@ -52336,6 +52420,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/circuits)
 "hyP" = (
@@ -53425,6 +53510,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"iap" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "iav" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -53798,6 +53898,34 @@
 /obj/structure/cable,
 /turf/open/floor/plating/rust,
 /area/security/prison)
+"iht" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/command/heads_quarters/rd)
 "ihC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/exodrone_launcher,
@@ -54650,17 +54778,11 @@
 /turf/open/floor/grass,
 /area/service/chapel/main)
 "iAU" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "iBe" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -55370,7 +55492,7 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "iQE" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall/r_wall/rust,
 /area/science/cytology)
 "iQO" = (
 /obj/effect/turf_decal/tile/brown,
@@ -56519,6 +56641,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"jpZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/research)
 "jqk" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -57758,6 +57894,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
+"jSg" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jSw" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -59123,6 +59269,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"ktF" = (
+/turf/closed/wall/rust,
+/area/science/cytology)
 "kuu" = (
 /obj/structure/frame/computer{
 	anchored = 1;
@@ -59920,34 +60069,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"kHA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/command/heads_quarters/rd)
 "kHH" = (
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced/tinted,
@@ -59990,6 +60111,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
+"kIb" = (
+/obj/effect/turf_decal/box/corners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/science/cytology)
 "kIo" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -61782,6 +61908,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/xmastree/rdrod,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "lvo" = (
@@ -61909,6 +62036,7 @@
 	pixel_y = 12
 	},
 /obj/item/food/candy_trash,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "lxO" = (
@@ -62070,6 +62198,7 @@
 	dir = 4
 	},
 /obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/science/cytology)
 "lBX" = (
@@ -63187,9 +63316,8 @@
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
 "lYV" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/closed/wall/r_wall,
-/area/science/storage)
+/turf/open/floor/engine,
+/area/science/cytology)
 "lYX" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -63755,6 +63883,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"mmY" = (
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/commons/toilet/restrooms)
 "mnt" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -65528,6 +65660,21 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/storage/tech)
+"mWS" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "mXn" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -65730,21 +65877,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
-"ndp" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/science/research)
 "neo" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -66072,13 +66204,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore)
-"nnW" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "nok" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -66739,16 +66864,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/security/prison)
-"nFm" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "nFo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -67219,12 +67334,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"nOR" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "nPa" = (
 /obj/structure/chair{
 	dir = 1
@@ -67366,16 +67475,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/storage/tech)
-"nRp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard)
 "nRr" = (
 /obj/machinery/power/solar{
 	id = "aftstarboard";
@@ -70871,12 +70970,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/warden)
-"pnj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/circuits)
 "pnQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
@@ -72824,16 +72917,6 @@
 /obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"qcf" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qcg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -73090,6 +73173,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"qjn" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qjw" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/turf_decal/tile/neutral{
@@ -73363,6 +73453,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
+"qqA" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/science/cytology)
 "qre" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -73766,6 +73863,7 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/science/cytology)
 "qyL" = (
@@ -74774,16 +74872,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
-"qUj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "qUp" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -76023,6 +76111,13 @@
 	dir = 4
 	},
 /area/service/chapel/main)
+"rwV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rxO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -76053,12 +76148,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"ryq" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/cytology)
 "ryU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -76882,6 +76971,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
+"rRD" = (
+/obj/machinery/dna_scannernew,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "rSi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -79309,6 +79403,29 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/service/bar/atrium)
+"sWC" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "sWJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -79841,6 +79958,7 @@
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "tlV" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "tmi" = (
@@ -80081,14 +80199,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison)
 "tpF" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
+/obj/structure/railing/corner,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tpP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -80625,6 +80740,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/construction/mining/aux_base)
+"tAV" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tBb" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/visible{
@@ -80993,15 +81118,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"tHz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno2";
-	name = "Creature Cell 2"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/science/cytology)
 "tHI" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/carpspawn,
@@ -81802,6 +81918,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "tWd" = (
@@ -82243,11 +82360,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
-"ufp" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron/dark,
-/area/science/genetics)
 "ufq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -83120,6 +83232,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/science/cytology)
 "uwx" = (
@@ -83471,16 +83584,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uFr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/research)
 "uFB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -83626,12 +83729,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"uHw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/circuits)
 "uHJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83881,16 +83978,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
-"uMS" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "uNl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -83974,9 +84061,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
-"uPl" = (
-/turf/closed/wall/rust,
-/area/science/cytology)
 "uPn" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -84807,11 +84891,9 @@
 	},
 /area/maintenance/starboard)
 "vgy" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
-/obj/structure/railing/corner,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "vgz" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -84859,6 +84941,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/engineering/supermatter/room)
+"vhD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "vhR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -85447,6 +85535,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "vsF" = (
@@ -85863,7 +85952,7 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "vBV" = (
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/science/cytology)
 "vCb" = (
 /obj/effect/turf_decal/tile/red,
@@ -86273,6 +86362,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "vKw" = (
@@ -88064,6 +88154,14 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/surgery/room_b)
+"wAl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "wAy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -88941,21 +89039,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"wTF" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
 "wTT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -89052,13 +89135,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"wVc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "wVh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -91220,6 +91296,18 @@
 /obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/paramedic)
+"xLe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "xLk" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen/empty,
@@ -91402,10 +91490,6 @@
 "xOP" = (
 /turf/closed/wall/rust,
 /area/science/test_area)
-"xPa" = (
-/obj/effect/turf_decal/box/corners,
-/turf/open/floor/engine,
-/area/science/cytology)
 "xPl" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
@@ -91779,6 +91863,10 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xXR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/science/cytology)
 "xXS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -111569,8 +111657,8 @@ dyu
 bKl
 add
 lSH
-bgA
-bgA
+mmY
+mmY
 ikp
 fJK
 uMr
@@ -127735,9 +127823,9 @@ eEW
 amm
 aRR
 aBX
-wVc
+wAl
 bdd
-dLT
+azt
 aJK
 aLV
 cgR
@@ -127965,11 +128053,11 @@ aUz
 aeU
 aeU
 aeU
+vBV
+vBV
+vBV
 iQE
-iQE
-iQE
-bbQ
-iQE
+vBV
 dIg
 gbf
 agv
@@ -127989,8 +128077,8 @@ aZS
 aZS
 aZS
 axK
-axR
-auk
+ajk
+eEx
 aCa
 aZU
 bgB
@@ -128222,14 +128310,14 @@ aeU
 aeU
 aeU
 aeu
-bbQ
-aPQ
+iQE
+qqA
 qyy
 bfs
-iQE
+vBV
 cId
 cIh
-iQE
+vBV
 alB
 bwe
 alB
@@ -128246,8 +128334,8 @@ aEG
 enM
 kHH
 vzX
+eWQ
 apS
-qUj
 aCK
 aEP
 aVd
@@ -128479,14 +128567,14 @@ aeu
 alB
 alB
 alB
-iQE
 vBV
+lYV
 lBJ
-vBV
-tHz
+xXR
+bgo
 cIe
 hJx
-iQE
+vBV
 bbx
 agQ
 kvc
@@ -128503,7 +128591,7 @@ kAC
 aOT
 xrO
 aXt
-apS
+eWQ
 aBe
 aCe
 aHM
@@ -128736,17 +128824,17 @@ alB
 alB
 aWJ
 bhz
-iQE
-ryq
+vBV
+apw
 uwd
-xPa
-tHz
+kIb
+bgo
 bhv
 gFD
-tHz
+bgo
 aWJ
 bhn
-nOR
+iAU
 lHK
 dcM
 cbg
@@ -128761,7 +128849,7 @@ vqD
 atq
 aXe
 aqU
-dJA
+auk
 aDs
 aHP
 aKM
@@ -128993,17 +129081,17 @@ alB
 aWJ
 ayv
 aWJ
-iQE
+vBV
 aeX
 aOS
 xnT
-uPl
+ktF
 bbk
 acB
-tHz
+bgo
 bfq
 lrl
-tpF
+aFY
 aWJ
 jXM
 hNX
@@ -129254,10 +129342,10 @@ mfS
 aXa
 afk
 tTB
-awB
+fga
 beY
 adx
-awB
+fga
 agM
 aha
 noH
@@ -129767,7 +129855,7 @@ aWJ
 aXX
 bgx
 afo
-bfP
+bbQ
 lpH
 bfh
 bgt
@@ -130046,7 +130134,7 @@ auG
 aws
 axL
 azL
-ndp
+iap
 aCh
 aMN
 aDc
@@ -130280,18 +130368,18 @@ aWJ
 aWJ
 aXX
 bfK
-afo
+aDK
 bfP
 eSg
-bgo
+bgA
 wyq
 rps
 abK
-ajk
-bgo
+ahm
+bgA
 bgO
 bgT
-ajk
+ahm
 cHF
 aeQ
 ads
@@ -130307,7 +130395,7 @@ vKn
 vse
 aXE
 aXI
-uFr
+gAo
 beE
 bbj
 aOi
@@ -130563,8 +130651,8 @@ vkX
 rJG
 rJG
 kzj
-aYS
-aYS
+jpZ
+jpZ
 aZt
 wiA
 aOi
@@ -130823,7 +130911,7 @@ vlS
 aYN
 aYT
 dci
-boV
+ayp
 aOo
 bgj
 aYe
@@ -131065,7 +131153,7 @@ xva
 sbu
 aOF
 alB
-bcu
+fCq
 aps
 ajO
 baL
@@ -131316,7 +131404,7 @@ akt
 agM
 aWJ
 bhn
-nOR
+iAU
 lHK
 dcM
 cbg
@@ -131331,7 +131419,7 @@ bcx
 aWU
 iOj
 hea
-kHA
+iht
 cYO
 tWx
 vlS
@@ -131347,8 +131435,8 @@ bdZ
 hYj
 bbb
 bdz
-ahm
-fga
+bcu
+awB
 jMR
 oHM
 leq
@@ -131573,13 +131661,13 @@ odA
 alB
 bfq
 oFk
-tpF
+aFY
 aWJ
 lrl
 uaH
 cqw
 alB
-aFY
+anf
 bkd
 cNa
 aZF
@@ -132093,7 +132181,7 @@ cMw
 cLK
 cbk
 cMC
-aFY
+anf
 cLt
 cNd
 aZF
@@ -132357,7 +132445,7 @@ arJ
 okx
 auV
 cLt
-fHC
+rwV
 iOj
 iOj
 rJG
@@ -132370,7 +132458,7 @@ akB
 bbY
 bcs
 bxn
-faC
+eht
 bef
 beJ
 cLp
@@ -132626,8 +132714,8 @@ bbm
 aZZ
 bdF
 bcs
-azt
-faC
+sWC
+eht
 beg
 beS
 tJs
@@ -132884,7 +132972,7 @@ aOs
 aRD
 aSK
 aUY
-uHw
+ePz
 bee
 baz
 xqf
@@ -133398,7 +133486,7 @@ aOw
 bbW
 aSK
 aiY
-pnj
+vhD
 beq
 jZo
 xAA
@@ -133655,7 +133743,7 @@ aOD
 bcd
 bcs
 qyL
-fwE
+faC
 eUP
 baC
 jkC
@@ -133898,7 +133986,7 @@ cbj
 cbk
 atv
 aGb
-fga
+awB
 cNY
 yib
 aWY
@@ -134669,13 +134757,13 @@ cHa
 arO
 cNp
 cHa
-anf
+ayw
 cNY
 cNY
 aWY
 baq
 bbw
-ufp
+rRD
 eOl
 uTh
 hct
@@ -134685,9 +134773,9 @@ aWY
 lxK
 bwa
 tWc
-dxS
+xLe
 aub
-ahm
+bcu
 bic
 bkd
 acm
@@ -134926,7 +135014,7 @@ rQB
 arS
 atz
 cHa
-anf
+ayw
 cNY
 yib
 aWY
@@ -134942,7 +135030,7 @@ aWY
 hvo
 tlV
 dPm
-ayw
+dxS
 cMW
 bkd
 vUr
@@ -135185,19 +135273,19 @@ ily
 cHa
 awR
 aGb
-ahm
-ahm
+bcu
+bcu
 aCi
 aGb
 aAp
 aAp
 aFF
-nRp
+fVj
 ank
 apu
 aSQ
 shr
-dxS
+xLe
 sWJ
 cjV
 cMW
@@ -135447,7 +135535,7 @@ bbc
 bbc
 bbc
 bbc
-lYV
+vgy
 aAS
 lqr
 lqr
@@ -136220,7 +136308,7 @@ aMC
 cMp
 biU
 rWz
-wTF
+mWS
 arG
 cZU
 aKY
@@ -136737,7 +136825,7 @@ jkW
 aZg
 maQ
 oJt
-cCx
+axR
 awi
 cOn
 cOo
@@ -137510,7 +137598,7 @@ bcM
 paR
 bbi
 ttK
-iAU
+bdV
 ayL
 bcJ
 mQR
@@ -137767,7 +137855,7 @@ hoO
 bhj
 bbi
 fOT
-iAU
+bdV
 aXs
 caT
 caT
@@ -138272,9 +138360,9 @@ ckk
 oaA
 cmU
 cmU
-nnW
+qjn
 alm
-nnW
+qjn
 bbi
 jtb
 jtb
@@ -138788,7 +138876,7 @@ sTh
 cmU
 tTP
 hUx
-vgy
+tpF
 bbi
 bEo
 acm
@@ -139045,7 +139133,7 @@ xLT
 cmU
 tTP
 hUx
-ayp
+ffK
 aaa
 aaa
 aaa
@@ -139300,9 +139388,9 @@ ckk
 oaA
 cmU
 cmU
-nFm
-uMS
-qcf
+cWB
+tAV
+jSg
 aaa
 aaa
 aaa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -4625,6 +4625,10 @@
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /obj/machinery/duct,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 32
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -7020,7 +7024,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard)
+/area/science/breakroom)
 "aud" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
@@ -10066,6 +10070,10 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/reagent_dispensers/watertank,
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aET" = (
@@ -12239,14 +12247,12 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "aOn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
-	suit_type = /obj/item/clothing/suit/space/fragile
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/science/test_area)
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "aOo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -12315,6 +12321,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
+	},
+/obj/structure/sign/departments/science/alt{
+	pixel_x = 32
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
@@ -14317,7 +14326,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard)
+/area/science/breakroom)
 "aSR" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-18"
@@ -14472,31 +14481,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aTn" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/south{
-	id = "robotics_shutters";
-	name = "Robotics Shutter Toggle";
-	pixel_x = 24;
-	req_access_txt = "29"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "aTo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -16135,13 +16127,31 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "aYe" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;47"
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	id = "robotics_shutters";
+	name = "Robotics Shutter Toggle";
+	pixel_x = 24;
+	req_access_txt = "29"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "aYf" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/lab)
@@ -17266,9 +17276,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "baG" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "baH" = (
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
@@ -17889,9 +17899,9 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bcf" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "bcg" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -19107,7 +19117,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bfr" = (
-/obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/science/explab)
 "bfs" = (
@@ -21621,6 +21630,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
+"brp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/turf/open/floor/plating,
+/area/science/test_area)
 "brF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -22257,7 +22275,7 @@
 /obj/effect/landmark/start/scientist,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "bwe" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/xenobiology)
@@ -33770,20 +33788,18 @@
 /area/security/execution/education)
 "cjV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
 /obj/machinery/vending/assist,
 /obj/machinery/light/directional/south,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 30
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "cjZ" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -39905,26 +39921,17 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "cHb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "cHc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
 	},
-/area/maintenance/starboard)
+/turf/open/space/basic,
+/area/space)
 "cHm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -41780,9 +41787,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/paramedic)
 "cZU" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/obj/effect/turf_decal/box,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
@@ -42874,16 +42885,10 @@
 /area/command/heads_quarters/cmo)
 "dxS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
 /obj/machinery/vending/cigarette,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "dyi" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/wood,
@@ -43592,8 +43597,15 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "dPy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -45157,17 +45169,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"exO" = (
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
-	suit_type = /obj/item/clothing/suit/space/fragile
-	},
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
 "exZ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow,
@@ -47950,22 +47951,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
-"fBM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/nosmoking/small{
-	pixel_y = 28
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
 "fBN" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/blue,
@@ -51003,6 +50988,19 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gPP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "gQl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52331,7 +52329,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "hvG" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -52993,6 +52991,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"hND" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/closed/mineral/random/labormineral,
+/area/space/nearstation)
 "hNF" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -55420,13 +55424,21 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iNO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_y = 28
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "iNS" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -57310,6 +57322,14 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
+"jDZ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "jEj" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/tile/neutral,
@@ -57874,6 +57894,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
+"jRx" = (
+/obj/machinery/power/apc/auto_name/south,
+/turf/closed/wall,
+/area/maintenance/starboard)
 "jRP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/frame/computer{
@@ -58098,13 +58122,23 @@
 	},
 /area/maintenance/starboard)
 "jTL" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/obj/structure/sign/directions/evac{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard)
 "jTR" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -62085,8 +62119,12 @@
 	},
 /obj/item/food/candy_trash,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/pods{
+	pixel_y = 32
+	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "lxO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -62538,10 +62576,13 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
 "lGO" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "lHn" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -69484,6 +69525,13 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
+"oHA" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "oHJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -71890,6 +71938,22 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/fore)
+"pEP" = (
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen{
+	pixel_x = 5
+	},
+/obj/item/tank/internals/oxygen{
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "pES" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -77035,13 +77099,14 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
-"rSE" = (
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
-	suit_type = /obj/item/clothing/suit/space/fragile
+"rSF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/open/space/basic,
-/area/space)
+/area/maintenance/starboard)
 "rSK" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral{
@@ -77838,7 +77903,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "shX" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -79495,7 +79560,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "sWQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -80007,8 +80072,11 @@
 /area/cargo/storage)
 "tlV" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "tmi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -81968,8 +82036,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "tWd" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -84939,20 +85008,12 @@
 	},
 /area/maintenance/starboard)
 "vgy" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen{
-	pixel_x = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/item/tank/internals/oxygen{
-	pixel_x = -5
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "vgz" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -87764,14 +87825,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
-"wpr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
 "wpt" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -91359,7 +91412,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
+/area/science/breakroom)
 "xLk" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen/empty,
@@ -91540,12 +91593,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "xOP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/science/breakroom)
 "xPl" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
@@ -129163,7 +129212,7 @@ bfM
 bfM
 otz
 jSc
-aTn
+aYe
 aAF
 aIr
 wwp
@@ -131493,7 +131542,7 @@ hYj
 bbb
 bdz
 aht
-cHb
+gPP
 jMR
 oHM
 leq
@@ -131724,7 +131773,7 @@ lrl
 uaH
 cqw
 alB
-anf
+jTL
 bkd
 cNa
 aZF
@@ -132999,7 +133048,7 @@ bkd
 bkd
 bkd
 age
-iNO
+vgy
 bkd
 bkd
 bkd
@@ -133014,7 +133063,7 @@ cLs
 cNg
 cNs
 ava
-bkd
+jRx
 bkd
 ayd
 ayl
@@ -133511,9 +133560,9 @@ mvk
 aAG
 sDo
 xuc
-aYe
-wpr
-cHc
+jDZ
+rSF
+lGO
 vun
 ctI
 agb
@@ -135088,7 +135137,7 @@ hvo
 tlV
 dPm
 dxS
-cMW
+xOP
 bkd
 vUr
 bkd
@@ -135345,7 +135394,7 @@ shr
 xLe
 sWJ
 cjV
-cMW
+xOP
 aPm
 bfw
 avA
@@ -135850,12 +135899,12 @@ faf
 bct
 kGY
 gaw
-bcf
+baG
 bfQ
 azI
 afq
 xhY
-bcf
+baG
 nlf
 bkX
 ffM
@@ -136107,13 +136156,13 @@ xEw
 lEy
 bck
 aRE
-bcf
+baG
 nfS
 beW
 oer
 mfj
 lqr
-fBM
+iNO
 bej
 apG
 caT
@@ -138689,8 +138738,8 @@ fVn
 hdj
 fVn
 bgb
-cZU
-vgy
+aOn
+pEP
 ava
 acm
 aeo
@@ -138940,14 +138989,14 @@ acm
 bEo
 bbi
 caT
-aOn
+brp
 fVn
 caT
 maj
 caT
 iYL
-jTL
-exO
+aTn
+cZU
 ava
 cmJ
 aaa
@@ -139206,7 +139255,7 @@ cNC
 avA
 avA
 ava
-lGO
+cHb
 cmJ
 aaa
 aaa
@@ -139462,7 +139511,7 @@ acm
 bgf
 cmJ
 cmJ
-lGO
+cHb
 cmJ
 aaa
 aaa
@@ -140483,7 +140532,7 @@ aaa
 aaa
 aaa
 aaa
-rSE
+cHc
 acm
 aaa
 aaQ
@@ -142012,7 +142061,7 @@ alm
 aeu
 aeu
 aeu
-aeu
+hND
 aeu
 aeu
 aeu
@@ -142286,7 +142335,7 @@ aaa
 aeo
 aaa
 aeo
-baG
+bcf
 pFC
 dyq
 xUP
@@ -142543,7 +142592,7 @@ aaa
 acm
 aaa
 aaQ
-baG
+bcf
 pFC
 pqf
 vzj
@@ -142800,7 +142849,7 @@ aaa
 aeo
 aaa
 aeo
-baG
+bcf
 pFC
 qBh
 wiR
@@ -143314,7 +143363,7 @@ aaa
 acm
 aaa
 acm
-baG
+bcf
 aaa
 acK
 acK
@@ -143828,7 +143877,7 @@ aaa
 acm
 aaa
 acm
-baG
+bcf
 aaa
 aaa
 aaa
@@ -144856,7 +144905,7 @@ aaa
 aeo
 aaa
 acm
-baG
+bcf
 aaa
 aaa
 aaa
@@ -145113,7 +145162,7 @@ aaa
 acm
 aaa
 acm
-xOP
+oHA
 aaa
 aaa
 aaa
@@ -145370,7 +145419,7 @@ aaa
 acm
 aaa
 acm
-xOP
+oHA
 aaa
 aaa
 aaa
@@ -145884,7 +145933,7 @@ aaa
 acm
 aaa
 acm
-baG
+bcf
 aaa
 aaa
 aaa
@@ -146912,7 +146961,7 @@ aaa
 aeo
 aaa
 acm
-baG
+bcf
 aaa
 aaa
 aaa
@@ -147426,7 +147475,7 @@ aaa
 acm
 aaa
 aaQ
-baG
+bcf
 aaa
 aaa
 aaa
@@ -147940,7 +147989,7 @@ aaa
 aaQ
 aaa
 acm
-xOP
+oHA
 aaa
 aaa
 aaa
@@ -148197,7 +148246,7 @@ aaa
 acm
 aaa
 acm
-xOP
+oHA
 aaa
 aaa
 aeu

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -11602,6 +11602,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"aLY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wardrobe/genetics_white,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aLZ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -12247,11 +12252,9 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "aOn" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aOo" = (
 /obj/effect/turf_decal/tile/purple{
@@ -14481,14 +14484,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aTn" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_y = 28
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "aTo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -16127,31 +16137,8 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "aYe" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/south{
-	id = "robotics_shutters";
-	name = "Robotics Shutter Toggle";
-	pixel_x = 24;
-	req_access_txt = "29"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
+/turf/closed/wall/r_wall,
+/area/science/breakroom)
 "aYf" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/lab)
@@ -17276,9 +17263,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "baG" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/turf/open/space/basic,
+/area/space)
 "baH" = (
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
@@ -17899,9 +17887,9 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bcf" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "bcg" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -21630,15 +21618,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
-"brp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
-	suit_type = /obj/item/clothing/suit/space/fragile
-	},
-/turf/open/floor/plating,
-/area/science/test_area)
 "brF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -22274,6 +22253,9 @@
 	},
 /obj/effect/landmark/start/scientist,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/breakroom)
 "bwe" = (
@@ -39921,17 +39903,29 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "cHb" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space)
-"cHc" = (
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
-	suit_type = /obj/item/clothing/suit/space/fragile
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
+"cHc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "cHm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -41182,6 +41176,11 @@
 	},
 /area/maintenance/starboard)
 "cNY" = (
+/obj/effect/loot_site_spawner,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNZ" = (
@@ -41787,16 +41786,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/paramedic)
 "cZU" = (
-/obj/machinery/suit_storage_unit/standard_unit{
-	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
-	suit_type = /obj/item/clothing/suit/space/fragile
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/turf/open/space/basic,
+/area/space)
 "cZV" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -46166,6 +46161,17 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ePm" = (
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "ePn" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -46396,6 +46402,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"eTi" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "eTL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -47243,6 +47254,32 @@
 "flP" = (
 /turf/closed/wall/rust,
 /area/commons/vacant_room/commissary)
+"flU" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	id = "robotics_shutters";
+	name = "Robotics Shutter Toggle";
+	pixel_x = 24;
+	req_access_txt = "29"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "flW" = (
 /turf/closed/wall/rust,
 /area/service/chapel/main)
@@ -48994,10 +49031,14 @@
 /turf/open/floor/iron,
 /area/security/warden)
 "fVj" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "fVk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -50988,19 +51029,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"gPP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
 "gQl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52275,6 +52303,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
+"huu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
 "huG" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -52545,6 +52581,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"hCs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "hCz" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -52991,12 +53035,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
-"hND" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/closed/mineral/random/labormineral,
-/area/space/nearstation)
 "hNF" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -54746,6 +54784,19 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
+"izd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
 "izm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -55424,21 +55475,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iNO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/nosmoking/small{
-	pixel_y = 28
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "iNS" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -57322,14 +57367,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
-"jDZ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;47"
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
 "jEj" = (
 /obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/tile/neutral,
@@ -57894,10 +57931,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
-"jRx" = (
-/obj/machinery/power/apc/auto_name/south,
-/turf/closed/wall,
-/area/maintenance/starboard)
 "jRP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/frame/computer{
@@ -58122,24 +58155,9 @@
 	},
 /area/maintenance/starboard)
 "jTL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/obj/machinery/duct,
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "jTR" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -62576,12 +62594,9 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
 "lGO" = (
+/obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "lHn" = (
 /obj/effect/turf_decal/tile/brown,
@@ -66220,6 +66235,25 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/bar/atrium)
+"nlX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/obj/structure/sign/directions/evac{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "nmc" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -69525,13 +69559,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
-"oHA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
 "oHJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -71740,6 +71767,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
+"pBO" = (
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen{
+	pixel_x = 5
+	},
+/obj/item/tank/internals/oxygen{
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "pBQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -71938,22 +71981,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/fore)
-"pEP" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen{
-	pixel_x = 5
-	},
-/obj/item/tank/internals/oxygen{
-	pixel_x = -5
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
 "pES" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -75430,6 +75457,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
+"rgr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
 "rgQ" = (
 /obj/machinery/door/airlock/atmos/glass{
 	req_access_txt = "24"
@@ -76144,6 +76178,14 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/port)
+"rtQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "rtZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -77099,14 +77141,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
-"rSF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
 "rSK" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral{
@@ -79818,6 +79852,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"teu" = (
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/turf/open/space/basic,
+/area/space)
 "teL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/binary/heat_pump/freezer{
@@ -81506,6 +81547,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/safe)
+"tMu" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "tMB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -83146,6 +83194,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/cargo/sorting)
+"uqt" = (
+/obj/machinery/power/apc/auto_name/south,
+/turf/closed/wall,
+/area/maintenance/starboard)
 "uqP" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/grassybush,
@@ -85009,10 +85061,15 @@
 /area/maintenance/starboard)
 "vgy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /obj/structure/cable,
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
 "vgz" = (
@@ -88512,6 +88569,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
+"wEz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/closed/mineral/random/labormineral,
+/area/space/nearstation)
 "wET" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -91593,8 +91656,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "xOP" = (
-/turf/closed/wall/r_wall,
-/area/science/breakroom)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/turf/open/floor/plating,
+/area/science/test_area)
 "xPl" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
@@ -129212,7 +129281,7 @@ bfM
 bfM
 otz
 jSc
-aYe
+flU
 aAF
 aIr
 wwp
@@ -131542,7 +131611,7 @@ hYj
 bbb
 bdz
 aht
-gPP
+vgy
 jMR
 oHM
 leq
@@ -131773,7 +131842,7 @@ lrl
 uaH
 cqw
 alB
-jTL
+nlX
 bkd
 cNa
 aZF
@@ -133048,7 +133117,7 @@ bkd
 bkd
 bkd
 age
-vgy
+huu
 bkd
 bkd
 bkd
@@ -133063,7 +133132,7 @@ cLs
 cNg
 cNs
 ava
-jRx
+uqt
 bkd
 ayd
 ayl
@@ -133307,7 +133376,7 @@ ava
 aER
 xuc
 cbk
-cLK
+rgr
 agb
 cLr
 ahP
@@ -133560,9 +133629,9 @@ mvk
 aAG
 sDo
 xuc
-jDZ
-rSF
-lGO
+iNO
+hCs
+rtQ
 vun
 ctI
 agb
@@ -133580,7 +133649,7 @@ cNE
 cNO
 cNR
 ayq
-ctI
+aLY
 aXk
 aXU
 bdb
@@ -134093,7 +134162,7 @@ cbk
 atv
 aGb
 awB
-cNY
+tMu
 yib
 aWY
 mSM
@@ -134607,8 +134676,8 @@ arN
 aty
 aAp
 awG
-cNY
-cNY
+aOn
+ctI
 aWY
 aXN
 bbt
@@ -134863,8 +134932,8 @@ cHa
 arO
 cNp
 cHa
-ayw
-cNY
+cHc
+lGO
 cNY
 aWY
 baq
@@ -135121,7 +135190,7 @@ arS
 atz
 cHa
 ayw
-cNY
+lGO
 yib
 aWY
 aXk
@@ -135137,7 +135206,7 @@ hvo
 tlV
 dPm
 dxS
-xOP
+aYe
 bkd
 vUr
 bkd
@@ -135382,7 +135451,7 @@ aGb
 bcu
 bcu
 aCi
-aGb
+izd
 aAp
 aAp
 aFF
@@ -135394,7 +135463,7 @@ shr
 xLe
 sWJ
 cjV
-xOP
+aYe
 aPm
 bfw
 avA
@@ -135899,12 +135968,12 @@ faf
 bct
 kGY
 gaw
-baG
+bcf
 bfQ
 azI
 afq
 xhY
-baG
+bcf
 nlf
 bkX
 ffM
@@ -136156,13 +136225,13 @@ xEw
 lEy
 bck
 aRE
-baG
+bcf
 nfS
 beW
 oer
 mfj
 lqr
-iNO
+aTn
 bej
 apG
 caT
@@ -138738,8 +138807,8 @@ fVn
 hdj
 fVn
 bgb
-aOn
-pEP
+cHb
+pBO
 ava
 acm
 aeo
@@ -138989,14 +139058,14 @@ acm
 bEo
 bbi
 caT
-brp
+xOP
 fVn
 caT
 maj
 caT
 iYL
-aTn
-cZU
+fVj
+ePm
 ava
 cmJ
 aaa
@@ -139255,7 +139324,7 @@ cNC
 avA
 avA
 ava
-cHb
+eTi
 cmJ
 aaa
 aaa
@@ -139511,7 +139580,7 @@ acm
 bgf
 cmJ
 cmJ
-cHb
+eTi
 cmJ
 aaa
 aaa
@@ -140532,7 +140601,7 @@ aaa
 aaa
 aaa
 aaa
-cHc
+teu
 acm
 aaa
 aaQ
@@ -142061,7 +142130,7 @@ alm
 aeu
 aeu
 aeu
-hND
+wEz
 aeu
 aeu
 aeu
@@ -142335,7 +142404,7 @@ aaa
 aeo
 aaa
 aeo
-bcf
+jTL
 pFC
 dyq
 xUP
@@ -142592,7 +142661,7 @@ aaa
 acm
 aaa
 aaQ
-bcf
+jTL
 pFC
 pqf
 vzj
@@ -142849,7 +142918,7 @@ aaa
 aeo
 aaa
 aeo
-bcf
+jTL
 pFC
 qBh
 wiR
@@ -143363,7 +143432,7 @@ aaa
 acm
 aaa
 acm
-bcf
+jTL
 aaa
 acK
 acK
@@ -143877,7 +143946,7 @@ aaa
 acm
 aaa
 acm
-bcf
+jTL
 aaa
 aaa
 aaa
@@ -144134,7 +144203,7 @@ aaa
 acm
 aaa
 aeo
-fVj
+baG
 aaa
 aaa
 aaa
@@ -144391,7 +144460,7 @@ aaa
 acm
 aaa
 aeo
-fVj
+baG
 aaa
 aaa
 aaa
@@ -144648,7 +144717,7 @@ aaa
 aeo
 aaa
 aaQ
-fVj
+baG
 aaa
 aaa
 aaa
@@ -144905,7 +144974,7 @@ aaa
 aeo
 aaa
 acm
-bcf
+jTL
 aaa
 aaa
 aaa
@@ -145162,7 +145231,7 @@ aaa
 acm
 aaa
 acm
-oHA
+cZU
 aaa
 aaa
 aaa
@@ -145419,7 +145488,7 @@ aaa
 acm
 aaa
 acm
-oHA
+cZU
 aaa
 aaa
 aaa
@@ -145933,7 +146002,7 @@ aaa
 acm
 aaa
 acm
-bcf
+jTL
 aaa
 aaa
 aaa
@@ -146190,7 +146259,7 @@ aaa
 aaQ
 aaa
 aeo
-fVj
+baG
 aaa
 aaa
 aaa
@@ -146447,7 +146516,7 @@ aaa
 aaQ
 aaa
 aeo
-fVj
+baG
 aaa
 aaa
 aaa
@@ -146704,7 +146773,7 @@ aaa
 aeo
 aaa
 acm
-fVj
+baG
 aaa
 aaa
 aaa
@@ -146961,7 +147030,7 @@ aaa
 aeo
 aaa
 acm
-bcf
+jTL
 aaa
 aaa
 aaa
@@ -147218,7 +147287,7 @@ aaa
 aeo
 aaa
 aaQ
-fVj
+baG
 aaa
 aaa
 aaa
@@ -147475,7 +147544,7 @@ aaa
 acm
 aaa
 aaQ
-bcf
+jTL
 aaa
 aaa
 aaa
@@ -147989,7 +148058,7 @@ aaa
 aaQ
 aaa
 acm
-oHA
+cZU
 aaa
 aaa
 aaa
@@ -148246,7 +148315,7 @@ aaa
 acm
 aaa
 acm
-oHA
+cZU
 aaa
 aaa
 aeu

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2358,15 +2358,19 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ahm" = (
-/obj/effect/turf_decal/loading_area/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "ahn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -5601,10 +5605,16 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "apS" = (
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "apT" = (
@@ -5949,15 +5959,11 @@
 /area/science/robotics/mechbay)
 "aqU" = (
 /obj/effect/turf_decal/loading_area/red,
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -7894,7 +7900,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aww" = (
@@ -7930,12 +7935,8 @@
 	},
 /area/maintenance/starboard)
 "awB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/closed/wall,
+/area/science/cytology)
 "awG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -8248,20 +8249,19 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "axR" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/loading_area/red,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "aya" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -8375,14 +8375,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ayp" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/circuits)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
+/obj/structure/railing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ayq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -8415,14 +8412,18 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ayw" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "ayy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -8680,8 +8681,28 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "azt" = (
-/turf/closed/wall,
-/area/science/cytology)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "azv" = (
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -10321,8 +10342,20 @@
 /turf/open/floor/engine/telecomms,
 /area/tcommsat/server)
 "aFY" = (
-/turf/closed/wall/r_wall,
-/area/science/cytology)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "aGb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -12945,6 +12978,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"aPQ" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/cytology)
 "aPR" = (
 /obj/item/storage/firstaid/regular{
 	pixel_x = 3;
@@ -17635,12 +17674,8 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "bbQ" = (
-/obj/effect/turf_decal/box/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
+/turf/closed/wall/r_wall/rust,
+/area/science/cytology)
 "bbR" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -17903,6 +17938,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -18797,7 +18833,7 @@
 	location = "Research Division"
 	},
 /obj/machinery/door/window/westleft{
-	dir = 2;
+	dir = 1;
 	name = "Research Division Delivery Access";
 	req_access_txt = "47"
 	},
@@ -19461,11 +19497,9 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "bgA" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/cytology)
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/commons/toilet/restrooms)
 "bgB" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -20999,6 +21033,16 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/central)
+"boV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/science/research)
 "boX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -38826,6 +38870,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"cCx" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "cCB" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -42204,10 +42252,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
-"diS" = (
-/obj/effect/turf_decal/box/corners,
-/turf/open/floor/engine,
-/area/science/cytology)
 "djY" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -43272,6 +43316,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"dJA" = (
+/obj/effect/turf_decal/box/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "dJB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -43363,6 +43414,13 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"dLT" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Lab";
+	req_access_txt = "29"
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "dMh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -47612,6 +47670,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"fwE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "fxf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48204,6 +48271,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"fHC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "fHP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -50454,19 +50528,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/cytology)
-"gFQ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
-/obj/structure/railing,
-/turf/open/space/basic,
-/area/space/nearstation)
-"gFS" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Robotics Lab";
-	req_access_txt = "29"
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "gGl" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -51111,12 +51172,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"gWw" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
-/obj/structure/railing/corner,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gWN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -55315,14 +55370,8 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "iQE" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/turf/closed/wall/r_wall,
+/area/science/cytology)
 "iQO" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -55407,21 +55456,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"iRn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/obj/machinery/duct,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
 "iRo" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -55460,9 +55494,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"iSk" = (
-/turf/open/floor/engine,
-/area/science/cytology)
 "iSz" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -56304,16 +56335,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/chapel/office)
-"jjH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/science/research)
 "jjR" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -57083,16 +57104,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"jCQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "jCZ" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating{
@@ -57675,20 +57686,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
-"jRc" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/showroomfloor,
-/area/science/research)
 "jRt" = (
 /obj/structure/closet/radiation,
 /obj/structure/grille/broken,
@@ -59196,10 +59193,13 @@
 /area/maintenance/solars/port/aft)
 "kvc" = (
 /obj/effect/turf_decal/box/corners{
-	dir = 4
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/engine,
-/area/science/cytology)
+/area/science/xenobiology)
 "kvy" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table,
@@ -59391,21 +59391,6 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/dark,
 /area/service/bar)
-"kyK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/obj/machinery/duct,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
 "kyS" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -59935,6 +59920,34 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"kHA" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/command/heads_quarters/rd)
 "kHH" = (
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced/tinted,
@@ -60487,10 +60500,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"kSt" = (
-/obj/machinery/duct,
-/turf/closed/wall,
-/area/commons/toilet/restrooms)
 "kSE" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -62545,19 +62554,6 @@
 	},
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
-"lLO" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
 "lLS" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/glass,
@@ -62572,29 +62568,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"lMJ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/dark,
-/area/science/circuits)
 "lMO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -63214,33 +63187,9 @@
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
 "lYV" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/command/heads_quarters/rd)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "lYX" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -65781,6 +65730,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
+"ndp" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "neo" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -66108,6 +66072,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore)
+"nnW" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nok" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -66768,6 +66739,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/security/prison)
+"nFm" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nFo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -66787,16 +66768,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
-"nFA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "nFQ" = (
 /obj/item/canvas/nineteen_nineteen,
 /obj/structure/easel,
@@ -66954,9 +66925,6 @@
 "nJY" = (
 /turf/closed/wall/rust,
 /area/service/lawoffice)
-"nKw" = (
-/turf/closed/wall/rust,
-/area/science/cytology)
 "nKz" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
@@ -67251,6 +67219,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"nOR" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "nPa" = (
 /obj/structure/chair{
 	dir = 1
@@ -67392,6 +67366,16 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/storage/tech)
+"nRp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "nRr" = (
 /obj/machinery/power/solar{
 	id = "aftstarboard";
@@ -68556,16 +68540,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
-"opR" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "opS" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -69916,9 +69890,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/warehouse)
-"oTn" = (
-/turf/closed/wall/r_wall/rust,
-/area/science/cytology)
 "oTs" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -70900,16 +70871,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/warden)
-"pno" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+"pnj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/area/maintenance/starboard)
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "pnQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
@@ -71410,12 +71377,6 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plastic,
 /area/security/prison)
-"pwx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/circuits)
 "pwC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -71491,16 +71452,6 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/office)
-"pzq" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "pzX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -72416,10 +72367,6 @@
 	dir = 1
 	},
 /area/hallway/primary/port)
-"pRK" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "pSo" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_x = 32
@@ -72877,6 +72824,16 @@
 /obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"qcf" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qcg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -74817,6 +74774,16 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
+"qUj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "qUp" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -76086,6 +76053,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"ryq" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/cytology)
 "ryU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -77931,19 +77904,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"sot" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/showroomfloor,
-/area/maintenance/starboard)
 "sox" = (
 /turf/closed/wall/rust,
 /area/service/kitchen)
@@ -79609,10 +79569,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"tcK" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/closed/wall/r_wall,
-/area/science/storage)
 "tdY" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/stack/rods,
@@ -80125,14 +80081,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison)
 "tpF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno2";
-	name = "Creature Cell 2"
+/obj/effect/turf_decal/box/corners{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/science/cytology)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "tpP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -81037,16 +80993,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"tHH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"tHz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno2";
+	name = "Creature Cell 2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/research)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/cytology)
 "tHI" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/carpspawn,
@@ -82288,6 +82243,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
+"ufp" = (
+/obj/machinery/dna_scannernew,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "ufq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -83511,6 +83471,16 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uFr" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/research)
 "uFB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -83656,6 +83626,12 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
+"uHw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "uHJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83905,6 +83881,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
+"uMS" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "uNl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -83988,6 +83974,9 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
+"uPl" = (
+/turf/closed/wall/rust,
+/area/science/cytology)
 "uPn" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -84818,11 +84807,11 @@
 	},
 /area/maintenance/starboard)
 "vgy" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
+/obj/structure/railing/corner,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vgz" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -85874,11 +85863,8 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "vBV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/circuits)
+/turf/open/floor/engine,
+/area/science/cytology)
 "vCb" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -86105,13 +86091,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
-"vGt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "vGA" = (
 /obj/machinery/camera{
 	c_tag = "Prison Recreation";
@@ -86767,11 +86746,6 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
-"vUb" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron/dark,
-/area/science/genetics)
 "vUi" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -88967,6 +88941,21 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"wTF" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "wTT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -89063,6 +89052,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"wVc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "wVh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -91406,6 +91402,10 @@
 "xOP" = (
 /turf/closed/wall/rust,
 /area/science/test_area)
+"xPa" = (
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/engine,
+/area/science/cytology)
 "xPl" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
@@ -111569,8 +111569,8 @@ dyu
 bKl
 add
 lSH
-kSt
-kSt
+bgA
+bgA
 ikp
 fJK
 uMr
@@ -127735,9 +127735,9 @@ eEW
 amm
 aRR
 aBX
-apS
+wVc
 bdd
-gFS
+dLT
 aJK
 aLV
 cgR
@@ -127965,11 +127965,11 @@ aUz
 aeU
 aeU
 aeU
-aFY
-aFY
-aFY
-oTn
-aFY
+iQE
+iQE
+iQE
+bbQ
+iQE
 dIg
 gbf
 agv
@@ -127989,7 +127989,7 @@ aZS
 aZS
 aZS
 axK
-aqU
+axR
 auk
 aCa
 aZU
@@ -128222,14 +128222,14 @@ aeU
 aeU
 aeU
 aeu
-oTn
-bgA
+bbQ
+aPQ
 qyy
 bfs
-aFY
+iQE
 cId
 cIh
-aFY
+iQE
 alB
 bwe
 alB
@@ -128246,8 +128246,8 @@ aEG
 enM
 kHH
 vzX
-lLO
-jCQ
+apS
+qUj
 aCK
 aEP
 aVd
@@ -128479,17 +128479,17 @@ aeu
 alB
 alB
 alB
-aFY
-iSk
+iQE
+vBV
 lBJ
-iSk
-tpF
+vBV
+tHz
 cIe
 hJx
-aFY
+iQE
 bbx
 agQ
-ayw
+kvc
 aWJ
 xva
 iFf
@@ -128503,7 +128503,7 @@ kAC
 aOT
 xrO
 aXt
-lLO
+apS
 aBe
 aCe
 aHM
@@ -128736,17 +128736,17 @@ alB
 alB
 aWJ
 bhz
-aFY
-kvc
+iQE
+ryq
 uwd
-diS
-tpF
+xPa
+tHz
 bhv
 gFD
-tpF
+tHz
 aWJ
 bhn
-vgy
+nOR
 lHK
 dcM
 cbg
@@ -128760,8 +128760,8 @@ dtc
 vqD
 atq
 aXe
-ahm
-bbQ
+aqU
+dJA
 aDs
 aHP
 aKM
@@ -128993,17 +128993,17 @@ alB
 aWJ
 ayv
 aWJ
-aFY
+iQE
 aeX
 aOS
 xnT
-nKw
+uPl
 bbk
 acB
-tpF
+tHz
 bfq
 lrl
-iQE
+tpF
 aWJ
 jXM
 hNX
@@ -129254,10 +129254,10 @@ mfS
 aXa
 afk
 tTB
-azt
+awB
 beY
 adx
-azt
+awB
 agM
 aha
 noH
@@ -130043,10 +130043,10 @@ aqB
 arH
 atp
 auG
-jRc
+aws
 axL
 azL
-aws
+ndp
 aCh
 aMN
 aDc
@@ -130307,7 +130307,7 @@ vKn
 vse
 aXE
 aXI
-tHH
+uFr
 beE
 bbj
 aOi
@@ -130823,7 +130823,7 @@ vlS
 aYN
 aYT
 dci
-jjH
+boV
 aOo
 bgj
 aYe
@@ -131059,13 +131059,13 @@ oRD
 agM
 ohv
 xva
-ayw
+kvc
 aWJ
 xva
 sbu
 aOF
 alB
-kyK
+bcu
 aps
 ajO
 baL
@@ -131316,7 +131316,7 @@ akt
 agM
 aWJ
 bhn
-vgy
+nOR
 lHK
 dcM
 cbg
@@ -131331,7 +131331,7 @@ bcx
 aWU
 iOj
 hea
-lYV
+kHA
 cYO
 tWx
 vlS
@@ -131347,7 +131347,7 @@ bdZ
 hYj
 bbb
 bdz
-bcu
+ahm
 fga
 jMR
 oHM
@@ -131573,13 +131573,13 @@ odA
 alB
 bfq
 oFk
-iQE
+tpF
 aWJ
 lrl
 uaH
 cqw
 alB
-iRn
+aFY
 bkd
 cNa
 aZF
@@ -132093,7 +132093,7 @@ cMw
 cLK
 cbk
 cMC
-iRn
+aFY
 cLt
 cNd
 aZF
@@ -132357,7 +132357,7 @@ arJ
 okx
 auV
 cLt
-awB
+fHC
 iOj
 iOj
 rJG
@@ -132626,7 +132626,7 @@ bbm
 aZZ
 bdF
 bcs
-lMJ
+azt
 faC
 beg
 beS
@@ -132884,7 +132884,7 @@ aOs
 aRD
 aSK
 aUY
-vBV
+uHw
 bee
 baz
 xqf
@@ -133398,7 +133398,7 @@ aOw
 bbW
 aSK
 aiY
-pwx
+pnj
 beq
 jZo
 xAA
@@ -133655,7 +133655,7 @@ aOD
 bcd
 bcs
 qyL
-ayp
+fwE
 eUP
 baC
 jkC
@@ -134675,7 +134675,7 @@ cNY
 aWY
 baq
 bbw
-vUb
+ufp
 eOl
 uTh
 hct
@@ -134687,7 +134687,7 @@ bwa
 tWc
 dxS
 aub
-bcu
+ahm
 bic
 bkd
 acm
@@ -134942,7 +134942,7 @@ aWY
 hvo
 tlV
 dPm
-sot
+ayw
 cMW
 bkd
 vUr
@@ -135185,14 +135185,14 @@ ily
 cHa
 awR
 aGb
-bcu
-bcu
+ahm
+ahm
 aCi
 aGb
 aAp
 aAp
 aFF
-pno
+nRp
 ank
 apu
 aSQ
@@ -135447,7 +135447,7 @@ bbc
 bbc
 bbc
 bbc
-tcK
+lYV
 aAS
 lqr
 lqr
@@ -136220,7 +136220,7 @@ aMC
 cMp
 biU
 rWz
-axR
+wTF
 arG
 cZU
 aKY
@@ -136737,7 +136737,7 @@ jkW
 aZg
 maQ
 oJt
-pRK
+cCx
 awi
 cOn
 cOo
@@ -138272,9 +138272,9 @@ ckk
 oaA
 cmU
 cmU
-vGt
+nnW
 alm
-vGt
+nnW
 bbi
 jtb
 jtb
@@ -138788,7 +138788,7 @@ sTh
 cmU
 tTP
 hUx
-gWw
+vgy
 bbi
 bEo
 acm
@@ -139045,7 +139045,7 @@ xLT
 cmU
 tTP
 hUx
-gFQ
+ayp
 aaa
 aaa
 aaa
@@ -139300,9 +139300,9 @@ ckk
 oaA
 cmU
 cmU
-pzq
-nFA
-opR
+nFm
+uMS
+qcf
 aaa
 aaa
 aaa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1673,9 +1673,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afq" = (
-/obj/machinery/atmospherics/components/binary/heat_pump/freezer{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1683,6 +1680,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "afr" = (
@@ -2929,7 +2927,6 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aiY" = (
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -2942,6 +2939,7 @@
 	pixel_x = -4
 	},
 /obj/item/multitool/circuit,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "aiZ" = (
@@ -4683,7 +4681,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -5466,7 +5463,6 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "apw" = (
@@ -6215,6 +6211,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "arH" = (
@@ -7020,7 +7017,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -8536,7 +8532,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "ayU" = (
@@ -8719,7 +8714,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "azH" = (
@@ -8731,14 +8725,14 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "azI" = (
-/obj/machinery/atmospherics/components/binary/heat_pump/heater{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -8982,7 +8976,6 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "aAF" = (
-/obj/machinery/light_switch/directional/east,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
@@ -9064,7 +9057,9 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore)
 "aAS" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/orange,
+/obj/machinery/atmospherics/pipe/layer_manifold/orange{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "aAV" = (
@@ -9279,7 +9274,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/purple/corner,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -10783,6 +10777,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 26
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aIs" = (
@@ -11262,6 +11259,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "aKZ" = (
@@ -12241,8 +12239,13 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "aOn" = (
-/obj/structure/sign/poster/contraband/random,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/turf/open/floor/plating,
 /area/science/test_area)
 "aOo" = (
 /obj/effect/turf_decal/tile/purple{
@@ -14311,7 +14314,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -14470,9 +14472,31 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aTn" = (
-/obj/effect/turf_decal/bot_red,
-/turf/closed/wall/r_wall,
-/area/science/server)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	id = "robotics_shutters";
+	name = "Robotics Shutter Toggle";
+	pixel_x = 24;
+	req_access_txt = "29"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "aTo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -14650,11 +14674,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/lobby)
 "aTE" = (
-/obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics_shutters";
 	name = "Robotics Privacy Shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "aTF" = (
@@ -16111,9 +16135,13 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "aYe" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/lab)
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "aYf" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/lab)
@@ -16368,7 +16396,6 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/grille/broken,
 /obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -17239,9 +17266,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "baG" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall,
-/area/science/test_area)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "baH" = (
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
@@ -17315,6 +17342,9 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "baU" = (
@@ -17825,6 +17855,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_y = 28
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "bcc" = (
@@ -17856,20 +17889,15 @@
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "bcf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/research{
-	name = "Testing Lab";
-	req_access_txt = "8"
-	},
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "bcg" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "bch" = (
@@ -18201,7 +18229,6 @@
 	dir = 4;
 	pixel_y = 24
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bdl" = (
@@ -18862,6 +18889,7 @@
 	req_access_txt = "47"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "beJ" = (
@@ -18997,9 +19025,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "beW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "beX" = (
@@ -19105,7 +19130,6 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bfv" = (
@@ -19290,16 +19314,13 @@
 "bfQ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/item/pipe_dispenser,
-/obj/item/wrench,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/heat_pump/heater,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bfU" = (
@@ -19335,18 +19356,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bgb" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bgf" = (
 /obj/structure/lattice/catwalk,
@@ -19366,7 +19380,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bgh" = (
@@ -19743,7 +19756,6 @@
 	sortType = 3
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bhf" = (
@@ -19761,7 +19773,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/starboard)
 "bhh" = (
@@ -19781,7 +19792,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "bhi" = (
@@ -19798,7 +19808,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "bhj" = (
@@ -19824,7 +19833,6 @@
 	pixel_y = 24
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bhl" = (
@@ -19855,7 +19863,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -19876,7 +19883,6 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -19908,7 +19914,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "bhy" = (
@@ -19923,7 +19928,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -20053,7 +20057,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bih" = (
@@ -20186,14 +20189,17 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/light_switch/directional/west{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -32
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 26
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/storage)
 "biV" = (
@@ -21700,12 +21706,6 @@
 /obj/effect/landmark/start/roboticist,
 /obj/structure/chair/office/light{
 	dir = 4
-	},
-/obj/machinery/button/door/directional/south{
-	id = "robotics_shutters";
-	name = "Robotics Shutter Toggle";
-	pixel_x = 24;
-	req_access_txt = "29"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
@@ -33778,8 +33778,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/vending/assist,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /obj/machinery/light/directional/south,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 30
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "cjZ" = (
@@ -39903,11 +39905,26 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "cHb" = (
-/turf/closed/wall,
-/area/maintenance/solars/starboard/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "cHc" = (
-/turf/closed/wall/rust,
-/area/maintenance/solars/starboard/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "cHm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -41078,15 +41095,15 @@
 /turf/closed/wall/r_wall/rust,
 /area/maintenance/solars/starboard/fore)
 "cNC" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/external{
+	name = "Toxins Test Site External Airlock";
+	req_one_access_txt = "8;13"
+	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41194,9 +41211,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 28
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
@@ -41766,19 +41780,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/paramedic)
 "cZU" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "cZV" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -42874,7 +42881,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
@@ -45151,6 +45157,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"exO" = (
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "exZ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow,
@@ -47574,7 +47591,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "fuC" = (
@@ -47934,6 +47950,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"fBM" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_y = 28
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "fBN" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/blue,
@@ -48977,15 +49009,10 @@
 /turf/open/floor/iron,
 /area/security/warden)
 "fVj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/turf/open/space/basic,
+/area/space)
 "fVk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -50212,6 +50239,7 @@
 	req_access_txt = "8"
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "gxr" = (
@@ -50673,14 +50701,14 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "gGX" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "gHq" = (
@@ -51385,9 +51413,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
@@ -52122,6 +52147,21 @@
 	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/transfer_valve{
+	pixel_x = -4
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 4
+	},
+/obj/item/transfer_valve{
+	pixel_x = 4
+	},
+/obj/item/transfer_valve{
+	pixel_x = 4
+	},
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "hqF" = (
@@ -55380,12 +55420,13 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iNO" = (
-/obj/machinery/atmospherics/components/binary/heat_pump/heater{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/maintenance/starboard)
 "iNS" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -55931,13 +55972,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/airalarm/directional/south,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "BOMB RANGE";
 	pixel_y = 32
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "iYM" = (
@@ -58055,14 +58098,14 @@
 	},
 /area/maintenance/starboard)
 "jTL" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "jTR" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -61090,8 +61133,14 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/grille/broken,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -61336,7 +61385,6 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ljH" = (
@@ -62085,6 +62133,7 @@
 /obj/structure/rack,
 /obj/item/integrated_circuit/loaded/speech_relay,
 /obj/item/integrated_circuit/loaded/hello_world,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "lyT" = (
@@ -62489,12 +62538,10 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
 "lGO" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 5
-	},
+/obj/structure/lattice,
+/obj/structure/grille/broken,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "lHn" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -64953,9 +65000,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/heat_pump/heater{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mIE" = (
@@ -65932,7 +65976,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
@@ -68036,9 +68079,6 @@
 /turf/closed/wall/rust,
 /area/medical/paramedic)
 "oer" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
@@ -69965,8 +70005,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/door/airlock/external{
+	name = "Toxins Test Site External Airlock";
+	req_one_access_txt = "8;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -70337,7 +70381,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "pbm" = (
@@ -76992,6 +77035,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
+"rSE" = (
+/obj/machinery/suit_storage_unit/standard_unit{
+	helmet_type = /obj/item/clothing/head/helmet/space/fragile;
+	suit_type = /obj/item/clothing/suit/space/fragile
+	},
+/turf/open/space/basic,
+/area/space)
 "rSK" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral{
@@ -77787,7 +77837,6 @@
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "shX" = (
@@ -79445,7 +79494,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "sWQ" = (
@@ -81240,6 +81288,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/circuits)
 "tJO" = (
@@ -81963,11 +82012,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 28
-	},
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_y = 28
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "tXk" = (
@@ -82768,7 +82817,6 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -84891,9 +84939,21 @@
 	},
 /area/maintenance/starboard)
 "vgy" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
-/turf/closed/wall/r_wall,
-/area/science/storage)
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen{
+	pixel_x = 5
+	},
+/obj/item/tank/internals/oxygen{
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "vgz" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -87704,6 +87764,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"wpr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "wpt" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -89808,30 +89876,16 @@
 /area/hallway/primary/fore)
 "xhY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
-/obj/item/transfer_valve{
-	pixel_x = -4
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 4
-	},
-/obj/item/transfer_valve{
-	pixel_x = 4
-	},
-/obj/item/transfer_valve{
-	pixel_x = 4
-	},
-/obj/item/transfer_valve{
-	pixel_x = 4
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/heat_pump/freezer{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -91059,7 +91113,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "xIk" = (
@@ -91305,7 +91358,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard)
 "xLk" = (
@@ -91488,8 +91540,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "xOP" = (
-/turf/closed/wall/rust,
-/area/science/test_area)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "xPl" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/disposal/bin,
@@ -92062,6 +92118,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "ycC" = (
@@ -123263,7 +123320,7 @@ tth
 xIT
 xLF
 vPk
-iNO
+uVC
 tIU
 kJJ
 ipP
@@ -129106,7 +129163,7 @@ bfM
 bfM
 otz
 jSc
-jSc
+aTn
 aAF
 aIr
 wwp
@@ -129873,7 +129930,7 @@ jLI
 aZS
 bah
 bah
-bah
+aTE
 aTE
 bah
 aTE
@@ -129886,7 +129943,7 @@ lve
 bcE
 bcW
 lXQ
-aYe
+aYg
 aXn
 aZn
 bcG
@@ -130657,7 +130714,7 @@ aZt
 wiA
 aOi
 bep
-aYe
+aYg
 aXQ
 aXY
 bdY
@@ -130914,7 +130971,7 @@ dci
 ayp
 aOo
 bgj
-aYe
+aYg
 aZa
 aXY
 aZp
@@ -131413,7 +131470,7 @@ alB
 amK
 mll
 ajU
-aTn
+aZF
 aXR
 bcx
 aWU
@@ -131435,8 +131492,8 @@ bdZ
 hYj
 bbb
 bdz
-bcu
-awB
+aht
+cHb
 jMR
 oHM
 leq
@@ -132942,7 +132999,7 @@ bkd
 bkd
 bkd
 age
-ahO
+iNO
 bkd
 bkd
 bkd
@@ -133199,7 +133256,7 @@ cLg
 cOj
 ava
 aER
-bjs
+xuc
 cbk
 cLK
 agb
@@ -133454,9 +133511,9 @@ mvk
 aAG
 sDo
 xuc
-agD
-aim
-alT
+aYe
+wpr
+cHc
 vun
 ctI
 agb
@@ -134775,7 +134832,7 @@ bwa
 tWc
 xLe
 aub
-bcu
+aht
 bic
 bkd
 acm
@@ -135009,7 +135066,7 @@ aeu
 aeu
 aeu
 aeu
-cHb
+cHa
 rQB
 arS
 atz
@@ -135266,7 +135323,7 @@ aap
 aeu
 aeu
 aeu
-cHc
+cHa
 muA
 arU
 ily
@@ -135280,7 +135337,7 @@ aGb
 aAp
 aAp
 aFF
-fVj
+alT
 ank
 apu
 aSQ
@@ -135523,7 +135580,7 @@ cui
 aeu
 aeu
 aeu
-cHb
+cHa
 aqG
 arW
 ayn
@@ -135535,11 +135592,11 @@ bbc
 bbc
 bbc
 bbc
-vgy
+bbc
 aAS
-lqr
-lqr
-lqr
+aUZ
+aUZ
+aUZ
 awi
 awi
 fVn
@@ -135780,11 +135837,11 @@ aeU
 aap
 aeu
 aeu
-cHb
-cHb
+cHa
+cHa
 asb
-cHb
-cHb
+cHa
+cHa
 aeu
 aeu
 bbc
@@ -135793,12 +135850,12 @@ faf
 bct
 kGY
 gaw
-awi
+bcf
 bfQ
 azI
 afq
 xhY
-awi
+bcf
 nlf
 bkX
 ffM
@@ -136050,13 +136107,13 @@ xEw
 lEy
 bck
 aRE
-awi
+bcf
 nfS
 beW
 oer
 mfj
-aUZ
-bdV
+lqr
+fBM
 bej
 apG
 caT
@@ -136310,7 +136367,7 @@ biU
 rWz
 mWS
 arG
-cZU
+mWS
 aKY
 gxo
 bfW
@@ -137088,7 +137145,7 @@ bdV
 nzb
 vuR
 bBX
-caT
+fVn
 pVj
 dxa
 aaa
@@ -137345,7 +137402,7 @@ bwy
 ayL
 sAd
 ary
-caT
+fVn
 pji
 bkd
 aaa
@@ -137602,7 +137659,7 @@ bdV
 ayL
 bcJ
 mQR
-caT
+fVn
 aYR
 avA
 aaa
@@ -138116,7 +138173,7 @@ cbm
 hvG
 sXM
 phw
-aOn
+fVn
 gGX
 bkd
 aaQ
@@ -138373,11 +138430,11 @@ xHg
 cmg
 fVn
 sUq
-bcf
+fVn
 oSE
 ava
-aaa
-acm
+ava
+ava
 aaa
 aaa
 aaa
@@ -138630,14 +138687,14 @@ gDi
 bkp
 fVn
 hdj
-baG
+fVn
 bgb
-bkd
-aeo
-aeo
+cZU
+vgy
+ava
 acm
 aeo
-acm
+aaQ
 aaa
 aaa
 aaa
@@ -138883,16 +138940,16 @@ acm
 bEo
 bbi
 caT
-fVn
+aOn
 fVn
 caT
 maj
-xOP
+caT
 iYL
-bkd
-acm
-aaa
-aaa
+jTL
+exO
+ava
+cmJ
 aaa
 aaa
 aaa
@@ -139144,13 +139201,13 @@ cry
 aaa
 acm
 acm
-bkd
+cMW
 cNC
+avA
+avA
 ava
-aeo
-aaa
-aaa
-aaa
+lGO
+cmJ
 aaa
 aaa
 aaa
@@ -139404,9 +139461,9 @@ aaa
 acm
 bgf
 cmJ
-aaa
-aaa
-aaa
+cmJ
+lGO
+cmJ
 aaa
 aaa
 aaa
@@ -139661,7 +139718,7 @@ aaa
 acm
 acK
 aaa
-aaa
+cmJ
 aaa
 aaa
 aaa
@@ -139918,7 +139975,7 @@ aaa
 acK
 qDp
 acm
-aaa
+cmJ
 aaa
 aaa
 aaa
@@ -140426,11 +140483,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
+rSE
 acm
 aaa
 aaQ
-jTL
+eiW
 aaa
 aaa
 aaa
@@ -141715,7 +141772,7 @@ aaa
 acm
 aaa
 acm
-lGO
+qDp
 acK
 acK
 acK
@@ -141972,7 +142029,7 @@ aaa
 acm
 aaa
 aeo
-acm
+acK
 gpw
 pFC
 pFC
@@ -142229,7 +142286,7 @@ aaa
 aeo
 aaa
 aeo
-aaa
+baG
 pFC
 dyq
 xUP
@@ -142486,7 +142543,7 @@ aaa
 acm
 aaa
 aaQ
-aaa
+baG
 pFC
 pqf
 vzj
@@ -142743,7 +142800,7 @@ aaa
 aeo
 aaa
 aeo
-aaa
+baG
 pFC
 qBh
 wiR
@@ -143000,7 +143057,7 @@ aaa
 aeo
 aaa
 acm
-acm
+acK
 gpw
 pFC
 pFC
@@ -143257,7 +143314,7 @@ aaa
 acm
 aaa
 acm
-aaa
+baG
 aaa
 acK
 acK
@@ -143514,7 +143571,7 @@ acm
 acK
 acm
 acK
-acm
+acK
 aeo
 acm
 aaa
@@ -143771,7 +143828,7 @@ aaa
 acm
 aaa
 acm
-aaa
+baG
 aaa
 aaa
 aaa
@@ -144028,7 +144085,7 @@ aaa
 acm
 aaa
 aeo
-aaa
+fVj
 aaa
 aaa
 aaa
@@ -144285,7 +144342,7 @@ aaa
 acm
 aaa
 aeo
-aaa
+fVj
 aaa
 aaa
 aaa
@@ -144542,7 +144599,7 @@ aaa
 aeo
 aaa
 aaQ
-aaa
+fVj
 aaa
 aaa
 aaa
@@ -144799,7 +144856,7 @@ aaa
 aeo
 aaa
 acm
-aaa
+baG
 aaa
 aaa
 aaa
@@ -145056,7 +145113,7 @@ aaa
 acm
 aaa
 acm
-aaa
+xOP
 aaa
 aaa
 aaa
@@ -145313,7 +145370,7 @@ aaa
 acm
 aaa
 acm
-aaa
+xOP
 aaa
 aaa
 aaa
@@ -145570,7 +145627,7 @@ acm
 acK
 acm
 acK
-acm
+acK
 aeo
 aeo
 aaQ
@@ -145827,7 +145884,7 @@ aaa
 acm
 aaa
 acm
-aaa
+baG
 aaa
 aaa
 aaa
@@ -146084,7 +146141,7 @@ aaa
 aaQ
 aaa
 aeo
-aaa
+fVj
 aaa
 aaa
 aaa
@@ -146341,7 +146398,7 @@ aaa
 aaQ
 aaa
 aeo
-aaa
+fVj
 aaa
 aaa
 aaa
@@ -146598,7 +146655,7 @@ aaa
 aeo
 aaa
 acm
-aaa
+fVj
 aaa
 aaa
 aaa
@@ -146855,7 +146912,7 @@ aaa
 aeo
 aaa
 acm
-aaa
+baG
 aaa
 aaa
 aaa
@@ -147112,7 +147169,7 @@ aaa
 aeo
 aaa
 aaQ
-aaa
+fVj
 aaa
 aaa
 aaa
@@ -147369,7 +147426,7 @@ aaa
 acm
 aaa
 aaQ
-aaa
+baG
 aaa
 aaa
 aaa
@@ -147626,7 +147683,7 @@ aaa
 acK
 acm
 acK
-acm
+acK
 aeo
 aaa
 aaa
@@ -147883,7 +147940,7 @@ aaa
 aaQ
 aaa
 acm
-aaa
+xOP
 aaa
 aaa
 aaa
@@ -148140,7 +148197,7 @@ aaa
 acm
 aaa
 acm
-aaa
+xOP
 aaa
 aaa
 aeu
@@ -148396,8 +148453,8 @@ aeo
 aaQ
 acm
 aaa
-acm
-acm
+acK
+acK
 aaQ
 aeo
 ciQ

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -177,29 +177,17 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aaL" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/folder,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -4
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
 	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "aaM" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -467,9 +455,10 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "abL" = (
@@ -482,8 +471,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 1
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
@@ -757,12 +746,16 @@
 /turf/open/space,
 /area/space/nearstation)
 "acB" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/cytology)
 "acG" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -863,6 +856,11 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/scientist,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "acY" = (
@@ -997,12 +995,7 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "ads" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno_blastdoor";
-	name = "Xenobiology Containment Blast Door"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "adt" = (
@@ -1036,17 +1029,19 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "adx" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	glass = 1;
 	name = "Slime Euthanization Chamber";
 	opacity = 0;
 	req_access_txt = "55"
 	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/science/xenobiology)
+/area/science/cytology)
 "ady" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -1448,11 +1443,18 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "aeQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno_blastdoor";
+	name = "Xenobiology Containment Blast Door"
+	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "aeR" = (
@@ -1466,6 +1468,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "Containment Chamber Blast Door"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aeS" = (
@@ -1496,7 +1503,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/science/cytology)
 "aeY" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -1528,12 +1535,12 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "afb" = (
-/obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -1582,15 +1589,15 @@
 	},
 /area/maintenance/starboard/fore)
 "afk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Chamber"
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "afl" = (
@@ -1606,11 +1613,13 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to Chamber"
-	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afm" = (
@@ -1641,49 +1650,39 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/machinery/meter,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afq" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/binary/heat_pump/freezer{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "afr" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -1692,13 +1691,11 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/start/scientist,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afs" = (
@@ -1783,19 +1780,29 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to Chamber"
+/obj/machinery/button/door/directional/south{
+	id = "xeno5";
+	name = "Creature Cell 5 Toggle";
+	pixel_x = -24;
+	req_access_txt = "55"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afG" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/holopad,
 /obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afI" = (
@@ -1859,12 +1866,14 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
+	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "afX" = (
@@ -1890,13 +1899,25 @@
 /area/maintenance/starboard/fore)
 "aga" = (
 /obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/storage/box/beakers{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "agb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/effect/loot_site_spawner,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
 "agd" = (
@@ -1910,7 +1931,6 @@
 /area/security/warden)
 "age" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/sign/warning/xeno_mining{
 	pixel_y = 32
 	},
@@ -2080,7 +2100,13 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/chem_heater/withbuffer,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "agC" = (
 /obj/effect/turf_decal/bot,
@@ -2165,7 +2191,10 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
-/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "agT" = (
@@ -2178,11 +2207,22 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/requests_console/directional/north{
+	department = "Xenobiology";
+	departmentType = 2;
+	name = "Xenobiology Requests Console";
+	pixel_x = -32;
+	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
@@ -2243,6 +2283,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
+/obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ahb" = (
@@ -2288,15 +2329,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Creature Cell";
-	req_access_txt = "55"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/color/latex,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ahl" = (
@@ -2316,19 +2358,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ahm" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/loading_area/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "ahn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -2358,6 +2396,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ahp" = (
@@ -2378,6 +2417,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/cable,
+/obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aht" = (
@@ -2418,10 +2458,13 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "ahD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/processor/slime,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ahE" = (
@@ -2433,6 +2476,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -2520,13 +2564,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ahN" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin{
-	desc = "A pneumatic waste disposal unit. This one leads into space!";
-	name = "deathsposal unit"
-	},
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ahO" = (
@@ -2637,6 +2683,12 @@
 "aii" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/holopad,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "aik" = (
@@ -2862,21 +2914,29 @@
 	id = "xeno1";
 	name = "Creature Cell 1"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Creature Cell";
-	req_access_txt = "55"
-	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aiY" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/visible,
-/turf/closed/wall,
-/area/science/storage)
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/table,
+/obj/item/multitool/circuit{
+	pixel_x = -8
+	},
+/obj/item/multitool/circuit{
+	pixel_x = -4
+	},
+/obj/item/multitool/circuit,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "aiZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -2905,22 +2965,21 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/landmark/start/scientist,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ajd" = (
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "aje" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ajh" = (
@@ -2942,9 +3001,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 30
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -2954,13 +3010,11 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ajl" = (
@@ -2968,13 +3022,11 @@
 	id = "xeno3";
 	name = "Creature Cell 3"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Creature Cell";
-	req_access_txt = "55"
-	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ajn" = (
@@ -3068,6 +3120,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3170,6 +3223,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3189,6 +3243,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port/fore)
 "ajO" = (
@@ -3199,9 +3254,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/structure/grille/broken,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ajP" = (
@@ -3216,9 +3268,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/emcloset,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ajV" = (
@@ -3240,6 +3289,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3269,6 +3319,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3300,6 +3351,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/fore)
 "akg" = (
@@ -3314,6 +3366,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3325,9 +3378,6 @@
 "aki" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/ore_box,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "akj" = (
@@ -3342,25 +3392,27 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/fore)
 "akk" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Research Division"
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Research Division Delivery Access";
-	req_access_txt = "47"
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Genetics Lab Maintenance";
+	req_access_txt = "9"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "akl" = (
 /turf/closed/wall/r_wall/rust,
 /area/maintenance/port/aft)
@@ -3386,6 +3438,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -3407,6 +3460,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3422,6 +3476,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aku" = (
@@ -3433,6 +3490,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3459,6 +3517,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aky" = (
@@ -3471,6 +3530,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3484,6 +3544,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3492,23 +3553,18 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/starboard)
 "akB" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "akC" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -3529,6 +3585,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3565,6 +3622,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3712,6 +3770,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -3739,6 +3798,7 @@
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -3795,6 +3855,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3814,6 +3875,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -3833,6 +3895,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/fore)
 "alt" = (
@@ -3844,6 +3907,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -3892,6 +3956,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "alx" = (
@@ -3970,6 +4035,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "alD" = (
@@ -3995,6 +4061,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -4051,6 +4118,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno_blastdoor";
+	name = "Xenobiology Containment Blast Door"
+	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "alP" = (
@@ -4082,18 +4155,17 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
 /obj/machinery/light/directional/south,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
-	},
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/newscaster/security_unit/directional/south{
 	pixel_x = 28
+	},
+/obj/machinery/atmospherics/components/binary/heat_pump/freezer/on{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -4204,6 +4276,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4220,24 +4293,25 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/fore)
 "amm" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "amo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -4283,6 +4357,7 @@
 	pixel_y = -32
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4296,6 +4371,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4311,6 +4387,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4323,6 +4400,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -4356,6 +4434,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4368,6 +4447,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4381,6 +4461,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4398,16 +4479,12 @@
 	},
 /area/maintenance/starboard/fore)
 "amI" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno_blastdoor";
-	name = "Xenobiology Containment Blast Door"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold/orange,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "amK" = (
@@ -4422,6 +4499,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4494,9 +4573,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/south{
+	id = "xeno6";
+	name = "Creature Cell 6 Toggle";
+	pixel_x = 24;
+	req_access_txt = "55"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
@@ -4530,6 +4614,8 @@
 	dir = 1;
 	pixel_y = 24
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4543,6 +4629,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4584,6 +4671,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4798,6 +4886,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4814,6 +4903,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -4833,23 +4923,26 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/fore)
 "anS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Testing Lab Maintainance";
-	req_access_txt = "8"
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+/obj/machinery/component_printer,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "anT" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -4871,6 +4964,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4893,6 +4987,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anX" = (
@@ -4906,6 +5001,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4968,6 +5064,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4985,6 +5082,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5013,6 +5111,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -5033,6 +5132,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5099,6 +5199,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -5115,6 +5216,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aoO" = (
@@ -5125,6 +5227,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aoQ" = (
@@ -5139,6 +5242,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aoT" = (
@@ -5177,6 +5281,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "apa" = (
@@ -5211,6 +5317,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "apc" = (
@@ -5248,6 +5356,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "aph" = (
@@ -5332,6 +5442,8 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5342,6 +5454,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "apx" = (
@@ -5402,17 +5515,35 @@
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "apG" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/item/assembly/signaler{
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
+	pixel_x = 8;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/item/assembly/signaler{
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
+	pixel_x = 8;
+	pixel_y = 4
 	},
+/obj/item/assembly/signaler{
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
+/area/science/test_area)
 "apH" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/tile/neutral,
@@ -5470,20 +5601,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "apS" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "apT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5497,6 +5619,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5523,6 +5646,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -5539,6 +5663,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqa" = (
@@ -5553,6 +5678,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -5571,6 +5697,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port/fore)
 "aqd" = (
@@ -5598,6 +5725,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -5611,11 +5739,31 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/fore)
+"aql" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "aqm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -5660,6 +5808,7 @@
 	pixel_x = 32
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5689,6 +5838,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5698,6 +5848,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -5717,8 +5868,10 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/science/research)
 "aqC" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -5730,6 +5883,8 @@
 /obj/machinery/meter/atmos/layer4{
 	name = "gas flow meter"
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aqG" = (
@@ -5758,6 +5913,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqP" = (
@@ -5792,22 +5948,18 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "aqU" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/loading_area/red,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/start/roboticist,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aqV" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -5821,6 +5973,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5850,6 +6003,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/fore)
 "arg" = (
@@ -5861,6 +6015,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5870,6 +6025,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -5960,17 +6116,13 @@
 	},
 /area/maintenance/starboard/fore)
 "ary" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "Containment Chamber Blast Door"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 8
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "arz" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/tank/internals/emergency_oxygen/empty,
@@ -6016,6 +6168,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -6030,36 +6183,28 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron/dark,
-/area/science/genetics)
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "arH" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -6069,8 +6214,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/area/science/research)
 "arJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -6079,6 +6226,8 @@
 	pixel_x = -30
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "arK" = (
@@ -6305,6 +6454,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6398,6 +6548,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asL" = (
@@ -6409,6 +6560,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -6422,6 +6574,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asO" = (
@@ -6468,6 +6621,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -6491,6 +6645,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6536,6 +6691,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -6562,15 +6718,30 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
-"atq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "telelab";
-	name = "Test Chamber Blast Door"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
+"atq" = (
+/obj/structure/window/reinforced/tinted,
+/obj/item/storage/box/bodybags,
+/obj/structure/table,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "att" = (
 /obj/machinery/computer/rdservercontrol,
@@ -6590,6 +6761,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6605,6 +6777,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -6621,6 +6794,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6667,6 +6841,7 @@
 	sortType = 23
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atL" = (
@@ -6765,21 +6940,14 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "atV" = (
+/obj/item/radio/intercom/directional/east,
+/obj/structure/closet/wardrobe/robotics_black,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "atW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -6824,14 +6992,22 @@
 /turf/open/floor/engine/telecomms,
 /area/tcommsat/server)
 "aub" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "8;12"
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "aud" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
@@ -6844,6 +7020,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6857,6 +7034,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auf" = (
@@ -6880,6 +7058,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -6911,17 +7090,20 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
 "auk" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/box/red,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aul" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6933,6 +7115,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -6949,6 +7132,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6990,6 +7174,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -7004,9 +7189,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auz" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/rust,
-/area/maintenance/starboard)
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "auA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -7051,16 +7239,18 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	name = "rd sorting disposal pipe";
-	sortType = 13
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/area/science/research)
 "auH" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -7074,30 +7264,23 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "auJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/closet/l3closet/scientist,
+/obj/item/extinguisher,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/area/science/research)
 "auK" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -7106,19 +7289,11 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "auO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Research Division Server Room";
-	req_access_txt = "30"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/science/server)
 "auP" = (
 /obj/effect/spawner/structure/window,
@@ -7133,9 +7308,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -7157,9 +7329,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -7179,6 +7348,8 @@
 /obj/machinery/meter/atmos/layer2{
 	name = "gas flow meter"
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -7207,6 +7378,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -7227,6 +7400,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -7264,6 +7438,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -7559,6 +7734,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -7606,6 +7782,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "awi" = (
@@ -7623,6 +7800,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -7649,6 +7827,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -7666,6 +7845,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -7684,6 +7864,7 @@
 	sortType = 14
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awr" = (
@@ -7698,27 +7879,30 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aws" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/area/science/research)
 "aww" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -7740,22 +7924,17 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
 "awB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "awG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7766,6 +7945,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "awH" = (
@@ -7801,6 +7981,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -7815,6 +7996,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -8011,30 +8193,41 @@
 /area/medical/medbay/central)
 "axK" = (
 /obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/camera{
+	c_tag = "Robotics Lab";
+	name = "science camera";
+	network = list("ss13","rd")
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "axL" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "8"
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/area/science/research)
 "axN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8055,15 +8248,20 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "axR" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "Containment Chamber Blast Door"
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/hidden,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "aya" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -8081,6 +8279,8 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -8099,6 +8299,8 @@
 	pixel_y = 28
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -8168,13 +8370,19 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ayp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "ayq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -8182,6 +8390,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -8195,18 +8405,24 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ayv" = (
 /obj/effect/turf_decal/box,
+/obj/machinery/light/floor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ayw" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/science/genetics)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "ayy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -8251,17 +8467,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayL" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "Containment Chamber Blast Door"
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/sign/warning/biohazard{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "ayO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -8297,26 +8516,14 @@
 	},
 /area/maintenance/port/fore)
 "ayT" = (
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple,
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "ayU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -8378,6 +8585,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -8472,21 +8680,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "azt" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/turf/closed/wall,
+/area/science/cytology)
 "azv" = (
 /turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -8495,17 +8690,18 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "azG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 5
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "azH" = (
 /obj/effect/turf_decal/siding/purple{
@@ -8516,36 +8712,36 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "azI" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/binary/heat_pump/heater{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
-"azL" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
+"azL" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	name = "rd sorting disposal pipe";
+	sortType = 13
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/area/science/research)
 "azM" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -8553,6 +8749,12 @@
 /obj/machinery/light_switch/directional/south,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/heat_pump/freezer/on{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = -26
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -8579,6 +8781,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -8710,24 +8913,22 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "aAo" = (
-/obj/effect/turf_decal/box,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
-"aAp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Genetics Lab";
-	req_access_txt = "47, 9"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/purple/corner,
-/obj/effect/turf_decal/siding/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/science/genetics)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"aAp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "aAz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -8746,21 +8947,39 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/fore)
 "aAC" = (
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "aAF" = (
-/obj/machinery/aug_manipulator,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light_switch/directional/east,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aAG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8782,6 +9001,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aAJ" = (
@@ -8824,19 +9044,9 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore)
 "aAS" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/obj/machinery/atmospherics/pipe/layer_manifold/orange,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "aAV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -8853,10 +9063,14 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/server)
 "aBe" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/box,
 /obj/machinery/holopad,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aBi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -8928,6 +9142,26 @@
 	luminosity = 2
 	},
 /area/science/robotics/mechbay)
+"aBD" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "aBE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -9026,14 +9260,19 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple/corner,
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
-"aBX" = (
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
+"aBX" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -9041,16 +9280,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/red,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aCa" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -9060,14 +9302,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/red,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aCe" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
@@ -9077,35 +9324,41 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
+/obj/effect/turf_decal/siding/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aCh" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/junction,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aCi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
 "aCn" = (
@@ -9125,6 +9378,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -9198,6 +9452,7 @@
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aCG" = (
@@ -9227,11 +9482,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aCK" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -9241,7 +9491,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aCM" = (
@@ -9307,11 +9568,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aDe" = (
@@ -9365,14 +9630,22 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aDs" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aDw" = (
@@ -9419,6 +9692,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -9436,6 +9710,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -9465,6 +9740,8 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aDS" = (
@@ -9498,6 +9775,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aDY" = (
@@ -9662,46 +9940,68 @@
 	},
 /area/maintenance/starboard/fore)
 "aEy" = (
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/robotics/lab)
 "aEB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aEG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/structure/table,
+/obj/item/circular_saw,
+/obj/item/scalpel{
+	pixel_y = 16
+	},
+/obj/item/hemostat,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
-"aEH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
+"aEH" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 4
+	},
+/obj/item/toy/figure/geneticist{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "aEK" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/rust,
@@ -9721,16 +10021,17 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore)
 "aEP" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/siding/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/vending/wardrobe/robo_wardrobe,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/obj/structure/rack,
+/turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aER" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9816,6 +10117,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -9834,7 +10136,7 @@
 	},
 /area/maintenance/port)
 "aFl" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold/orange,
 /turf/closed/wall,
 /area/medical/exam_room)
 "aFp" = (
@@ -9928,6 +10230,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/execution/education)
+"aFA" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aFC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -9946,10 +10253,20 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aFF" = (
+/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/starboard)
 "aFI" = (
 /turf/closed/wall,
@@ -10004,37 +10321,18 @@
 /turf/open/floor/engine/telecomms,
 /area/tcommsat/server)
 "aFY" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/research)
+/turf/closed/wall/r_wall,
+/area/science/cytology)
 "aGb" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/maintenance/starboard)
 "aGc" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
@@ -10047,6 +10345,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;5;39"
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "aGj" = (
@@ -10221,15 +10520,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/execution/education)
 "aHM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -10237,9 +10527,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aHN" = (
@@ -10275,6 +10563,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/red/corner,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aHQ" = (
@@ -10367,6 +10658,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "aIf" = (
@@ -10388,6 +10681,8 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aIh" = (
@@ -10406,6 +10701,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aIk" = (
@@ -10429,15 +10726,21 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aIr" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -10638,6 +10941,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aKb" = (
@@ -10662,18 +10966,9 @@
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/fore)
 "aKf" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/obj/machinery/modular_computer/console/preset/civilian,
+/turf/open/floor/iron/dark,
+/area/science/explab)
 "aKg" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/neutral,
@@ -10775,6 +11070,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "aKz" = (
@@ -10849,14 +11145,25 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aKM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aKR" = (
@@ -10904,15 +11211,17 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "aKY" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "aKZ" = (
@@ -11177,18 +11486,19 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/supply)
 "aLO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/siding/red{
+	dir = 5
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/area/science/robotics/lab)
 "aLQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -11362,19 +11672,26 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aMz" = (
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/purple/end{
+	dir = 1
+	},
+/obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "aMA" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -11387,23 +11704,25 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "aMC" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/storage)
 "aME" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
@@ -11427,33 +11746,21 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/aft)
 "aMN" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/obj/machinery/button/ignition/incinerator/toxmix{
-	pixel_x = -6;
-	pixel_y = 30
-	},
-/obj/machinery/button/door/incinerator_vent_toxmix{
-	pixel_x = 8;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing/chamber)
+/area/science/research)
 "aMP" = (
 /obj/structure/chair{
 	dir = 8
@@ -11676,6 +11983,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aNU" = (
@@ -11828,7 +12136,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aOi" = (
@@ -11893,17 +12201,9 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "aOn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/science/test_area)
 "aOo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -11971,38 +12271,38 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aOs" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "aOt" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "aOv" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -12018,18 +12318,22 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "aOw" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "aOx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -12097,20 +12401,21 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "aOD" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "aOE" = (
 /obj/structure/water_source/puddle,
 /obj/structure/flora/ausbushes/reedbush{
@@ -12119,14 +12424,16 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "aOF" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent";
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "aOG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -12179,22 +12486,23 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/paramedic)
 "aOJ" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/meter,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple{
 	dir = 10
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/dark/visible,
-/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing/chamber)
+/area/science/genetics)
 "aOK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -12244,77 +12552,75 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aOQ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 8
-	},
-/obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing/chamber)
-"aOS" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/meter,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/green/visible,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing/chamber)
-"aOT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Toxins Lab Maintenance";
-	req_access_txt = "8"
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/sign/directions/evac{
-	dir = 4;
-	pixel_y = 24
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"aOS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno5";
+	name = "Creature Cell 5"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/science/cytology)
+"aOT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
+"aOU" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
-"aOU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 5
 	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "aOZ" = (
 /turf/closed/wall,
 /area/medical/storage)
@@ -12387,6 +12693,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "aPk" = (
@@ -12426,13 +12733,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aPm" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
 	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron/dark,
-/area/science/mixing/chamber)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aPo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -12742,6 +13050,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aQf" = (
@@ -12799,6 +13109,8 @@
 /obj/effect/turf_decal/siding/blue/corner,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aQo" = (
@@ -12944,6 +13256,8 @@
 /obj/machinery/modular_computer/console/preset/cargochat/medical{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aQD" = (
@@ -13265,7 +13579,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/camera{
 	c_tag = "Research Division";
 	dir = 1;
@@ -13277,6 +13590,15 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 6
+	},
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aRr" = (
@@ -13418,14 +13740,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aRC" = (
@@ -13437,28 +13759,35 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/lobby)
 "aRD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "aRE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "aRF" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -13582,6 +13911,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "aRN" = (
@@ -13621,8 +13951,14 @@
 	},
 /area/maintenance/aft)
 "aRR" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aRS" = (
 /obj/effect/turf_decal/tile/blue,
@@ -13750,21 +14086,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/lobby)
 "aSm" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/genetics)
 "aSn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -13914,16 +14238,8 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "aSK" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/turf/closed/wall,
+/area/science/circuits)
 "aSO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -13944,9 +14260,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "aSQ" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
-/area/science/test_area)
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "8;12"
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "aSR" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-18"
@@ -13969,6 +14294,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -13994,6 +14320,9 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "aSW" = (
@@ -14043,6 +14372,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "aTf" = (
@@ -14072,6 +14403,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "aTh" = (
@@ -14087,26 +14420,15 @@
 /area/medical/virology)
 "aTk" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aTn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/obj/effect/turf_decal/bot_red,
+/turf/closed/wall/r_wall,
+/area/science/server)
 "aTo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -14123,6 +14445,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "aTp" = (
@@ -14143,16 +14467,24 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "aTr" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/science/robotics/lab)
 "aTs" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -14169,6 +14501,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aTt" = (
@@ -14184,6 +14518,8 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aTu" = (
@@ -14270,21 +14606,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/lobby)
 "aTE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics_shutters";
+	name = "Robotics Privacy Shutters"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/turf/open/floor/plating,
+/area/science/robotics/lab)
 "aTF" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -14391,18 +14719,30 @@
 /area/maintenance/port/fore)
 "aTU" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
-	req_access_txt = "8"
-	},
-/obj/structure/sign/warning/explosives/alt{
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	id_tag = "ResearchInt";
+	name = "Research Division";
+	req_one_access_txt = "47"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/explab)
 "aTV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
@@ -14445,20 +14785,17 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "aTZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/science/explab)
 "aUd" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -14530,21 +14867,25 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/central)
 "aUr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small/directional/north,
+/obj/item/raw_anomaly_core/random{
+	pixel_x = 8;
+	pixel_y = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/item/raw_anomaly_core/random{
+	pixel_x = -8;
+	pixel_y = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/obj/item/raw_anomaly_core/random,
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "aUx" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -14628,23 +14969,18 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "aUO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/clipboard,
+/obj/item/taperecorder{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/turf/open/floor/iron/dark,
+/area/science/explab)
 "aUP" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall/rust,
@@ -14711,26 +15047,24 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "aUY" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/circuits)
 "aUZ" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "mass driver intersection";
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/mixing)
 "aVc" = (
 /obj/structure/chair/office/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -14742,22 +15076,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "aVd" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/siding/red{
+	dir = 10
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/item/multitool,
-/obj/item/storage/toolbox/electrical,
-/obj/item/multitool{
-	pixel_x = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/iron/dark,
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aVf" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -14808,6 +15138,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -14847,6 +15178,8 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "aVo" = (
@@ -15186,6 +15519,8 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aWv" = (
@@ -15247,6 +15582,8 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "aWI" = (
@@ -15291,18 +15628,22 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
 "aWN" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "mass driver intersection";
-	req_access_txt = "12"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "aWO" = (
 /obj/structure/table/wood,
 /obj/item/paper/guides/jobs/security/courtroom,
@@ -15330,21 +15671,32 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "aWW" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/dna_scannernew,
-/turf/open/floor/iron/dark,
-/area/science/genetics)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "aWY" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
 "aXa" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aXb" = (
@@ -15353,13 +15705,14 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "aXe" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/turf_decal/delivery/red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aXj" = (
@@ -15369,8 +15722,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/science/genetics)
 "aXl" = (
-/turf/closed/wall/r_wall/rust,
-/area/science/mixing)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "aXn" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
@@ -15393,32 +15750,66 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "aXs" = (
-/obj/machinery/door/poddoor/incinerator_toxmix,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
-"aXt" = (
-/obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
-"aXx" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/test_area)
+"aXt" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags{
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/stack/package_wrap,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
+"aXx" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "aXy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -15427,35 +15818,37 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/research)
+/area/science/robotics/lab)
 "aXA" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/tank_dispenser,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/grass,
+/area/science/genetics)
 "aXE" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
-	},
-/obj/structure/window/spawner/west,
-/obj/structure/window/spawner/north,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aXH" = (
@@ -15483,53 +15876,58 @@
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aXJ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
-"aXK" = (
-/obj/effect/decal/remains/human,
-/obj/machinery/sparker/toxmix{
-	name = "chamber igniter";
-	pixel_x = -16
-	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
-"aXM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
-"aXN" = (
-/obj/machinery/igniter/incinerator_toxmix,
-/mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
-	desc = "A timeless classic.";
-	name = "Kentucky"
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/explab)
+"aXK" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe,
+/obj/item/flashlight/pen,
+/obj/item/folder/white,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
+"aXM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
+"aXN" = (
+/obj/machinery/light/directional/north,
+/obj/structure/mirror/directional/north,
+/obj/machinery/shower,
+/obj/structure/lattice/catwalk/plated/dark,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/science/genetics)
 "aXO" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -15549,7 +15947,18 @@
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aXQ" = (
 /obj/structure/table,
@@ -15607,23 +16016,15 @@
 /turf/closed/wall/rust,
 /area/maintenance/starboard/fore)
 "aXX" = (
-/obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "Containment Chamber Blast Door"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/dark,
-/area/science/research)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "aXY" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -15653,16 +16054,14 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "aYc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/box/corners,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent";
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "aYd" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -15678,44 +16077,31 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "aYi" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard)
-"aYj" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 4
+/obj/structure/chair/comfy{
+	dir = 4
 	},
-/obj/item/storage/pill_bottle/mannitol,
-/obj/item/toy/figure/geneticist{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/siding/purple/corner,
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/science/research)
+"aYj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "aYk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -15730,20 +16116,22 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "aYn" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/purple/end,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing/chamber)
+/area/science/circuits)
 "aYo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -15753,6 +16141,8 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "aYr" = (
@@ -15799,12 +16189,6 @@
 /area/hallway/primary/port)
 "aYA" = (
 /obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -15813,6 +16197,15 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aYB" = (
@@ -15882,7 +16275,6 @@
 	},
 /area/maintenance/central)
 "aYN" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -15893,7 +16285,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/component_printer,
+/obj/structure/chair/comfy,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aYO" = (
@@ -15917,20 +16309,26 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aYR" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/integrated_circuit/loaded/hello_world,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/structure/window/spawner/west,
-/turf/open/floor/iron/dark,
-/area/science/research)
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "aYS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -15945,7 +16343,6 @@
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aYT" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -15957,17 +16354,17 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/multitool/circuit{
-	pixel_x = -8
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/item/multitool/circuit{
-	pixel_x = -4
+/obj/item/pen,
+/obj/item/storage/pill_bottle/dice{
+	desc = "A weathered and well used dice bag, it has seen many a tabletop session."
 	},
-/obj/item/multitool/circuit,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aYU" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15978,7 +16375,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/module_duplicator,
+/obj/structure/chair/comfy{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aYY" = (
@@ -16002,14 +16401,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "aYZ" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/area/maintenance/starboard)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "aZa" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
@@ -16049,6 +16449,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -16077,17 +16479,25 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "aZg" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/science_wardrobe,
+/obj/machinery/button/door/incinerator_vent_toxmix{
+	pixel_x = 8;
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/ignition/incinerator/toxmix{
+	pixel_x = -6;
+	pixel_y = 30
+	},
 /turf/open/floor/iron/dark,
-/area/science/lab)
+/area/science/mixing)
 "aZh" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 8
@@ -16105,23 +16515,25 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "aZn" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -16262,11 +16674,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/item/analyzer,
-/obj/item/analyzer,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aZF" = (
@@ -16282,9 +16693,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/scientist,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "aZH" = (
@@ -16444,37 +16855,32 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
 "aZT" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "aZU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/item/surgical_drapes,
-/obj/item/retractor,
-/obj/item/cautery,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -16516,27 +16922,25 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/jukebox,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aZZ" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "bae" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -16583,28 +16987,26 @@
 /turf/closed/wall,
 /area/science/robotics/lab)
 "bai" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/robotics/lab)
-"baj" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/siding/red{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 16
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/item/hemostat,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
+"baj" = (
+/obj/structure/chair/sofa/left{
+	color = "#c45c57";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -16641,12 +17043,14 @@
 /turf/closed/wall/rust,
 /area/science/robotics/mechbay)
 "baq" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = 32
+/obj/structure/table,
+/obj/item/storage/box/disks{
+	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/obj/item/clothing/gloves/color/latex,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "bas" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16707,10 +17111,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "bay" = (
@@ -16727,18 +17127,12 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
 "baz" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/loading_area{
-	dir = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "baA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
@@ -16755,88 +17149,27 @@
 	},
 /area/maintenance/central)
 "baC" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "baD" = (
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/transfer_valve{
-	pixel_x = -4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/green/visible,
+/obj/machinery/airalarm/mixingchamber{
+	dir = 8;
+	pixel_x = -8
 	},
-/obj/item/transfer_valve{
-	pixel_x = -4
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 4
-	},
-/obj/item/transfer_valve{
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "baE" = (
-/obj/structure/table/reinforced,
-/obj/item/wirecutters{
-	pixel_y = 5
-	},
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	desc = "A small electronic device able to ignite combustible substances. This one goes slightly to the right.";
-	pixel_x = 6
-	},
-/obj/item/assembly/igniter{
-	desc = "A small electronic device able to ignite combustible substances. This one goes slightly to the right.";
-	pixel_x = 6
-	},
-/obj/item/assembly/igniter{
-	desc = "A small electronic device able to ignite combustible substances. This one goes slightly to the right.";
-	pixel_x = 6
-	},
-/obj/item/assembly/igniter{
-	desc = "A small electronic device able to ignite combustible substances. This one goes slightly to the right.";
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
+/obj/machinery/bounty_board/directional/west,
+/obj/structure/table,
+/obj/item/modular_computer/laptop/preset/civilian,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/explab)
 "baF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -16853,10 +17186,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "baG" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall,
+/area/science/test_area)
 "baH" = (
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
@@ -16865,30 +17197,40 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "baK" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/modular_computer/console/preset/cargochat/science,
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/explab)
 "baL" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/server)
 "baN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/book/manual/wiki/toxins{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/area/maintenance/starboard)
+/obj/item/clothing/mask/gas{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas,
+/obj/machinery/requests_console/directional/south{
+	department = "Toxins Lab";
+	departmentType = 2;
+	name = "Toxins Lab Requests Console";
+	receive_ore_updates = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "baP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -16917,17 +17259,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "baS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/storage)
 "baU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16944,20 +17280,55 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "baX" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input,
-/obj/machinery/sparker/toxmix{
-	name = "chamber igniter";
-	pixel_x = -16
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "baY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "bba" = (
-/turf/closed/wall,
-/area/science/storage)
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
 "bbb" = (
 /turf/closed/wall,
 /area/security/checkpoint/science/research)
@@ -16966,7 +17337,7 @@
 /area/science/storage)
 "bbd" = (
 /turf/closed/wall/r_wall/rust,
-/area/science/storage)
+/area/science/circuits)
 "bbe" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -17020,34 +17391,27 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "bbj" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/cell_charger{
-	pixel_y = 5
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/item/stock_parts/cell/high,
+/obj/structure/window/reinforced,
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "bbk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/structure/sink{
+	pixel_y = 29
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/science/cytology)
 "bbl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17058,89 +17422,87 @@
 /turf/open/floor/iron/dark,
 /area/science/research)
 "bbm" = (
-/obj/structure/table/reinforced,
-/obj/item/assembly/timer{
-	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock. But slightly shifted to the left.";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler{
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler{
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler{
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler{
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
-"bbn" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins Mixers";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/purple/end{
+	dir = 1
+	},
+/obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
+/area/science/explab)
+"bbn" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/machinery/duct,
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"bbt" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"bbu" = (
+/obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"bbw" = (
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/science/mixing)
-"bbt" = (
-/obj/machinery/air_sensor/atmos/toxins_mixing_tank,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
-"bbu" = (
-/turf/closed/wall/r_wall/rust,
-/area/science/mixing/chamber)
-"bbw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/area/science/genetics)
 "bbx" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -17170,27 +17532,40 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "bbC" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/airlock_sensor/incinerator_toxmix{
-	pixel_x = -24
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
-"bbD" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"bbD" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "bbH" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
@@ -17201,13 +17576,52 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bbK" = (
-/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/structure/cable,
+/obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "bbN" = (
-/turf/closed/wall,
-/area/science/mixing)
+/obj/machinery/door/airlock/research{
+	name = "Circuit Testing Lab";
+	req_access_txt = "47"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
 "bbP" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/bot,
@@ -17221,14 +17635,9 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "bbQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass{
-	name = "Robotics Lab";
-	req_access_txt = "29"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics_shutters";
-	name = "Robotics Privacy Shutters"
+/obj/effect/turf_decal/box/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -17244,18 +17653,17 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "bbS" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "bbU" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -17287,33 +17695,72 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "bbW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
-"bbX" = (
-/obj/structure/sign/warning/fire,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/dark/visible,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
-"bbY" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/explab)
+"bbX" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"bbY" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "bca" = (
-/obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
 "bcb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -17328,43 +17775,50 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "bcc" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/maintenance/starboard)
 "bcd" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/hand_labeler,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/explab)
 "bce" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light/directional/north,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/explab)
 "bcf" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/mixing/chamber)
-"bcg" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/research{
+	name = "Testing Lab";
+	req_access_txt = "8"
+	},
 /turf/open/floor/iron/dark,
-/area/science/mixing/chamber)
+/area/science/test_area)
+"bcg" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "bch" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -17381,22 +17835,17 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "bcj" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/light/directional/south,
+/obj/structure/mirror/directional/south,
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/mixing/chamber)
+/obj/structure/lattice/catwalk/plated/dark,
+/turf/open/floor/plating,
+/area/science/genetics)
 "bck" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -17405,12 +17854,7 @@
 "bcl" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "bcn" = (
@@ -17436,53 +17880,33 @@
 "bcr" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
-"bcs" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Toxins Pumps";
-	dir = 1;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
-"bct" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
-"bcu" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"bcs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/circuits)
+"bct" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/storage)
+"bcu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "bcw" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 1
@@ -17514,8 +17938,24 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bcD" = (
-/turf/closed/wall/rust,
-/area/science/mixing)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "bcE" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -17523,8 +17963,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -17554,51 +17992,52 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "bcI" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/purple/end{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"bcJ" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
-"bcJ" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/area/science/test_area)
 "bcK" = (
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bcL" = (
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/book/manual/wiki/toxins{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/computer/cargo/request,
+/obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/explab)
 "bcM" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bcO" = (
 /obj/effect/turf_decal/tile/purple,
@@ -17614,28 +18053,25 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "bcR" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/sign/warning/explosives/alt{
-	pixel_x = -32
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/circuits)
 "bcW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17657,11 +18093,12 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "bdd" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bde" = (
@@ -17686,20 +18123,32 @@
 	},
 /area/maintenance/central)
 "bdh" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
-"bdj" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/research{
+	name = "Genetics Lab";
+	req_access_txt = "47, 9"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/genetics)
+"bdj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 24
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bdl" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -17802,19 +18251,26 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bdF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "bdG" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -17909,15 +18365,21 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdR" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/requests_console/directional/east{
+	department = "Robotics";
+	departmentType = 2;
+	name = "Robotics Requests Console";
+	receive_ore_updates = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/science/robotics/lab)
 "bdT" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
@@ -18044,58 +18506,43 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bee" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
-"bef" = (
-/obj/effect/turf_decal/loading_area{
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
-"beg" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
+"bef" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple/end{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/storage)
+/area/science/circuits)
+"beg" = (
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
 "bei" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -18123,84 +18570,101 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "bek" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Lab";
+	req_access_txt = "8"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/warning/explosives/alt{
+	pixel_y = -32
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/circuits)
 "bem" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
-"beo" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
-"bep" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
+"beo" = (
+/obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"bep" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "beq" = (
-/obj/effect/turf_decal/loading_area{
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/siding/purple,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/storage)
+/area/science/circuits)
 "ber" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/fire{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "beu" = (
@@ -18235,19 +18699,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "bex" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
-	req_access_txt = "8"
-	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/explab)
 "bey" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/line,
@@ -18306,45 +18760,59 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/compact_remote,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/effect/turf_decal/bot,
-/obj/structure/window/spawner/west,
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "beH" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/test_area)
-"beI" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -32
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno4";
+	name = "Creature Cell 4"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Creature Cell";
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Closet";
+	dir = 1;
+	name = "xenobiology camera";
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/xenobiology)
+"beI" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Research Division"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Research Division Delivery Access";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "beJ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "beK" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
@@ -18428,32 +18896,27 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "beS" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "beT" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/loading_area{
-	dir = 1;
-	pixel_y = 5
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/storage)
+/area/science/circuits)
 "beV" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -18471,11 +18934,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "beW" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
+/area/science/mixing)
 "beX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -18485,7 +18948,7 @@
 "beY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/science/cytology)
 "bff" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -18498,11 +18961,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -18511,13 +18971,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "bfj" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen,
-/obj/item/pickaxe,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bfk" = (
@@ -18560,13 +19021,13 @@
 "bfr" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
-/area/science/mixing)
+/area/science/explab)
 "bfs" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/science/xenobiology)
+/area/science/cytology)
 "bft" = (
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/engine,
@@ -18580,6 +19041,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bfv" = (
@@ -18604,13 +19066,8 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bfx" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -18721,19 +19178,23 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "bfM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
-/obj/structure/grille/broken,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "bfN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -18760,56 +19221,45 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "bfP" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
-	dir = 9
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "bfQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/pipe_dispenser,
+/obj/item/wrench,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/grille/broken,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard)
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "bfU" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bfW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "bfX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "bfY" = (
 /obj/machinery/camera{
@@ -18817,6 +19267,7 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bgb" = (
@@ -18851,6 +19302,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bgh" = (
@@ -18879,13 +19331,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/computer/cargo/request{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
+/obj/item/experi_scanner{
+	pixel_x = -4
 	},
-/turf/open/floor/iron/dark,
+/obj/item/experi_scanner,
+/obj/item/experi_scanner{
+	pixel_x = 4
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "bgo" = (
 /obj/effect/turf_decal/tile/purple{
@@ -18893,8 +19351,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
@@ -18934,15 +19390,18 @@
 /area/maintenance/port)
 "bgt" = (
 /obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -18972,13 +19431,17 @@
 "bgw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/l3closet/scientist,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/extinguisher,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/extinguisher{
+	pixel_y = 4
+	},
+/obj/item/extinguisher{
+	pixel_x = -4
+	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "bgx" = (
@@ -18990,53 +19453,29 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/microscope{
-	pixel_x = -1;
-	pixel_y = 1
-	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "bgy" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/research{
-	name = "Testing Lab";
-	req_access_txt = "8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/rnd/server,
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/science/server)
+"bgA" = (
+/obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/test_area)
-"bgA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
+/turf/open/floor/engine,
+/area/science/cytology)
 "bgB" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/structure/window/reinforced{
+/obj/structure/window/reinforced/tinted{
 	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/obj/item/clothing/suit/hooded/techpriest,
+/obj/item/clothing/head/hooded/techpriest,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -19090,6 +19529,13 @@
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
@@ -19145,12 +19591,11 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Computers";
-	dir = 8;
-	name = "xenobiology camera";
-	network = list("ss13","rd","xeno")
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
@@ -19174,11 +19619,12 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/landmark/start/scientist,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "bgU" = (
@@ -19186,10 +19632,23 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "bha" = (
 /turf/closed/wall/r_wall/rust,
@@ -19217,6 +19676,7 @@
 	sortType = 3
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bhf" = (
@@ -19234,6 +19694,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/starboard)
 "bhh" = (
@@ -19253,6 +19714,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "bhi" = (
@@ -19269,15 +19731,16 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "bhj" = (
-/obj/effect/turf_decal/box/corners,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "bhk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -19294,6 +19757,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bhl" = (
@@ -19301,8 +19765,11 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "bhn" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
+/obj/structure/window/reinforced,
+/mob/living/simple_animal/slime,
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/box,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bho" = (
 /obj/effect/landmark/xeno_spawn,
@@ -19321,6 +19788,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -19341,13 +19809,13 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
 "bhu" = (
-/mob/living/simple_animal/slime,
-/turf/open/floor/engine,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bhv" = (
 /obj/machinery/camera{
@@ -19355,11 +19823,13 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/cytology)
 "bhw" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -19371,6 +19841,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "bhy" = (
@@ -19385,59 +19856,51 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
 "bhz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/item/storage/box/lights/mixed,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 5";
+	dir = 4;
+	name = "xenobiology camera";
+	network = list("ss13","rd","xeno")
 	},
-/area/maintenance/starboard)
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "bhA" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/surgery/room_b)
 "bhB" = (
-/obj/structure/table,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 10;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/book/manual/wiki/robotics_cyborgs,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
-"bhC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
+"bhC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bhE" = (
@@ -19445,14 +19908,6 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/grille/broken,
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -19497,13 +19952,6 @@
 "bhY" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -19523,13 +19971,6 @@
 "bib" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -19543,6 +19984,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bih" = (
@@ -19662,18 +20104,29 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "biU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research{
-	name = "Genetics Lab";
-	req_access_txt = "47, 9"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/science/genetics)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west{
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "biV" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -19887,6 +20340,31 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bkp" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 8;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("toxins");
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "bkx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
@@ -20687,13 +21165,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bpC" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "bpD" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -21152,6 +21626,20 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"bsb" = (
+/obj/effect/landmark/start/roboticist,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/south{
+	id = "robotics_shutters";
+	name = "Robotics Shutter Toggle";
+	pixel_x = 24;
+	req_access_txt = "29"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "bsf" = (
 /obj/structure/sign/departments/custodian,
 /turf/closed/wall,
@@ -21692,6 +22180,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"bwa" = (
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "bwe" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/xenobiology)
@@ -21733,6 +22228,19 @@
 "bwu" = (
 /turf/closed/wall/rust,
 /area/security/processing)
+"bwy" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "bwz" = (
 /turf/closed/wall/rust,
 /area/security/checkpoint/supply)
@@ -21830,9 +22338,32 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bxn" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
-/area/science/storage)
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "bxp" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -22978,13 +23509,14 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bBX" = (
-/obj/machinery/door/poddoor{
-	id = "toxinsdriver";
-	name = "Toxins Launcher Bay Door"
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/area/science/test_area)
 "bBY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -23270,6 +23802,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"bEo" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "bEp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -25237,6 +25773,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/maintenance/port/aft)
 "bNp" = (
@@ -25393,6 +25930,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -25855,18 +26393,20 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "bPE" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins Launch Site";
+	name = "science camera";
+	network = list("ss13","rd")
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/obj/structure/tank_dispenser,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "bPI" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
@@ -26380,20 +26920,11 @@
 "bQW" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/red,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "bQX" = (
@@ -26546,6 +27077,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bRl" = (
@@ -30343,15 +30875,14 @@
 	},
 /area/maintenance/port/aft)
 "cbg" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/maintenance/starboard)
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "cbh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30392,9 +30923,20 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cbm" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "cbn" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -32334,22 +32876,15 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/aft)
 "chg" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/heat_pump/heater{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "chi" = (
 /obj/item/reagent_containers/food/drinks/bottle/rum{
 	pixel_x = -7;
@@ -33162,21 +33697,19 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/execution/education)
 "cjV" = (
-/obj/machinery/door/window/southleft{
-	name = "Mass Driver Door";
-	req_access_txt = "7"
-	},
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/vending/assist,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "cjZ" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -33862,17 +34395,18 @@
 	},
 /area/maintenance/port/aft)
 "cmg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/modular_computer/console/preset/cargochat/science{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/science/research)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "cmh" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall,
@@ -34186,6 +34720,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -35144,10 +35679,8 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal)
 "cqw" = (
-/obj/structure/sign/warning/deathsposal{
-	layer = 4
-	},
-/turf/closed/wall,
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "cqx" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -36110,11 +36643,13 @@
 	},
 /area/maintenance/fore)
 "cuf" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/loot_site_spawner,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cuh" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -36320,15 +36855,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/port/aft)
 "cuG" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno_blastdoor";
-	name = "Xenobiology Containment Blast Door"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cuH" = (
@@ -39412,29 +39942,15 @@
 	},
 /area/maintenance/disposal)
 "cHF" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 4
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "cHH" = (
 /obj/machinery/door/airlock/external{
@@ -39472,23 +39988,17 @@
 	},
 /area/maintenance/aft)
 "cId" = (
-/obj/structure/grille/broken,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/fore)
+/turf/closed/wall/r_wall,
+/area/science/cytology)
 "cIe" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "xenobiology maintenance";
-	req_access_txt = "55"
-	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/closet/secure_closet/cytology,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/maintenance/starboard/fore)
+/area/science/cytology)
 "cIf" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
@@ -39504,13 +40014,9 @@
 	},
 /area/security/execution/education)
 "cIh" = (
-/obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall/r_wall,
+/area/science/cytology)
 "cIi" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/sign/plaques/kiddie/library{
@@ -39961,6 +40467,7 @@
 	dir = 8;
 	pixel_y = 32
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -40096,15 +40603,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cLp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/component_printer,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "cLq" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 1
@@ -40273,6 +40784,27 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/chemistry)
+"cMp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "cMq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -40356,18 +40888,12 @@
 	},
 /area/engineering/gravity_generator)
 "cMW" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard)
 "cNa" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -40375,9 +40901,6 @@
 "cNd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -40481,12 +41004,15 @@
 /turf/closed/wall/r_wall/rust,
 /area/maintenance/solars/starboard/fore)
 "cNC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/girder/displaced,
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "cNE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -40500,7 +41026,14 @@
 /area/maintenance/starboard)
 "cNH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNN" = (
@@ -40551,11 +41084,6 @@
 	},
 /area/maintenance/starboard)
 "cNY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "Director's Privacy Blast Door"
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNZ" = (
@@ -40584,20 +41112,34 @@
 	},
 /area/maintenance/starboard)
 "cOn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 28
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
+"cOo" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
-"cOo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "cOp" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
@@ -40608,7 +41150,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/loot_site_spawner,
-/obj/structure/closet/cardboard,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -41094,6 +41635,9 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/start/research_director,
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "cYR" = (
@@ -41138,14 +41682,19 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/paramedic)
 "cZU" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "cZV" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -41162,30 +41711,32 @@
 /area/cargo/office)
 "cZY" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/disposal/bin{
+	desc = "A pneumatic waste disposal unit. This one leads into space!";
+	name = "deathsposal unit"
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "daF" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/extinguisher{
-	pixel_y = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/item/extinguisher{
-	pixel_x = -4
-	},
-/obj/machinery/button/door/directional/south{
-	id = "xeno6";
-	name = "Creature Cell 6 Toggle";
-	pixel_x = 24;
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Creature Cell";
 	req_access_txt = "55"
 	},
 /turf/open/floor/iron/dark,
@@ -41233,6 +41784,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dbf" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "dbl" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -41263,6 +41820,22 @@
 "dbG" = (
 /turf/closed/wall,
 /area/command/bridge)
+"dci" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/research)
 "dcy" = (
 /obj/effect/mapping_helpers/smart_pipe/simple/dark/visible{
 	dir = 4
@@ -41279,16 +41852,9 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "dcM" = (
-/obj/machinery/door/poddoor{
-	id = "toxinsdriver";
-	name = "Toxins Launcher Bay Door"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/obj/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "dcO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -41540,6 +42106,16 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"dhJ" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dhR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -41607,21 +42183,31 @@
 /turf/open/floor/engine,
 /area/ai_monitored/command/nuke_storage)
 "diL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom/directional/north,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = -7;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
-/area/science/research)
+/obj/item/clothing/glasses/science{
+	pixel_x = 11
+	},
+/obj/item/clothing/glasses/science{
+	pixel_x = 11;
+	pixel_y = 7
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
+"diS" = (
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/engine,
+/area/science/cytology)
 "djY" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -41974,6 +42560,23 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"dtc" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/surgical_drapes,
+/obj/item/retractor,
+/obj/item/cautery,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "dtq" = (
 /turf/closed/wall/rust,
 /area/engineering/gravity_generator)
@@ -42183,30 +42786,17 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
 "dxS" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/machinery/light/directional/south,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/maintenance/starboard)
 "dyi" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/wood,
@@ -42656,6 +43246,10 @@
 /obj/item/electronics/airalarm,
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"dIg" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dIT" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/cargo{
@@ -42900,49 +43494,31 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "dPm" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/table,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler{
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler{
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/assembly/signaler{
-	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/pen,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/maintenance/starboard)
 "dPy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "dPB" = (
@@ -43233,6 +43809,8 @@
 /obj/machinery/meter/atmos/layer4{
 	name = "gas flow meter"
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dZv" = (
@@ -43605,6 +44183,24 @@
 	icon_state = "wood-broken3"
 	},
 /area/service/bar)
+"egC" = (
+/obj/item/target,
+/obj/item/target/syndicate,
+/obj/item/target/alien,
+/obj/item/target/clown,
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Test Site Materials Crate";
+	req_access_txt = "8"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "egH" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -43706,7 +44302,17 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "eiU" = (
 /obj/effect/turf_decal/tile/purple{
@@ -43780,9 +44386,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/spawner/randomsnackvend,
+/obj/item/kirbyplants{
+	icon_state = "plant-03"
+	},
 /turf/open/floor/iron/dark,
 /area/science/research)
 "ekD" = (
@@ -43829,6 +44436,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"elm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/camera{
+	c_tag = "Toxins Storage";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/machinery/portable_atmospherics/pump{
+	name = "lil pump"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "elp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -43944,15 +44568,22 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "enM" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/grassybush,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "enX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -44493,6 +45124,29 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ezs" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple/end{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
 "ezG" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/grassybush,
@@ -44771,18 +45425,48 @@
 /area/command/gateway)
 "eEW" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/glasses/welding,
-/obj/structure/noticeboard/directional/north,
+/obj/machinery/cell_charger,
+/obj/item/assembly/prox_sensor{
+	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/assembly/prox_sensor{
+	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/assembly/prox_sensor{
+	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/assembly/prox_sensor{
+	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/crowbar/red,
+/obj/item/toy/figure/roboticist{
+	pixel_x = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "eFt" = (
@@ -44832,6 +45516,8 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "eFF" = (
@@ -45309,13 +45995,11 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/hallway/secondary/entry)
 "eOl" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/obj/machinery/light/small/directional/east,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/structure/table,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "eOQ" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -45567,9 +46251,6 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple/corner,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "eSG" = (
@@ -45584,6 +46265,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "eTL" = (
@@ -45677,18 +46361,23 @@
 /turf/closed/wall/rust,
 /area/cargo/warehouse)
 "eUP" = (
-/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/siding/purple,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
 "eUX" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -45759,6 +46448,16 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
+"eVW" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "eWc" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -45884,6 +46583,33 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
+"eZv" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/red,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "eZy" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -45917,10 +46643,45 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"faC" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
+"faf" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/west{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/showroomfloor,
 /area/science/storage)
+"faC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "faV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -46118,11 +46879,14 @@
 /area/engineering/supermatter/room)
 "fga" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -46301,6 +47065,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"fkS" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "flc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -46321,18 +47091,13 @@
 /turf/open/floor/iron/dark,
 /area/commons/toilet/restrooms)
 "fls" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/aug_manipulator,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/chair/office/light,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/landmark/start/geneticist,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/science/robotics/lab)
 "flv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -46680,6 +47445,20 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
+"ftP" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "fuC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -46740,41 +47519,26 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "fvw" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/requests_console/directional/south{
-	department = "Toxins Lab";
-	departmentType = 2;
-	name = "Toxins Lab Requests Console";
-	receive_ore_updates = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/science{
-	pixel_x = 11
-	},
-/obj/item/clothing/glasses/science{
-	pixel_x = 11;
-	pixel_y = 7
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "fvI" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -46918,7 +47682,7 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "fyU" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold/orange,
 /turf/closed/wall/r_wall,
 /area/science/server)
 "fzA" = (
@@ -47093,8 +47857,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/monkey_recycler,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/monkey_recycler,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "fCj" = (
@@ -47756,9 +48520,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
 /obj/machinery/light_switch/directional/west{
 	pixel_y = -4
 	},
@@ -47851,15 +48612,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple/end,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "fPR" = (
@@ -48096,6 +48855,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "fVn" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/science/test_area)
 "fVr" = (
@@ -48283,6 +49043,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"gaw" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "gaZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/exile,
@@ -48296,7 +49068,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -48332,6 +49103,17 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/storage/tech)
+"gbw" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "gbF" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
@@ -48526,19 +49308,21 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ggL" = (
-/obj/machinery/computer/operating{
-	dir = 1;
-	name = "Robotics Operating Computer"
+/obj/item/radio/intercom/directional/south,
+/obj/structure/chair/sofa/right{
+	color = "#c45c57";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/directional/south,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "ggR" = (
@@ -48688,6 +49472,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "gls" = (
@@ -48849,6 +49634,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -49260,22 +50046,29 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "gxh" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/box/disks{
+	pixel_y = 5
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins Burn Chamber";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/machinery/airalarm/directional/east{
-	locked = 0
-	},
-/obj/machinery/light/small/directional/east,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
-/area/science/mixing/chamber)
+/area/science/genetics)
+"gxo" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Lab";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "gxr" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -49383,6 +50176,37 @@
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"gAX" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/assembly/signaler{
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/assembly/signaler{
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/assembly/signaler{
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/assembly/signaler{
+	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another. Slightly scooted.";
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "gBe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -49534,6 +50358,28 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"gDi" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 8;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("toxins");
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "gDl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -49592,17 +50438,35 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "gFD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	pressure_checks = 0
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/scientist,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/cytology)
+"gFQ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
+/obj/structure/railing,
+/turf/open/space/basic,
+/area/space/nearstation)
+"gFS" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Lab";
+	req_access_txt = "29"
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "gGl" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -49666,24 +50530,16 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "gGX" = (
-/obj/item/target,
-/obj/item/target/syndicate,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/structure/closet/crate/secure{
-	desc = "A secure crate containing various materials for building a customised test-site.";
-	name = "Test Site Materials Crate";
-	req_access_txt = "8"
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "gHq" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold/yellow/visible,
 /turf/closed/wall,
@@ -49812,19 +50668,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "gLF" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/storage/box/syringes{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/storage/box/beakers{
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -49832,6 +50679,11 @@
 	id = "xeno2";
 	name = "Creature Cell 2 Toggle";
 	pixel_x = -24;
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Creature Cell";
 	req_access_txt = "55"
 	},
 /turf/open/floor/iron/dark,
@@ -50259,6 +51111,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"gWw" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
+/obj/structure/railing/corner,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gWN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -50368,19 +51226,31 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "gZY" = (
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Lab";
+	req_access_txt = "8"
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
@@ -50476,10 +51346,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "hct" = (
-/obj/structure/sign/warning/fire,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
+/obj/machinery/dna_scannernew,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "hcD" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -50506,9 +51375,12 @@
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "hdj" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall/rust,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/science/test_area)
 "hdm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -50548,6 +51420,9 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/start/research_director,
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "hdT" = (
@@ -50826,6 +51701,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"hku" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/igniter/incinerator_toxmix,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "hkM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -50965,18 +51845,23 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hop" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/clipboard,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/corner,
-/obj/item/hand_labeler,
+/obj/effect/spawner/randomarcade{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_y = 15
+	},
+/obj/item/coin/iron{
+	pixel_y = 12;
+	pixel_x = -10
+	},
 /turf/open/floor/iron/dark,
 /area/science/research)
 "hoE" = (
@@ -51013,6 +51898,11 @@
 /mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"hoO" = (
+/obj/machinery/air_sensor/atmos/toxins_mixing_tank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "hpL" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -51082,16 +51972,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "hqC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
 "hqF" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -51102,13 +51996,25 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "hrX" = (
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "hsj" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -51236,14 +52142,31 @@
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "hvo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_y = 24
+	},
+/obj/structure/chair/comfy{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/scientist,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
+"hvG" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "hwo" = (
 /obj/item/storage/firstaid/regular{
@@ -51340,6 +52263,26 @@
 /obj/structure/cable,
 /turf/open/floor/plating/rust,
 /area/security/prison)
+"hyE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/circuits)
 "hyP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
@@ -51415,6 +52358,15 @@
 "hBN" = (
 /turf/closed/wall,
 /area/commons/fitness/recreation)
+"hCn" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "hCz" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -51460,6 +52412,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "hDE" = (
@@ -51530,6 +52483,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"hDW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hEn" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/green,
@@ -51659,6 +52619,29 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"hJx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/structure/microscope{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Closet";
+	dir = 1;
+	name = "xenobiology camera";
+	network = list("ss13","rd","xeno")
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/cytology)
 "hJQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -51861,17 +52844,17 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "hNX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/box/corners{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/meter,
-/obj/machinery/light_switch/directional/east,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/dark/visible,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "hNY" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -52055,6 +53038,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "hRT" = (
@@ -52118,15 +53107,23 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "hSN" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/computer/operating{
+	name = "Robotics Operating Computer"
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/grass,
-/area/science/genetics)
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "hTg" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall,
@@ -52197,16 +53194,10 @@
 /turf/open/floor/wood,
 /area/service/library)
 "hUx" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "toxinsdriver"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/test_area)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hUK" = (
 /obj/item/radio{
 	pixel_x = 5;
@@ -52249,6 +53240,9 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "hWk" = (
@@ -52546,6 +53540,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "icX" = (
@@ -52609,9 +53604,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera{
@@ -52620,11 +53612,13 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
-/obj/structure/closet/secure_closet/cytology,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/visible{
-	dir = 6
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "ifo" = (
@@ -52660,18 +53654,31 @@
 "ifJ" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/science/genetics)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/closet/l3closet/scientist,
+/obj/item/extinguisher,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Genetics";
+	dir = 8;
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "igh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -52800,6 +53807,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "ikp" = (
@@ -52821,6 +53829,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
 "ikz" = (
@@ -53807,8 +54816,18 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 140;
+	pressure_checks = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "iFr" = (
 /obj/structure/table,
@@ -53982,6 +55001,21 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/solars/starboard/aft)
+"iIO" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/blobstart,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	pixel_y = 5
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "iIT" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -54170,7 +55204,7 @@
 /area/cargo/storage)
 "iNO" = (
 /obj/machinery/atmospherics/components/binary/heat_pump/heater{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
@@ -54280,6 +55314,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"iQE" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "iQO" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -54306,6 +55349,29 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"iQX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/turf_decal/loading_area{
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/orange/visible,
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "iQZ" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/delivery,
@@ -54320,37 +55386,42 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "iRb" = (
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
+/obj/structure/lattice/catwalk/plated/dark,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "iRg" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"iRn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "iRo" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -54389,6 +55460,9 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"iSk" = (
+/turf/open/floor/engine,
+/area/science/cytology)
 "iSz" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -54641,7 +55715,6 @@
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "iXv" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -54651,11 +55724,17 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/processor/slime,
 /obj/machinery/button/door/directional/south{
 	id = "xeno4";
 	name = "Creature Cell 4 Toggle";
 	pixel_x = 24;
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Creature Cell";
 	req_access_txt = "55"
 	},
 /turf/open/floor/iron/dark,
@@ -55191,6 +56270,17 @@
 	},
 /turf/open/floor/wood,
 /area/commons/locker)
+"jiD" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Chamber"
+	},
+/obj/item/wrench,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "jiV" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -55214,6 +56304,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/chapel/office)
+"jjH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/science/research)
 "jjR" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -55255,16 +56355,26 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/aft)
-"jkW" = (
+"jkC" = (
+/obj/machinery/module_duplicator,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/circuits)
+"jkW" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "jkY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -55569,32 +56679,9 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "jtb" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/button/massdriver{
-	id = "toxinsdriver";
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/obj/machinery/door/poddoor/incinerator_toxmix,
+/turf/open/space/basic,
+/area/science/mixing/chamber)
 "jtw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/loot_site_spawner,
@@ -55996,6 +57083,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"jCQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "jCZ" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating{
@@ -56081,6 +57178,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/chapel/office)
+"jFN" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "jFR" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -56156,6 +57260,16 @@
 /obj/item/airlock_painter,
 /turf/open/floor/iron/dark,
 /area/service/library)
+"jID" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "jIQ" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -56284,6 +57398,8 @@
 	sortType = 28
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "jLU" = (
@@ -56559,6 +57675,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
+"jRc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "jRt" = (
 /obj/structure/closet/radiation,
 /obj/structure/grille/broken,
@@ -56612,24 +57742,24 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jSc" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/siding/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8
-	},
-/obj/machinery/requests_console/directional/east{
-	department = "Robotics";
-	departmentType = 2;
-	name = "Robotics Requests Console";
-	receive_ore_updates = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "jSw" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -56919,6 +58049,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
+"jXM" = (
+/obj/effect/turf_decal/box/corners,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "jXU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -57012,6 +58148,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -57051,27 +58188,9 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jZo" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/camera{
-	c_tag = "Toxins Storage";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/showroomfloor,
-/area/science/storage)
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "jZJ" = (
 /turf/closed/wall,
 /area/cargo/office)
@@ -57632,7 +58751,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/engineering/main)
 "klG" = (
@@ -58077,9 +59195,11 @@
 	},
 /area/maintenance/solars/port/aft)
 "kvc" = (
-/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
 /turf/open/floor/engine,
-/area/science/xenobiology)
+/area/science/cytology)
 "kvy" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table,
@@ -58271,6 +59391,21 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"kyK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "kyS" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -58333,13 +59468,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/camera{
 	c_tag = "Nanite Lab";
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "kzI" = (
@@ -58421,19 +59557,19 @@
 	},
 /area/maintenance/disposal/incinerator)
 "kAC" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/heat_pump/freezer{
-	dir = 1
-	},
+/obj/effect/landmark/start/roboticist,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/robotics/lab)
 "kAY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
@@ -58791,19 +59927,29 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
+"kHH" = (
+/obj/structure/bodycontainer/morgue,
+/obj/structure/window/reinforced/tinted,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/robotics/lab)
 "kHY" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -59341,6 +60487,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"kSt" = (
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/commons/toilet/restrooms)
 "kSE" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -59800,6 +60950,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"ldi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "ldA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -59878,13 +61039,11 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "lgq" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/light/directional/north,
 /obj/structure/cable,
-/obj/machinery/power/shieldwallgen/xenobiologyaccess,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/sign/warning/biohazard{
+	pixel_x = 32
 	},
+/turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "lgH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -59969,6 +61128,13 @@
 "lih" = (
 /turf/closed/wall/r_wall,
 /area/command/teleporter)
+"lii" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "lix" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -60035,6 +61201,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ljH" = (
@@ -60089,6 +61256,13 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"lkM" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "llp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -60194,7 +61368,6 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hos)
 "los" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -60202,28 +61375,30 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/components/binary/heat_pump/freezer/on{
-	name = "euthanization chamber freezer"
-	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/cytology,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "lov" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "loB" = (
@@ -60282,12 +61457,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "lpY" = (
@@ -60307,21 +61480,11 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "lqr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/west,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/plating,
+/area/science/mixing)
 "lqz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -60366,6 +61529,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
+"lrl" = (
+/obj/effect/turf_decal/box/corners,
+/obj/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lrp" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -60515,16 +61683,26 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ltR" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/rnd/bepis,
-/turf/open/floor/iron/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple,
+/turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "ltY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -60589,8 +61767,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/corner{
@@ -60718,20 +61894,14 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "lxK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/cigbutt{
+	pixel_x = -7;
+	pixel_y = 12
 	},
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/obj/item/food/candy_trash,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "lxO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -60764,6 +61934,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
+"lyG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/integrated_circuit/loaded/hello_world,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "lyT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -60869,6 +62055,14 @@
 	},
 /turf/open/floor/carpet/green,
 /area/cargo/warehouse)
+"lBJ" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/science/cytology)
 "lBX" = (
 /obj/structure/cable,
 /turf/open/floor/plating/rust,
@@ -61011,6 +62205,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lEy" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "lEF" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -61045,6 +62244,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "lEK" = (
@@ -61189,6 +62389,25 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lHq" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
+	},
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "lHG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
 	dir = 4
@@ -61196,15 +62415,11 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "lHK" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/closet/bombcloset,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/effect/turf_decal/box,
+/mob/living/simple_animal/slime,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lIc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -61274,24 +62489,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/closet/athletic_mixed,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lKm" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/science/test_area)
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "lKu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -61302,7 +62510,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -61338,6 +62545,19 @@
 	},
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
+"lLO" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "lLS" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/glass,
@@ -61352,6 +62572,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"lMJ" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "lMO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -61603,15 +62846,20 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
 "lSz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/valve/layer2,
-/obj/machinery/atmospherics/components/binary/valve/layer4,
 /obj/item/stack/cable_coil/cut,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -61699,6 +62947,12 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
+"lUC" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/hidden,
+/obj/effect/turf_decal/box,
+/obj/machinery/light/floor,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lUN" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -61959,6 +63213,34 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
+"lYV" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/command/heads_quarters/rd)
 "lYX" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -62011,6 +63293,12 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"maj" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/massdriver_toxins,
+/obj/structure/fans/tiny,
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "maq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -62036,6 +63324,14 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"maQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "maU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -62127,29 +63423,27 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "mbU" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/item/flashlight/pen,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/dropper,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/bodybags,
 /obj/machinery/requests_console/directional/north{
 	department = "Genetics";
 	name = "Genetics Requests Console"
 	},
+/obj/machinery/light/directional/east,
+/obj/structure/table,
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/science/robotics/lab)
 "mcc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62208,6 +63502,16 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"mfj" = (
+/obj/machinery/light_switch/directional/west{
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "mfD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -62217,14 +63521,10 @@
 /turf/open/floor/engine,
 /area/ai_monitored/command/nuke_storage)
 "mfS" = (
-/obj/machinery/power/shieldwallgen/xenobiologyaccess,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/box,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/sign/warning/biohazard{
+	pixel_x = -32
 	},
+/turf/closed/wall/r_wall/rust,
 /area/science/xenobiology)
 "mfV" = (
 /obj/structure/chair/sofa/left{
@@ -62384,35 +63684,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engineering/atmos)
+"mjm" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "mjr" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/cartridge/roboticist{
-	pixel_x = -3
-	},
-/obj/item/cartridge/signal/toxins{
-	pixel_x = 6
-	},
-/obj/item/cartridge/signal/toxins,
-/obj/item/cartridge/signal/toxins,
-/obj/item/circuitboard/aicore{
-	pixel_y = 5
-	},
-/obj/item/hand_labeler,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/west,
-/obj/item/paicard{
-	pixel_x = 6
-	},
-/obj/item/aicard,
-/obj/item/taperecorder{
-	pixel_x = -6;
-	pixel_y = 6
-	},
+/obj/machinery/rnd/bepis,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "mjB" = (
@@ -62858,17 +64143,10 @@
 /turf/open/floor/carpet/green,
 /area/service/library)
 "mvk" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light_switch/directional/west{
-	pixel_y = 26
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "mvR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -63488,6 +64766,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -63594,7 +64873,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/heat_pump/heater{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -63638,17 +64917,11 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "mJE" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/l3closet/scientist,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/machinery/firealarm/directional/north,
-/obj/item/extinguisher,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "Air to Room"
@@ -63957,6 +65230,14 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"mQR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box/corners,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "mRh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -64053,6 +65334,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"mSM" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "mTf" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -64085,6 +65370,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "mTS" = (
@@ -64241,6 +65527,7 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -64378,6 +65665,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "naE" = (
@@ -64542,6 +65830,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/cargo/warehouse)
+"nfS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "ngn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -64687,8 +65985,22 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"nkZ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Creature Cell";
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno6";
+	name = "Creature Cell 6"
+	},
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "nlf" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -64698,8 +66010,11 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/closet/bombcloset,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "nlh" = (
@@ -64817,6 +66132,30 @@
 /obj/effect/mapping_helpers/iannewyear,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"noH" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno2";
+	name = "Creature Cell 2"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Creature Cell";
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Closet";
+	dir = 1;
+	name = "xenobiology camera";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "noN" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -65448,6 +66787,16 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
+"nFA" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nFQ" = (
 /obj/item/canvas/nineteen_nineteen,
 /obj/structure/easel,
@@ -65605,6 +66954,9 @@
 "nJY" = (
 /turf/closed/wall/rust,
 /area/service/lawoffice)
+"nKw" = (
+/turf/closed/wall/rust,
+/area/science/cytology)
 "nKz" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
@@ -65865,6 +67217,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "nOK" = (
@@ -66324,25 +67679,22 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nXj" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple{
+	dir = 8
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing/chamber)
+/area/science/genetics)
 "nXm" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/neutral,
@@ -66594,11 +67946,19 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "odG" = (
 /turf/closed/wall/rust,
 /area/medical/paramedic)
+"oer" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "oeu" = (
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -66690,6 +68050,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"ohq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
+"ohv" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "ohA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -66820,16 +68192,17 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "ojK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/door/airlock/maintenance{
+	name = "Toxins Lab Maintenance";
+	req_access_txt = "8"
 	},
+/turf/open/floor/plating,
 /area/science/test_area)
 "ojM" = (
 /obj/effect/turf_decal/delivery,
@@ -66884,6 +68257,17 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/command/bridge)
+"okx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "okQ" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -67172,6 +68556,16 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
+"opR" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "opS" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -67414,6 +68808,18 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
+"osZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno1";
+	name = "Creature Cell 1"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "oth" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -67433,46 +68839,33 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "otz" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
-/obj/machinery/cell_charger,
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/prox_sensor{
-	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/crowbar/red,
-/obj/item/toy/figure/roboticist{
-	pixel_x = 6
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/red/corner,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "oub" = (
 /obj/structure/curtain,
 /turf/open/floor/plating,
 /area/security/prison)
+"oug" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "ouk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -67654,21 +69047,22 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "oAb" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/bed/dogbed{
+	name = "Jimothy's Bed"
+	},
+/mob/living/simple_animal/slime/pet{
+	name = "Jimothy"
+	},
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "oAc" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -67929,6 +69323,7 @@
 	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/light/small/directional/east,
+/obj/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oFA" = (
@@ -68095,6 +69490,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"oJt" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "oJA" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -68187,6 +69589,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"oKQ" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "oKX" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall/rust,
@@ -68424,7 +69836,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "oRZ" = (
@@ -68477,6 +69888,17 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
+"oSE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "oTh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -68494,6 +69916,9 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/warehouse)
+"oTn" = (
+/turf/closed/wall/r_wall/rust,
+/area/science/cytology)
 "oTs" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -68835,30 +70260,16 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "pbl" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 5
 	},
-/obj/item/clipboard,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -6
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
 	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 6
-	},
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/experi_scanner{
-	pixel_x = -4
-	},
-/obj/item/experi_scanner,
-/obj/item/experi_scanner{
-	pixel_x = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/lab)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "pbm" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -69183,6 +70594,16 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/disposal/incinerator)
+"phw" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mass_driver/toxins{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/test_area)
 "phX" = (
 /obj/effect/mapping_helpers/smart_pipe/simple/green/visible,
 /turf/closed/wall,
@@ -69255,16 +70676,16 @@
 	},
 /area/maintenance/disposal/incinerator)
 "pji" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
 "pjn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -69479,6 +70900,16 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/warden)
+"pno" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "pnQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
@@ -69943,6 +71374,7 @@
 	pixel_x = 8
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/item/aicard,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "pwa" = (
@@ -69978,6 +71410,12 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plastic,
 /area/security/prison)
+"pwx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "pwC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70053,6 +71491,16 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/office)
+"pzq" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pzX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -70495,6 +71943,16 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/library)
+"pIa" = (
+/obj/effect/turf_decal/box/corners,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Cell 6";
+	dir = 8;
+	name = "xenobiology camera";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "pIj" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible,
 /turf/closed/wall/r_wall,
@@ -70644,6 +72102,8 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/storage)
 "pLr" = (
@@ -70883,20 +72343,30 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "pQa" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/firealarm/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/explab)
 "pQg" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/secure_closet/personal,
@@ -70946,6 +72416,10 @@
 	dir = 1
 	},
 /area/hallway/primary/port)
+"pRK" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "pSo" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_x = 32
@@ -71049,6 +72523,18 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port)
+"pUC" = (
+/obj/machinery/atmospherics/components/binary/pump/off/dark/visible{
+	dir = 4
+	},
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden,
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "pUD" = (
 /obj/machinery/flasher/directional/north{
 	id = "AI";
@@ -71093,6 +72579,16 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"pVj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
 "pVk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -71553,6 +73049,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "qgG" = (
@@ -71679,6 +73176,12 @@
 "qkL" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"qkO" = (
+/obj/effect/landmark/blobstart,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "qkT" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -71712,6 +73215,18 @@
 /obj/item/stock_parts/scanning_module,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"qlF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno3";
+	name = "Creature Cell 3"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "qlU" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -71942,6 +73457,8 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "qsb" = (
@@ -72266,6 +73783,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -72291,13 +73809,25 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
-/area/science/xenobiology)
+/area/science/cytology)
 "qyL" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/visible,
-/turf/closed/wall/rust,
-/area/science/storage)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "qyZ" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/newscaster/security_unit/directional/east,
@@ -72540,12 +74070,12 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/exam_room)
 "qFo" = (
@@ -72704,6 +74234,8 @@
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
 "qIv" = (
@@ -72955,10 +74487,23 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/displaycase/labcage,
-/obj/effect/turf_decal/box,
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/table,
+/obj/item/circuitboard/aicore{
+	pixel_y = 5
+	},
+/obj/item/cartridge/signal/toxins,
+/obj/item/cartridge/signal/toxins{
+	pixel_x = 6
+	},
+/obj/item/taperecorder{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/cartridge/roboticist{
+	pixel_x = -3
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "qOk" = (
@@ -72991,23 +74536,21 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "qPt" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/light/directional/north,
-/obj/machinery/requests_console/directional/north{
-	department = "Xenobiology";
-	departmentType = 2;
-	name = "Xenobiology Requests Console";
-	pixel_x = -32;
-	receive_ore_updates = 1
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -4
 	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 4
+	},
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "qPF" = (
@@ -73341,6 +74884,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"qWO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/storage)
 "qWP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
@@ -73420,6 +74970,19 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"qYG" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/airlock_sensor/incinerator_toxmix{
+	pixel_y = -24
+	},
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "qYP" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -73984,25 +75547,16 @@
 /area/maintenance/disposal/incinerator)
 "rlr" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/shower{
 	dir = 8;
 	name = "emergency shower"
 	},
 /obj/structure/mirror/directional/east,
+/obj/structure/lattice/catwalk/plated/dark,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/showroomfloor,
-/area/science/genetics)
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/research)
 "rlv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -74284,14 +75838,19 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "rps" = (
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "rpH" = (
 /obj/effect/turf_decal/stripes/line,
@@ -74445,17 +76004,46 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/medbay/central)
+"ruh" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "ruR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/purple/corner,
+/turf/open/floor/iron/showroomfloor,
+/area/science/explab)
 "rvs" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -74969,6 +76557,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"rGF" = (
+/obj/structure/cable,
+/obj/machinery/chem_master,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "rHd" = (
 /obj/machinery/power/tracker,
 /obj/effect/turf_decal/box,
@@ -75523,6 +77121,22 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rWz" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "rWU" = (
 /turf/closed/wall,
 /area/service/theater)
@@ -75601,23 +77215,8 @@
 /area/commons/fitness/recreation)
 "rYN" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Genetics";
-	dir = 8;
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/genetics)
+/turf/closed/wall,
+/area/science/research)
 "rZk" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -75728,6 +77327,18 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"sbu" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "sbB" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -76098,21 +77709,20 @@
 /turf/open/floor/wood,
 /area/commons/locker)
 "shr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera{
-	c_tag = "Toxins Launch Site";
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/machinery/research/explosive_compressor,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/science/test_area)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/structure/sign/warning/explosives/alt{
+	pixel_x = 32
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "shX" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -76256,6 +77866,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "snm" = (
@@ -76315,6 +77931,19 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"sot" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "sox" = (
 /turf/closed/wall/rust,
 /area/service/kitchen)
@@ -76603,7 +78232,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/grille/broken,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -76611,6 +78239,8 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -76716,6 +78346,10 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/port)
+"sAd" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "sAN" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -76879,16 +78513,12 @@
 /area/engineering/storage/tcomms)
 "sDo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
 "sDp" = (
@@ -77626,6 +79256,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"sUq" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/science/test_area)
 "sUu" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
@@ -77712,6 +79349,28 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/service/bar/atrium)
+"sWJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "sWQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -77759,6 +79418,18 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/chemistry)
+"sXM" = (
+/obj/machinery/door/window/southleft{
+	name = "Mass Driver Door";
+	req_access_txt = "7"
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/computer/pod/old/mass_driver_controller/toxinsdriver{
+	pixel_x = -24
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/test_area)
 "sYg" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/tile/neutral{
@@ -77798,6 +79469,23 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
+"sZz" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Creature Cell";
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/dark,
+/area/science/xenobiology)
 "sZG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -77921,6 +79609,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"tcK" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "tdY" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/stack/rods,
@@ -78193,15 +79885,8 @@
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "tlV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard)
 "tmi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
@@ -78266,15 +79951,8 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "tno" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/turf/closed/wall/r_wall,
+/area/science/circuits)
 "tnC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78346,13 +80024,10 @@
 "tov" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "toK" = (
@@ -78450,8 +80125,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison)
 "tpF" = (
-/turf/closed/wall,
-/area/science/test_area)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno2";
+	name = "Creature Cell 2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/cytology)
 "tpP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -78572,6 +80253,15 @@
 /obj/machinery/door/poddoor/atmos_test_room_mainvent_1,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"ttK" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/research/explosive_compressor,
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "ttO" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -78959,19 +80649,14 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "tAG" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "tAI" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -79352,6 +81037,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"tHH" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/research)
 "tHI" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/carpspawn,
@@ -79403,18 +81098,22 @@
 /area/engineering/atmos)
 "tIM" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/storage/box/disks{
-	pixel_y = 5
-	},
-/obj/structure/noticeboard/directional/north,
-/obj/effect/turf_decal/tile/neutral,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/science/genetics)
+/area/science/robotics/lab)
 "tIU" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -79457,6 +81156,21 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"tJs" = (
+/obj/machinery/module_duplicator,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "tJO" = (
 /obj/structure/chair{
 	dir = 4
@@ -79472,9 +81186,6 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tJP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -79507,7 +81218,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/window/reinforced,
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
 	},
@@ -79626,6 +81336,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "tNa" = (
@@ -79819,11 +81530,13 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "tPt" = (
@@ -79995,23 +81708,30 @@
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "tTB" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/button/door/directional/south{
-	id = "xeno5";
-	name = "Creature Cell 5 Toggle";
-	pixel_x = -24;
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Creature Cell";
 	req_access_txt = "55"
 	},
 /turf/open/floor/iron/dark,
-/area/science/xenobiology)
+/area/science/cytology)
+"tTP" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tUw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -80098,6 +81818,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "tVX" = (
@@ -80110,19 +81831,24 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "tWc" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 6
 	},
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
-	dir = 9
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/maintenance/starboard)
 "tWd" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -80161,25 +81887,17 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "tWQ" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/mixing)
 "tXk" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -80334,7 +82052,18 @@
 	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
+	external_pressure_bound = 140;
+	pressure_checks = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "uaJ" = (
 /obj/effect/turf_decal/tile/blue{
@@ -80967,6 +82696,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -81426,6 +83156,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
+"uwd" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/general/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/science/cytology)
 "uwx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -81614,8 +83350,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
@@ -82174,20 +83910,29 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "uNr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "uNu" = (
@@ -82349,6 +84094,29 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/theater)
+"uSQ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/warning/fire{
+	pixel_y = -32
+	},
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
+"uTh" = (
+/obj/item/storage/box/monkeycubes,
+/obj/structure/table,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "uTl" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -82519,19 +84287,31 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "uZg" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/glasses/welding,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
 /obj/machinery/airalarm/directional/west,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/light/directional/north,
+/obj/machinery/light/directional/west,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot_red,
+/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/r_arm/robot,
+/obj/item/bodypart/r_arm/robot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "uZh" = (
@@ -83037,6 +84817,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
+"vgy" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "vgz" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -83294,6 +85080,22 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"vkX" = (
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Office";
+	req_access_txt = "30"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/command/heads_quarters/rd)
 "vkY" = (
 /obj/structure/girder/reinforced,
 /turf/open/space/basic,
@@ -83519,6 +85321,19 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/disposal/incinerator)
+"vqD" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "vqL" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -83615,30 +85430,35 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "vrU" = (
-/obj/effect/turf_decal/delivery,
+/obj/machinery/modular_computer/console/preset/civilian,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
-/area/science/mixing)
+/area/science/circuits)
 "vse" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/folder,
-/obj/machinery/light/directional/east,
-/obj/machinery/bounty_board/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/siding/purple,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/science/research)
 "vsF" = (
 /obj/machinery/light/directional/north,
@@ -83721,24 +85541,42 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "vtW" = (
-/obj/machinery/chem_heater/withbuffer,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
 /obj/machinery/button/door/directional/north{
 	id = "xeno1";
 	name = "Creature Cell 1 Toggle";
 	pixel_x = -24;
 	req_access_txt = "55"
 	},
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "vun" = (
-/turf/closed/wall/rust,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
+"vuR" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/test_area)
 "vuX" = (
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/tile/neutral,
@@ -83963,36 +85801,28 @@
 /area/ai_monitored/turret_protected/ai)
 "vzX" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/multitool{
+	pixel_x = 4
+	},
+/obj/item/multitool,
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/storage/box/bodybags{
-	pixel_y = 5
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/storage/firstaid/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/stack/package_wrap,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/machinery/camera{
-	c_tag = "Robotics Lab";
-	name = "science camera";
-	network = list("ss13","rd")
-	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "vAC" = (
@@ -84043,6 +85873,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"vBV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "vCb" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -84269,6 +86105,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
+"vGt" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "vGA" = (
 /obj/machinery/camera{
 	c_tag = "Prison Recreation";
@@ -84348,6 +86191,23 @@
 	icon_state = "wood-broken4"
 	},
 /area/service/chapel/office)
+"vJj" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "vJw" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -84426,6 +86286,16 @@
 	luminosity = 2
 	},
 /area/ai_monitored/command/nuke_storage)
+"vKn" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/research)
 "vKw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -84516,6 +86386,14 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"vLM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "vMt" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt,
@@ -84889,6 +86767,11 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"vUb" = (
+/obj/machinery/dna_scannernew,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/genetics)
 "vUi" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -84912,14 +86795,15 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "vUr" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance{
+	name = "Testing Lab Maintainance";
+	req_access_txt = "8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "vUt" = (
@@ -85425,6 +87309,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
+"wiA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/dark,
+/area/science/research)
 "wiR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tank/internals/plasmaman/belt/full,
@@ -85792,6 +87686,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/toilet/restrooms)
 "wqn" = (
@@ -85929,6 +87824,30 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
+"wsy" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera{
+	c_tag = "Robotics Lab";
+	name = "science camera";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "wtb" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -85974,9 +87893,8 @@
 	name = "Research Director's Office";
 	req_access_txt = "30"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "wtH" = (
 /obj/machinery/door/firedoor,
@@ -86054,24 +87972,9 @@
 "wwp" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
-	},
-/obj/machinery/button/door/directional/south{
-	id = "robotics_shutters";
-	name = "Robotics Shutter Toggle";
-	pixel_x = 24;
-	req_access_txt = "29"
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -86095,18 +87998,22 @@
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "wyq" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/purple{
+/obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 26
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "wyF" = (
@@ -86250,6 +88157,16 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"wBS" = (
+/obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "wCc" = (
 /obj/machinery/door/morgue{
 	name = "Relic Closet";
@@ -87241,18 +89158,9 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "wWz" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron/dark,
-/area/science/robotics/lab)
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "wWK" = (
 /turf/closed/wall,
 /area/service/chapel/office)
@@ -87501,6 +89409,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;5;39"
 	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "xbU" = (
@@ -87666,22 +89575,19 @@
 /turf/closed/wall,
 /area/engineering/storage/tech)
 "xfe" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/landmark/start/scientist,
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "xfz" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
@@ -87828,6 +89734,35 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
+"xhY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/south,
+/obj/item/transfer_valve{
+	pixel_x = -4
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = 4
+	},
+/obj/item/transfer_valve{
+	pixel_x = 4
+	},
+/obj/item/transfer_valve{
+	pixel_x = 4
+	},
+/obj/item/transfer_valve{
+	pixel_x = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "xiX" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/grassybush,
@@ -88054,11 +89989,30 @@
 /area/commons/vacant_room/commissary)
 "xnS" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"xnT" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Creature Cell";
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno5";
+	name = "Creature Cell 5"
+	},
+/turf/open/floor/iron/dark,
+/area/science/cytology)
 "xnY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -88102,13 +90056,6 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "xpk" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xpP" = (
@@ -88117,6 +90064,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"xqf" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/iron/dark,
+/area/science/circuits)
 "xqr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -88213,6 +90176,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"xrO" = (
+/obj/structure/window/reinforced/tinted,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "xrW" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/directional/east,
@@ -88364,6 +90343,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"xuc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xuj" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -88413,6 +90398,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"xva" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "xvk" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -88705,19 +90697,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "xAA" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/multitool,
+/obj/item/multitool{
+	pixel_x = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light/small/directional/east,
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/science/circuits)
 "xAY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -88758,6 +90749,21 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
+"xDr" = (
+/obj/effect/turf_decal/siding/red{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "xDx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -88823,6 +90829,29 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"xEw" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/storage)
 "xEE" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -88928,6 +90957,39 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"xHg" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/showroomfloor,
+/area/science/test_area)
+"xHL" = (
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/orange/hidden/layer1,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xIk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -89907,19 +91969,13 @@
 /turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
 "ycx" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden/layer4{
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/command{
-	name = "Research Director's Office";
-	req_access_txt = "30"
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/command/heads_quarters/rd)
+/area/science/robotics/lab)
 "ycC" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/effect/mapping_helpers/smart_pipe/simple/orange/visible,
@@ -90106,6 +92162,18 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"ygV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/computer/atmos_control/toxinsmix{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/smart_pipe/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing)
 "yhd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -90269,6 +92337,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "ylc" = (
@@ -109500,8 +111569,8 @@ dyu
 bKl
 add
 lSH
-fuK
-fuK
+kSt
+kSt
 ikp
 fJK
 uMr
@@ -125408,7 +127477,7 @@ aZS
 uZg
 bhB
 bhC
-aCa
+eZv
 baj
 ggL
 aZS
@@ -125666,9 +127735,9 @@ eEW
 amm
 aRR
 aBX
-aZT
+apS
 bdd
-aYH
+gFS
 aJK
 aLV
 cgR
@@ -125896,12 +127965,12 @@ aUz
 aeU
 aeU
 aeU
-alB
-alB
-alB
-bwe
-alB
-cEg
+aFY
+aFY
+aFY
+oTn
+aFY
+dIg
 gbf
 agv
 agK
@@ -125914,14 +127983,14 @@ akU
 alL
 amG
 aoO
-aXk
-aXk
-aWY
-aWY
+bam
+bam
+aZS
+aZS
 aZS
 axK
-azI
-aAo
+aqU
+auk
 aCa
 aZU
 bgB
@@ -126153,14 +128222,14 @@ aeU
 aeU
 aeU
 aeu
-bwe
-bbx
+oTn
+bgA
 qyy
 bfs
-alB
+aFY
 cId
 cIh
-alB
+aFY
 alB
 bwe
 alB
@@ -126171,14 +128240,14 @@ alB
 alB
 aep
 aoQ
-aWY
+bam
 hSN
-aqq
+aEG
 enM
-aXj
+kHH
 vzX
-apG
-aAC
+lLO
+jCQ
 aCK
 aEP
 aVd
@@ -126407,34 +128476,34 @@ aeU
 aeU
 aeU
 aeu
-aeu
-aeu
-aeu
 alB
-aWJ
-ayv
-aWJ
 alB
+alB
+aFY
+iSk
+lBJ
+iSk
+tpF
 cIe
-bhl
-alB
+hJx
+aFY
 bbx
 agQ
-bfs
-aWR
-bbx
+ayw
+aWJ
+xva
 iFf
-bfs
+lKm
 bwe
 crh
 cmN
-aWY
-bde
-aXo
-aXO
-atq
+aZS
+lHq
+kAC
+aOT
+xrO
 aXt
-apS
+lLO
 aBe
 aCe
 aHM
@@ -126663,40 +128732,40 @@ aeU
 aeu
 aeu
 aeu
-aeu
-aeu
-aeu
-aeu
 alB
-bfq
+alB
 aWJ
-bhj
-aWR
+bhz
+aFY
+kvc
+uwd
+diS
+tpF
 bhv
 gFD
-aWR
-bhu
-ayv
+tpF
 aWJ
-bwn
-aWJ
-ayv
+bhn
+vgy
+lHK
+dcM
+cbg
 bhu
 alB
 aeN
 aoQ
-aXk
-aWV
-aXb
-aXS
+aZS
+aZT
+dtc
+vqD
 atq
 aXe
-aqU
-auk
+ahm
+bbQ
 aDs
 aHP
 aKM
-bbQ
+aYH
 aKb
 axz
 aNU
@@ -126921,35 +128990,35 @@ aeu
 aeu
 alB
 alB
-alB
-alB
-alB
-alB
+aWJ
+ayv
+aWJ
+aFY
 aeX
-aeX
-aeX
-bwn
+aOS
+xnT
+nKw
 bbk
 acB
-aWR
+tpF
 bfq
+lrl
+iQE
 aWJ
-bft
-bhn
-bfq
-aWJ
-bft
+jXM
+hNX
+aYc
 alB
 quM
 aoQ
-aWY
-aXU
-bdb
-cvt
-bah
+aZS
+wsy
+xDr
+bfM
+bfM
 otz
 jSc
-wWz
+jSc
 aAF
 aIr
 wwp
@@ -126964,7 +129033,7 @@ bkG
 bbH
 bnM
 lLB
-bpC
+xpk
 xpk
 bhf
 bZK
@@ -127178,38 +129247,38 @@ aeu
 aeu
 alB
 bbx
-aax
-bfs
-bwe
+aWJ
+aWJ
+aWJ
 mfS
 aXa
 afk
 tTB
-aWR
+azt
 beY
 adx
-aWR
+azt
 agM
 aha
-agM
+noH
 aWR
 aih
 aiX
-aih
+osZ
 alB
 afb
 aoZ
-aWY
+aZS
 tIM
 aLO
 aYj
-bah
+aEy
 bai
-bah
+bsb
+ycx
 aXj
-bai
 aXP
-bai
+aTE
 aZS
 aZr
 ajL
@@ -127220,9 +129289,9 @@ ayU
 aAj
 bbU
 aYf
-aYK
-aYK
-aYd
+chg
+aAo
+oug
 bhh
 bpd
 bpF
@@ -127434,11 +129503,11 @@ aeu
 aeu
 aeu
 bwe
-kvc
-bfo
 aWJ
-alB
-aeQ
+aWJ
+aax
+aWJ
+aXX
 bfj
 afl
 afF
@@ -127447,24 +129516,24 @@ los
 bgU
 aWR
 qPt
-ahi
+sZz
 gLF
-cqw
+bgF
 vtW
 ahi
 azM
 alB
 ctJ
 apb
-aWY
+aZS
 mbU
 atV
 ayT
 fls
 bdR
 aTr
-aZv
-diL
+bah
+bah
 aYA
 aZB
 eky
@@ -127477,8 +129546,8 @@ aYK
 aZL
 bch
 aYd
-aZg
-pbl
+aYK
+aYK
 aYd
 bhi
 cbk
@@ -127694,8 +129763,8 @@ alB
 aWJ
 bfU
 aWJ
-ary
-aeQ
+aWJ
+aXX
 bgx
 afo
 bfP
@@ -127713,14 +129782,14 @@ aaL
 aeQ
 cuG
 jLI
-aWY
-arG
-aub
-azt
-aAS
-aTn
+aZS
+bah
+bah
+bah
 aTE
-biU
+bah
+aTE
+bah
 aXy
 aYP
 aZG
@@ -127950,21 +130019,21 @@ aeu
 bwe
 bfY
 bdD
+lUC
 apR
-axR
 aeR
 afa
 afp
-afG
+jiD
 xnS
 aga
 cZY
 agB
-aga
+rGF
 afG
 ahD
 ahN
-aii
+bbS
 aje
 aii
 alM
@@ -127974,16 +130043,16 @@ aqB
 arH
 atp
 auG
-aws
+jRc
 axL
 azL
-aAp
+aws
 aCh
+aMN
 aDc
-aDc
-aFY
-aDc
-aDc
+vJj
+vJj
+vJj
 aNX
 bdT
 bfO
@@ -128208,18 +130277,18 @@ alB
 aWJ
 bho
 aWJ
-ayL
-aeQ
+aWJ
+aXX
 bfK
-afq
-beW
+afo
+bfP
 eSg
 bgo
 wyq
 rps
 abK
-ahm
-bgA
+ajk
+bgo
 bgO
 bgT
 ajk
@@ -128227,18 +130296,18 @@ cHF
 aeQ
 ads
 eFB
-ayw
+aZr
 iRb
 rlr
 auJ
 ifJ
 rYN
 aWW
-aZv
+vKn
 vse
 aXE
 aXI
-aYR
+tHH
 beE
 bbj
 aOi
@@ -128463,10 +130532,10 @@ aeu
 aeu
 alB
 aWJ
-bfo
 aWJ
-alB
-aeQ
+aWJ
+aWJ
+aXX
 bfN
 afr
 anb
@@ -128479,7 +130548,7 @@ aho
 iXv
 bgF
 tJV
-aho
+aql
 alR
 alB
 cMF
@@ -128490,16 +130559,16 @@ aZF
 auO
 aZF
 iOj
-vlS
+vkX
 rJG
 rJG
 kzj
-aXX
+aYS
 aYS
 aZt
-bbl
+wiA
 aOi
-cmg
+bep
 aYe
 aXQ
 aXY
@@ -128721,8 +130790,8 @@ aeu
 alB
 bfq
 aWJ
-bft
-alB
+aWJ
+aWJ
 lgq
 bfi
 afv
@@ -128733,11 +130802,11 @@ aew
 bwn
 agU
 ahs
-agU
+beH
 aWR
 aik
 ajl
-aik
+qlF
 alB
 cMG
 sws
@@ -128753,8 +130822,8 @@ vlS
 vlS
 aYN
 aYT
-aYS
-bbl
+dci
+jjH
 aOo
 bgj
 aYe
@@ -128977,26 +131046,26 @@ aeu
 aeu
 alB
 alB
-bwe
-bwe
+aWJ
+bfo
+aWJ
 alB
-alB
 afg
 afg
-afg
+nkZ
 aWR
 bgw
 oRD
-aWR
-bbx
+agM
+ohv
+xva
+ayw
 aWJ
-bfs
-bhn
-bbx
-aWJ
-bfs
+xva
+sbu
+aOF
 alB
-aht
+kyK
 aps
 ajO
 baL
@@ -129233,44 +131302,44 @@ aeu
 aeu
 aeu
 aeu
-aeu
-aeu
-aeu
-aeu
+alB
+alB
+aWJ
+pIa
 alB
 bgR
 aWJ
-bfs
-bwn
+beo
+agM
 mJE
 akt
-aWR
+agM
 aWJ
-ayv
-aWJ
-aWR
+bhn
+vgy
+lHK
+dcM
+cbg
 bhu
-ayv
-aWJ
 alB
 amK
 mll
 ajU
-aZF
+aTn
 aXR
 bcx
 aWU
 iOj
 hea
-hRI
+lYV
 cYO
 tWx
 vlS
 vlS
 aZX
-bbl
+aYi
 aOi
-bep
+oKQ
 baU
 udp
 aQG
@@ -129278,8 +131347,8 @@ bdZ
 hYj
 bbb
 bdz
-aht
-awB
+bcu
+fga
 jMR
 oHM
 leq
@@ -129491,32 +131560,32 @@ aeu
 aeu
 aeu
 aeu
-aeu
-aeu
-aeu
+alB
+alB
+alB
 alB
 aWJ
 ayv
 aWJ
-aWR
+agM
 ajj
 odA
-bwn
+alB
 bfq
 oFk
-bft
-aWR
-bfq
+iQE
+aWJ
+lrl
 uaH
-bft
+cqw
 alB
-anf
+iRn
 bkd
 cNa
 aZF
 baJ
 bcz
-baJ
+bgy
 iOj
 pvu
 hRI
@@ -129785,7 +131854,7 @@ rJG
 bfr
 bex
 aTU
-bcD
+baV
 eRV
 bco
 beb
@@ -129793,7 +131862,7 @@ nQa
 bbb
 bdN
 bfu
-aCi
+cLg
 jMR
 vdz
 lBn
@@ -130024,7 +132093,7 @@ cMw
 cLK
 cbk
 cMC
-anf
+iRn
 cLt
 cNd
 aZF
@@ -130038,19 +132107,19 @@ swx
 fRy
 oAb
 tJP
-vlS
+rJG
 bcL
 aZl
 pQa
-bbN
-bba
-baY
+aSK
+aSK
+bcs
 aLp
-bba
+aSK
 bbd
-bbc
-bbc
-azG
+tno
+pbl
+cLK
 jMR
 jMR
 kbq
@@ -130281,33 +132350,33 @@ aim
 aim
 akX
 alT
-ank
-apu
+aXM
+dhJ
 aqC
 arJ
-alT
+okx
 auV
 cLt
-ctI
+awB
 iOj
 iOj
 rJG
 vlS
-ycx
 vlS
-vlS
+rJG
+rJG
 baK
 akB
 bbY
 bcs
 bxn
-mvk
+faC
 bef
 beJ
-kGY
-bct
-bbc
-ayo
+cLp
+tno
+pbl
+ctI
 bok
 hzt
 sJG
@@ -130527,7 +132596,7 @@ afI
 gmg
 uPW
 lFf
-agb
+cLK
 agn
 agD
 aim
@@ -130544,27 +132613,27 @@ cNf
 cNr
 bkd
 avb
-alT
+okx
 ayc
 ayj
-aXl
+aXk
 aXA
-aKY
+aqq
 aXx
-baD
+aZv
 baE
 bbm
 aZZ
 bdF
-baS
-baY
-bbP
+bcs
+lMJ
+faC
 beg
 beS
-bck
-ber
-bbc
-anf
+tJs
+tno
+pbl
+cLg
 cbj
 hzt
 oRo
@@ -130778,14 +132847,14 @@ avA
 avA
 bkd
 avA
-avA
+mvk
 bkd
 bkd
 bkd
 bkd
 bkd
 age
-cLp
+ahO
 bkd
 bkd
 bkd
@@ -130804,24 +132873,24 @@ bkd
 bkd
 ayd
 ayl
-awi
-lHK
-aKY
-aOn
+aWY
+bde
+aXo
+aXO
 aSm
 aTZ
-aUr
+aUO
 aOs
 aRD
 aSK
 aUY
-aXM
+vBV
 bee
 baz
-bcl
-baG
-bbc
-bhz
+xqf
+tno
+azG
+cmW
 boo
 pDR
 wJf
@@ -131036,16 +133105,16 @@ acm
 qJs
 acm
 acm
-acm
-acm
-acm
-acm
-bkd
-agg
-bkd
-bkd
-aeu
-aeu
+mvk
+bcc
+cLg
+cOj
+ava
+aER
+bjs
+cbk
+cLK
+agb
 cLr
 ahP
 aoy
@@ -131060,24 +133129,24 @@ jpf
 cNN
 cNX
 ayo
-cOb
-awi
-vrU
-aMC
-aEy
-aGb
+bkd
+aWY
+aWV
+aXb
+aXS
+aSm
 aKf
 aMz
 aOt
 fvw
 bbN
 bba
-aYb
+hyE
 bem
 beT
-bcr
+aYn
 beI
-bbd
+ftP
 bhE
 wkN
 wkN
@@ -131293,16 +133362,16 @@ aaa
 aaa
 qJs
 acm
-aaa
-aaa
-aaa
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+mvk
+aAG
+sDo
+xuc
+agD
+aim
+alT
+vun
+ctI
+agb
 cLs
 ahQ
 aiq
@@ -131317,24 +133386,24 @@ cNE
 cNO
 cNR
 ayq
-ayp
-aXl
-tlV
-bbS
-aEG
-bcc
+ctI
+aXk
+aXU
+bdb
+cvt
+aZv
 bce
 aUO
 aOw
 bbW
-chg
+aSK
 aiY
-fyH
+pwx
 beq
 jZo
 xAA
-bcu
-bbc
+tno
+xHL
 bhY
 wkN
 tyE
@@ -131550,16 +133619,16 @@ aaa
 aaa
 aaa
 acm
-aaa
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+bkd
+aze
+bWk
+caN
+cLt
+cOr
+aKl
+cOv
+ava
+agg
 cLs
 cLs
 cLH
@@ -131579,19 +133648,19 @@ akk
 bcI
 bbn
 aEH
-hNX
+aZv
 ruR
 aXJ
 aOD
 bcd
-kAC
+bcs
 qyL
-faC
+ayp
 eUP
-bba
-bbc
-bbd
-bbc
+baC
+jkC
+tno
+pbl
 bib
 bjt
 tNL
@@ -131807,15 +133876,15 @@ aaa
 aaa
 aaa
 acm
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+bkd
+cMF
+bXa
+cOb
+ava
+avA
+aKn
+avA
+bkd
 aeu
 cLr
 ahR
@@ -131828,28 +133897,28 @@ cLs
 cbj
 cbk
 atv
-ahO
-awB
-ava
-bkd
-bbi
-bbi
+aGb
+fga
+cNY
+yib
+aWY
+mSM
 bbu
-bbi
-bcJ
+aWN
+aZv
 bdh
-aPm
-aOF
-bcf
-tpF
-tpF
+aSm
+aSm
+aZv
+aSK
+vrU
 xfe
-bkX
-ffM
+eUP
+eVW
 anS
-vXM
-bic
-bic
+tno
+bdj
+hDW
 wkN
 loE
 nxZ
@@ -132064,15 +134133,15 @@ aaa
 aaa
 aaa
 acm
-aaa
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+bkd
+bUT
+bXR
+cei
+bkd
+cmi
+aKr
+cCs
+ava
 aeu
 cLs
 ahU
@@ -132086,26 +134155,26 @@ alD
 mtw
 atx
 bkd
-cNC
-ava
-acm
-aXs
+agg
+bkd
+bkd
+aWY
 aXK
 baX
 bbX
 bbC
-bby
+aBD
 nXj
 aOJ
 bcg
-beH
+bcs
 bcR
-bdV
-bej
+jID
+ezs
 baC
-tpF
-yib
-vUr
+lyG
+tno
+bic
 bkd
 pDR
 wkN
@@ -132321,15 +134390,15 @@ aaa
 aaa
 aaa
 acm
-aaa
-aaa
-aaa
-aaa
-aeu
-aeu
-aeu
-aeu
-aeu
+ava
+bkd
+cbV
+ceT
+ava
+agy
+cLR
+agy
+bkd
 aeu
 cLs
 cLs
@@ -132342,28 +134411,28 @@ cLr
 amB
 arN
 aty
-aim
+aAp
 awG
 cNY
-acK
-aXs
+cNY
+aWY
 aXN
 bbt
 bca
 bbD
 bbK
-aYn
+bbD
 aOQ
 bcj
-bgy
-aYc
-bdV
+tno
+tno
+tno
 bek
 tno
-xOP
-uhx
-vUr
-avA
+tno
+tno
+bic
+bkd
 acm
 wJf
 pHM
@@ -132578,15 +134647,15 @@ aaa
 aaa
 aaa
 acm
-aaa
-aaa
-aaa
-aaa
-aaa
-aeU
 aeu
-aeu
-aeu
+bkd
+bkd
+ava
+beK
+aaa
+aaa
+aaa
+bhq
 aeu
 aeu
 aeu
@@ -132601,26 +134670,26 @@ arO
 cNp
 cHa
 anf
-cNg
-acm
-aXs
+cNY
+cNY
+aWY
 baq
 bbw
-hct
+vUb
 eOl
-paR
-aMN
-aOS
+uTh
+hct
+bbw
 gxh
-beH
+aWY
 lxK
-bcb
+bwa
 tWc
 dxS
-xOP
-cOD
-vUr
-avA
+aub
+bcu
+bic
+bkd
 acm
 wJf
 lEG
@@ -132835,15 +134904,15 @@ aaa
 aaa
 qJs
 acm
-aaa
-aaa
-aaa
-aaa
-aaa
-aUz
-aeU
+fYy
 aeu
 aeu
+aeu
+akA
+aaa
+aaa
+aaa
+akA
 aeu
 aeu
 aeu
@@ -132858,24 +134927,24 @@ arS
 atz
 cHa
 anf
-bkd
-ava
-bbi
-bbu
-bbi
-bbi
-bcM
-beo
-hdj
-aOT
-bbi
-caT
+cNY
+yib
+aWY
+aXk
+aWY
+aWY
+aWY
+aWY
+aXk
+aWY
+aWY
+aWY
 hvo
-iAU
+tlV
 dPm
-tpF
-tpF
-xOP
+sot
+cMW
+bkd
 vUr
 bkd
 qJs
@@ -133092,15 +135161,15 @@ aaa
 aaa
 aaa
 acm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aeU
-aeU
+acm
+acm
 aeu
+aeu
+aDU
+aaa
+aaa
+aaa
+aod
 aeu
 aeu
 aeu
@@ -133115,26 +135184,26 @@ arU
 ily
 cHa
 awR
-ahO
-alT
-alT
+aGb
+bcu
+bcu
 aCi
-cOj
-ava
-aER
+aGb
+aAp
+aAp
 aFF
-cbk
-aOU
-aRE
+pno
+ank
+apu
 aSQ
 shr
-bdV
-nzb
+dxS
+sWJ
 cjV
-hUx
-tpF
+cMW
+aPm
 bfw
-dxa
+avA
 aaa
 aaa
 aaa
@@ -133351,13 +135420,13 @@ aaa
 acm
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aeU
+acm
 aeu
+aeZ
+aob
+cOd
+aob
+aoe
 aeu
 aeu
 aeU
@@ -133373,25 +135442,25 @@ ayn
 cNB
 bkd
 ava
-bkd
-aAG
-bPE
-bjs
-agD
-aim
-alT
+bbc
+bbc
+bbc
+bbc
+bbc
+tcK
+aAS
 lqr
-ayt
-fga
-aSQ
-gGX
-iAU
+lqr
+lqr
+awi
+awi
+fVn
 gZY
 fVn
-lKm
-xOP
-sDo
-bkd
+caT
+cuf
+bfw
+avA
 aaa
 aaa
 aaa
@@ -133608,13 +135677,13 @@ aaa
 acm
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aeu
+acm
+aof
+qJs
+acK
+acm
+acK
+qJs
 aeu
 aeu
 aeu
@@ -133630,25 +135699,25 @@ cHb
 cHb
 aeu
 aeu
-bkd
-aze
-bWk
-caN
-cLt
-cOr
-aKl
-cOv
-ava
-cZU
-xOP
-jkW
+bbc
+hCn
+faf
+bct
+kGY
+gaw
+awi
+bfQ
+azI
+afq
+xhY
+awi
 nlf
-tAG
-fVn
+bkX
+ffM
 ojK
-tpF
-bfM
-avA
+vXM
+bfw
+bkd
 aaa
 aaa
 aaa
@@ -133868,7 +135937,7 @@ aaa
 aaa
 aaa
 aaa
-aaB
+aaa
 aaa
 aaa
 aeU
@@ -133887,25 +135956,25 @@ cLM
 aeu
 aeu
 aeu
+bbc
+bbP
+xEw
+lEy
+bck
+aRE
+awi
+nfS
+beW
+oer
+mfj
+aUZ
+bdV
+bej
+apG
+caT
+yib
+bfX
 bkd
-cMF
-bXa
-cOb
-ava
-avA
-aKn
-avA
-bkd
-cZU
-tpF
-fOT
-tWQ
-jtb
-tpF
-dcM
-tpF
-bfQ
-avA
 aaa
 aaa
 aaa
@@ -134144,25 +136213,25 @@ cLM
 aeu
 aeu
 aeu
-bkd
-bUT
-bXR
-cei
-bkd
-cmi
-aKr
-cCs
-ava
+bbc
+ber
+iQX
+aMC
+cMp
+biU
+rWz
+axR
+arG
 cZU
-xOP
-tpF
-fVn
-fVn
-xOP
-cbg
-cbk
+aKY
+gxo
 bfW
-bkd
+gbw
+diL
+caT
+uhx
+bfX
+avA
 aaa
 aaa
 aaa
@@ -134401,25 +136470,25 @@ bFI
 aeu
 aeu
 aeu
-ava
-bkd
-cbV
-ceT
-ava
-agy
-cLR
-agy
-bkd
-cZU
-cZU
+bbc
+aYb
+ruh
+iIO
+bcl
+baS
+jkW
+tWQ
+wBS
+vLM
+ygV
 aUZ
-aYi
+bcb
 aYZ
 baN
-bdj
-aWN
+caT
+cOD
 bfX
-ava
+avA
 aaa
 aaa
 aaa
@@ -134658,24 +136727,24 @@ bFI
 aeU
 aeu
 aeu
-aeu
-bkd
-bkd
-ava
-beK
-aaa
-aaa
-aaa
-bhq
-avA
-avA
-auz
+bbc
+fyH
+aOU
+bcD
+bcr
+tAG
+jkW
+aZg
+maQ
+oJt
+pRK
+awi
 cOn
 cOo
 hqC
-cuf
-cbm
-bgb
+caT
+caT
+bfX
 bkd
 aaa
 aaa
@@ -134915,25 +136984,25 @@ bFI
 aeU
 aUz
 aeU
-fYy
-aeu
-aeu
-aeu
-akA
-aaa
-aaa
-aaa
-akA
-aeU
-aeU
-ava
-avA
-avA
-bkd
+bbc
+bbc
+elm
+fkS
+auz
+uSQ
+mjm
+bby
+aAC
+baD
+baY
+bPE
+bdV
+nzb
+vuR
 bBX
-ava
-iYL
-bkd
+caT
+pVj
+dxa
 aaa
 aaa
 aaa
@@ -135173,24 +137242,24 @@ cmU
 cmU
 cmU
 cmU
-cmU
-aeu
-aeu
-aDU
-aaa
-aaa
-aaa
-aod
-aeu
-aeU
-aUz
-cry
-aaa
-acm
-acm
-anH
+bbc
+bbc
+qWO
+bbc
+bbc
+wWz
+pUC
+qkO
+qYG
+ohq
+egC
+bwy
+ayL
+sAd
+ary
+caT
 pji
-vun
+bkd
 aaa
 aaa
 aaa
@@ -135413,7 +137482,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaB
 aaa
 aaa
 aeo
@@ -135432,22 +137501,22 @@ xLT
 xLT
 cmU
 aeU
-aeu
-aeZ
-aob
-cOd
-aob
-aoe
-aeu
-aeU
-aeU
-alm
-acm
-aeo
-aaa
-acm
-bgf
-cmJ
+tTP
+lii
+lkM
+bbi
+bby
+bcM
+paR
+bbi
+ttK
+iAU
+ayL
+bcJ
+mQR
+caT
+aYR
+avA
 aaa
 aaa
 aaa
@@ -135689,22 +137758,22 @@ sTh
 sTh
 cmU
 aeU
-aof
-qJs
-acK
-acm
-acK
-qJs
-aeu
-aUz
-aeu
-aeu
-aaa
-acm
-aaa
-acm
-qDp
-aaa
+tTP
+hUx
+aFA
+bbi
+jFN
+hoO
+bhj
+bbi
+fOT
+iAU
+aXs
+caT
+caT
+caT
+ldi
+avA
 qJs
 acm
 acK
@@ -135946,22 +138015,22 @@ xLT
 xLT
 cmU
 aeU
-aeU
-aaQ
-aaa
-aaa
-aaa
-acm
-aeu
-aeu
-aeu
-aeu
-aaa
-acm
-aaa
-acK
-qDp
-acm
+tTP
+aXl
+aFA
+bbi
+bpC
+hku
+bpC
+bbi
+caT
+cbm
+hvG
+sXM
+phw
+aOn
+gGX
+bkd
 aaQ
 aeo
 aeo
@@ -136203,22 +138272,22 @@ ckk
 oaA
 cmU
 cmU
-aUz
+vGt
 alm
-aeo
-aeo
-aaQ
-alm
-aeu
-aeu
-aeu
-aeu
-aeu
-acm
-aaa
-acm
-eiW
-aaa
+vGt
+bbi
+jtb
+jtb
+jtb
+bbi
+aUr
+xHg
+cmg
+fVn
+sUq
+bcf
+oSE
+ava
 aaa
 acm
 aaa
@@ -136460,22 +138529,22 @@ xLT
 xLT
 xLT
 cmU
-aeU
-aaQ
-aaa
-aaa
-aaa
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-acK
-aaa
+tTP
+lii
+aFA
+bbi
 acm
-viq
-aaQ
+acK
+acm
+bbi
+gAX
+gDi
+bkp
+fVn
+hdj
+baG
+bgb
+bkd
 aeo
 aeo
 acm
@@ -136717,22 +138786,22 @@ sTh
 sTh
 sTh
 cmU
-aeU
-aeo
-aaa
-aaa
-aaa
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+tTP
+hUx
+gWw
+bbi
+bEo
 acm
-aaa
-acm
-viq
-aaa
+bEo
+bbi
+caT
+fVn
+fVn
+caT
+maj
+xOP
+iYL
+bkd
 acm
 aaa
 aaa
@@ -136974,22 +139043,22 @@ xLT
 xLT
 xLT
 cmU
+tTP
+hUx
+gFQ
+aaa
+aaa
+aaa
+aaa
 aeU
-aeo
-aaa
-aaa
-aaa
-aaa
-aeu
-aeu
-aeu
-alm
-acm
-acm
+aUz
+cry
 aaa
 acm
-acK
-aeo
+acm
+bkd
+cNC
+ava
 aeo
 aaa
 aaa
@@ -137231,22 +139300,22 @@ ckk
 oaA
 cmU
 cmU
+pzq
+nFA
+opR
+aaa
+aaa
+aaa
+aaa
 aeU
+aeU
+alm
 acm
-aaa
-aaa
-aaa
-aaa
-aeu
-aeu
-aeu
-aeU
-aaa
 aeo
+aaa
 acm
-acm
-acK
-acm
+bgf
+cmJ
 aaa
 aaa
 aaa
@@ -137495,15 +139564,15 @@ aaQ
 aeo
 acm
 alm
-aeu
-aeU
 aUz
+aeu
+aeu
 aaa
-aeo
+acm
 aaa
 acm
 acK
-aeo
+aaa
 aaa
 aaa
 aaa
@@ -137753,14 +139822,14 @@ aaa
 aaa
 aeu
 aeu
-aeU
-aaa
-aaa
-aaQ
+aeu
+aeu
 aaa
 acm
-qDp
 aaa
+acK
+qDp
+acm
 aaa
 aaa
 aaa
@@ -138009,15 +140078,15 @@ aeU
 aaa
 aaa
 aeu
-aaa
-aaa
-aaa
-aaa
+aeu
+aeu
+aeu
+aeu
 acm
 aaa
-acK
+acm
 eiW
-aeo
+aaa
 aaQ
 aaa
 aaa
@@ -138779,7 +140848,7 @@ aeu
 aeu
 aeU
 aaa
-aaa
+dbf
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request
De-souls Kilo Station's atrocious research layout, overhauling the locations and sizes of parts of the department.

The goals of these changes are as follows: 
- Reconfigure Toxins to have less of a footprint.
- Reconfigure Xenobiology to look more organic and up to date with the standards of other stations.
- Give Circuits a larger space to exist that isn't central to the department.
- Give robotics a larger area to work with and a private space to do surgeries.
- Add a commons space to Research, as to give science players a place to be in when not working on a project.

Bonus changes:
- Add a cooling pipenet on layer 1 with an orange color. These are currently hooked up to Toxins, Xenobiology, RD Server, and Medbay Cryogenics. Its source of cooling is a small heat exchange net outside of toxins. This may be expanded.
- Adds some plumbing and stationary water tanks to shower hotspots, as to give showers within research, medbay, and dorms an even larger buffer.

Specifics:

Toxins
<details>
Moves the central location eastwards and compacts the overall size, this layout works but it is very tight to work with (which keeps to Kilo's overall theme of space efficiency). It is moved further away from the center of Research due to volatile nature of such. Additionally adds an extended space catwalk from Toxins maint to the bomb test site along with a fragile softsuit storage, this allows for researchers to make a brief EVA walk to the test site for whatever purpose (this also allows for people to do oil slime explosions safely without risking an explosion of the launch site).

![image](https://user-images.githubusercontent.com/29272475/176371896-e2f582cc-772b-4120-a1ef-628341c75a30.png)

</details>

Genetics/Circuits/Misc Research
<details>
Uses the area that was freed up from the toxins move to facilitate a more organic looking research area. Genetics has been given an area that is smaller than their previous location, and is no longer a throughway. Circuits have additionally been given their own large area, as to give people room to experiment with different types of setups. The connecting area has been turned into misc research area in a cubical-esq theme. 

![image](https://user-images.githubusercontent.com/29272475/176142634-49d71bad-2d91-4f3a-b181-e781df260540.png)

</details>

Central Research, RD/Server, and RnD
<details>
Central Research has been turned in a general commons area, used for relaxation and general mingling of the department. RnD is mostly unchanged, except for the moving of the scidrobe and experimental scanners to the commons room.

![image](https://user-images.githubusercontent.com/29272475/176143772-d737cc02-5b19-49d0-8d80-e7cde1ef862f.png)

</details>

Robotics
<details>
Robotics has gotten a substantial size increase and overhaul to its layout and color theming. It has been granted a more private area for implants and cybernetic work. The lab has also been given a small waiting room and sofa, as to allow for people who are waiting for service to sit and roleplay with the roboticist. This can be removed at the in-round roboticist's decision. As for color design, their shift to Black/Purple/Red has been a slow crawl over the last few years, and I find the combination to be quite appealing.

![image](https://user-images.githubusercontent.com/29272475/176144488-3ac1c132-08a2-4df6-a12b-fa2cb61f7be3.png)

</details>

Xenobiology

<details>

Xenobiology has gotten a small facelift, as to add more accessibility for a second research to take part in xenobiology. The additional goal of this is to bring this station's xenobiology up to date with the other stations in terms of layout and aesthetics. Cytology has been given one of the chambers for their own projects, as the space had been soully dominated by xenobiology. This loses xenobio a chamber, but this is made up for with a larger containment chamber in exchange.

![image](https://user-images.githubusercontent.com/29272475/176145990-722ec135-6b4c-46d8-9bfc-8b0d08abed69.png)

![image](https://user-images.githubusercontent.com/29272475/176146095-4c696a36-31c9-40c7-a4c9-5fff4a8eaf0f.png)


</details>

## Why It's Good For The Game
Kilo Station is very out of date and has gone through a lot of removals and additions over the years. This hopes to bring the department up to the current goals of the server, and make it easier to develop on going further.

## Changelog
:cl:
add: Adds stationary water tanks for some showers on station
add: Adds a cooling pipenet for use by Research and Medical
balance: Overhauls Kilo Station Research Department
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
