### PR TITLE
exclude spray bottles from transfer amt checks

### DIFF
--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -362,6 +362,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50,75,100)
 	list_reagents = list(/datum/reagent/toxin/plantbgone/weedkiller = 100)
 
 /obj/item/reagent_containers/spray/weedspray/suicide_act(mob/user)
@@ -378,6 +379,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50,75,100)
 	list_reagents = list(/datum/reagent/toxin/pestkiller = 100)
 
 /obj/item/reagent_containers/spray/pestspray/suicide_act(mob/user)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -212,15 +212,12 @@
 	if (beaker)
 		data["beakerCurrentVolume"] = round(beakerCurrentVolume, 0.01)
 		data["beakerMaxVolume"] = beaker.volume
-		data["beakerTransferAmounts"] = beaker.possible_transfer_amounts
 		data["beakerCurrentpH"] = round(beaker.reagents.ph, 0.01)
-		if(istype(beaker, /obj/item/reagent_containers/spray))
-			var/spraytransferlist[0]
-			spraytransferlist.Add(list(5,10,25,30,50,75,100))
-			if(beaker.volume == 250)
-				spraytransferlist.Add(125)
-				spraytransferlist.Add(250)
-			data["beakerTransferAmounts"] = spraytransferlist
+
+		if(beaker.dispenser_transfer_amounts != null)
+			data["beakerTransferAmounts"] = beaker.dispenser_transfer_amounts
+		else
+			data["beakerTransferAmounts"] = beaker.possible_transfer_amounts
 	else
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null
@@ -259,7 +256,7 @@
 			if(!is_operational || QDELETED(beaker))
 				return
 			var/target = text2num(params["target"])
-			if((target in beaker.possible_transfer_amounts) || istype(beaker, /obj/item/reagent_containers/spray))
+			if((target in beaker.possible_transfer_amounts) || target in beaker.dispenser_transfer_amounts)
 				amount = target
 				work_animation()
 				. = TRUE
@@ -286,7 +283,7 @@
 			if(!is_operational || recording_recipe)
 				return
 			var/amount = text2num(params["amount"])
-			if(beaker && ((amount in beaker.possible_transfer_amounts) || istype(beaker, /obj/item/reagent_containers/spray)))
+			if(beaker && ((amount in beaker.possible_transfer_amounts) || amount in beaker.dispenser_Transfer_amounts))
 				beaker.reagents.remove_all(amount)
 				work_animation()
 				. = TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -214,6 +214,8 @@
 		data["beakerMaxVolume"] = beaker.volume
 		data["beakerTransferAmounts"] = beaker.possible_transfer_amounts
 		data["beakerCurrentpH"] = round(beaker.reagents.ph, 0.01)
+		if(istype(beaker, /obj/item/reagent_containers/spray))
+			data["beakerTransferAmounts"] = list(5,10,20,30,50,75,100,125,250)
 	else
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null
@@ -252,7 +254,7 @@
 			if(!is_operational || QDELETED(beaker))
 				return
 			var/target = text2num(params["target"])
-			if(target in beaker.possible_transfer_amounts)
+			if((target in beaker.possible_transfer_amounts) || istype(beaker, /obj/item/reagent_containers/spray))
 				amount = target
 				work_animation()
 				. = TRUE
@@ -279,7 +281,7 @@
 			if(!is_operational || recording_recipe)
 				return
 			var/amount = text2num(params["amount"])
-			if(beaker && (amount in beaker.possible_transfer_amounts))
+			if(beaker && ((amount in beaker.possible_transfer_amounts) || istype(beaker, /obj/item/reagent_containers/spray)))
 				beaker.reagents.remove_all(amount)
 				work_animation()
 				. = TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -283,7 +283,7 @@
 			if(!is_operational || recording_recipe)
 				return
 			var/amount = text2num(params["amount"])
-			if(beaker && ((amount in beaker.possible_transfer_amounts) || amount in beaker.dispenser_Transfer_amounts))
+			if(beaker && ((amount in beaker.possible_transfer_amounts) || amount in beaker.dispenser_transfer_amounts))
 				beaker.reagents.remove_all(amount)
 				work_animation()
 				. = TRUE

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -215,7 +215,12 @@
 		data["beakerTransferAmounts"] = beaker.possible_transfer_amounts
 		data["beakerCurrentpH"] = round(beaker.reagents.ph, 0.01)
 		if(istype(beaker, /obj/item/reagent_containers/spray))
