### PR TITLE
Makes it easier for mappers to tell if a wall is rusted or not

### DIFF
--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -63,6 +63,7 @@
 	desc = "A rusted metal wall."
 	hardness = 45
 	rusted = TRUE
+	color = "#544f3c" //removed on initialize; helps mappers differentiate the wall types
 
 /turf/closed/wall/r_wall/rust
 	name = "rusted reinforced wall"

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -70,6 +70,7 @@
 	desc = "A huge chunk of rusted reinforced metal."
 	hardness = 15
 	rusted = TRUE
+	color = "#544f3c"
 
 /turf/closed/wall/mineral/bronze
 	name = "clockwork wall"


### PR DESCRIPTION
## About The Pull Request
• Makes it so mappers can tell regular and rusted walls apart with the same method that is used to make the walls which, are actually greyscale, appear coloured-in for the mapper.
• Closes #1134 which was the reason for doing this.

## Why It's Good For The Game
Makes Cypress happy, fewer chances of making mapping mistakes.

## Testing
![image](https://user-images.githubusercontent.com/53862927/181052387-66871f42-0857-4199-95bb-6b5835b00297.png)
Walls appear as they should in-game.

![image](https://user-images.githubusercontent.com/53862927/181052824-4eb7ccd4-5fa2-4927-83db-95dcb273617e.png)
How this looks in SDMM.

## Changelog
Non-player facing, only helps mappers.