-			data["beakerTransferAmounts"] = list(5,10,20,30,50,75,100,125,250)
+			var/spraytransferlist[0]
+			spraytransferlist.Add(list(5,10,25,30,50,75,100))
+			if(beaker.volume == 250)
+				spraytransferlist.Add(125)
+				spraytransferlist.Add(250)
+			data["beakerTransferAmounts"] = spraytransferlist
 	else
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -256,7 +256,7 @@
 			if(!is_operational || QDELETED(beaker))
 				return
 			var/target = text2num(params["target"])
-			if((target in beaker.possible_transfer_amounts) || target in beaker.dispenser_transfer_amounts)
+			if((target in beaker.possible_transfer_amounts) || (target in beaker.dispenser_transfer_amounts))
 				amount = target
 				work_animation()
 				. = TRUE
@@ -283,7 +283,7 @@
 			if(!is_operational || recording_recipe)
 				return
 			var/amount = text2num(params["amount"])
-			if(beaker && ((amount in beaker.possible_transfer_amounts) || amount in beaker.dispenser_transfer_amounts))
+			if(beaker && ((amount in beaker.possible_transfer_amounts) || (amount in beaker.dispenser_transfer_amounts)))
 				beaker.reagents.remove_all(amount)
 				work_animation()
 				. = TRUE

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -8,6 +8,7 @@
 	var/list/possible_transfer_amounts = list(5,10,15,20,25,30)
 	/// Where we are in the possible transfer amount list.
 	var/amount_list_position = 1
+	var/list/dispenser_transfer_amounts = null //when set, dispenser use these amounts. Otherwise, use normal amounts.
 	var/volume = 30
 	var/reagent_flags
 	var/list/list_reagents = null

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -24,6 +24,7 @@
 	amount_per_transfer_from_this = 5
 	volume = 250
 	possible_transfer_amounts = list(5,10)
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50,75,100,125,250)
 
 /obj/item/reagent_containers/spray/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
@@ -215,6 +216,7 @@
 	list_reagents = list(/datum/reagent/space_cleaner = 100)
 	amount_per_transfer_from_this = 2
 	possible_transfer_amounts = list(2,5)
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50,75,100)
 
 /obj/item/reagent_containers/spray/cleaner/suicide_act(mob/user)
 	user.visible_message(SPAN_SUICIDE("[user] is putting the nozzle of \the [src] in [user.p_their()] mouth. It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -236,6 +238,7 @@
 	volume = 50
 	desc = "Gyaro brand spray tan. Do not spray near eyes or other orifices."
 	list_reagents = list(/datum/reagent/spraytan = 50)
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50)
 
 
 //pepperspray
@@ -250,6 +253,7 @@
 	volume = 50
 	stream_range = 4
 	amount_per_transfer_from_this = 5
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50)
 	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 50)
 
 /obj/item/reagent_containers/spray/pepper/empty //for protolathe printing
@@ -274,6 +278,7 @@
 	inhand_icon_state = "sunflower"
 	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = list(1)
+	dispenser_transfer_amounts = list(1,5,10)
 	can_toggle_range = FALSE
 	current_range = 1
 	volume = 10
@@ -408,6 +413,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50,75,100)
 	list_reagents = list(/datum/reagent/toxin/plantbgone = 100)
 
 /obj/item/reagent_containers/spray/syndicate
@@ -421,6 +427,7 @@
 	spray_range = 4
 	stream_range = 2
 	volume = 100
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50,75,100)
 	custom_premium_price = PAYCHECK_HARD * 2
 
 /obj/item/reagent_containers/spray/syndicate/Initialize()
@@ -435,6 +442,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	volume = 100
+	dispenser_transfer_amounts = list(5,10,15,20,25,30,50,75,100)
 	unique_reskin = list("Red" = "sprayer_med_red",
 						"Yellow" = "sprayer_med_yellow",
 						"Blue" = "sprayer_med_blue")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes issue #1201 by excluding spray bottles specifically from a couple checks that chem dispensers do since they're the only ones that have restrictive transfer amounts like that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

you can refill spray bottles directly from a dispenser without it taking forever
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: spray bottles can be filled from a dispenser in larger amounts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
